### PR TITLE
feat: Add share section visibility toggle setting

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -152,6 +152,18 @@ function rbfw_settings_sec_fields_basic( $default_fields ) {
                 )
             ),
 
+            array(
+                'name' => 'rbfw_share_section_enable',
+                'label' => esc_html__( 'Enable Share Section', 'booking-and-rental-manager-for-woocommerce' ),
+                'desc' => esc_html__( "If you want to display the social media share section on rental item pages, then enable it.", 'booking-and-rental-manager-for-woocommerce' ),
+                'type' => 'select',
+                'default' => 'yes',
+                'options' => array(
+                    'yes' => 'Yes',
+                    'no'  => 'No'
+                )
+            ),
+
 
 
 		),

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -393,6 +393,14 @@
 // Post Share meta function
 	add_action( 'rbfw_product_meta', 'rbfw_post_share_meta' );
 	function rbfw_post_share_meta( $post_id ) {
+		// Check if share section is enabled in settings
+		$share_section_enabled = rbfw_get_option('rbfw_share_section_enable', 'rbfw_basic_gen_settings', 'yes');
+		
+		// If share section is disabled, don't display it
+		if ( $share_section_enabled !== 'yes' ) {
+			return;
+		}
+		
 		// Get current post URL
 		$rbfwURL = urlencode( get_permalink() );
 		// Get current post title


### PR DESCRIPTION
- Add new 'Enable Share Section' setting in General Settings
- Setting allows admins to show/hide social media share section on rental pages
- Default value is 'Yes' to maintain backward compatibility
- Setting affects all rental item templates (single-day, multi-day, resort, multiple-items)

Changes:
- admin/settings.php: Added rbfw_share_section_enable setting field
- inc/rbfw_functions.php: Modified rbfw_post_share_meta() to check setting before display

Features:
- Toggle share section visibility from admin settings
- Maintains existing functionality when enabled
- Clean implementation following plugin patterns
- No breaking changes to existing installations

Setting location: WordPress Admin  Rent Items  Settings  General Settings  Enable Share Section