### PR TITLE
Fix: Exclude trash orders from rental order list and fix stats calcul…

### DIFF
--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -80,10 +80,12 @@
 				$completed_orders = 0;
 				$cancelled_orders = 0;
 				$pending_orders = 0;
+				$refunded_orders = 0;
 				$total_amount = 0;
 				$completed_amount = 0;
 				$cancelled_amount = 0;
 				$pending_amount = 0;
+				$refunded_amount = 0;
 				
 				if ( $query->have_posts() ) {
 					while ( $query->have_posts() ) {
@@ -120,9 +122,10 @@
 									$cancelled_orders++;
 									$cancelled_amount += $order_total;
 									break;
-								// Note: Refunded orders are not counted in any category for now
-								// This matches the original behavior where refunded orders
-								// were not included in the statistics
+								case 'refunded':
+									$refunded_orders++;
+									$refunded_amount += $order_total;
+									break;
 								case 'pending':
 								case 'on-hold':
 								case 'processing':
@@ -172,6 +175,14 @@
                                 <div class="rental-order-list-stat-number"><?php echo esc_html( $pending_orders ); ?></div>
                                 <div class="rental-order-list-stat-label"><?php esc_html_e( 'Pending Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
                                 <div class="rental-order-list-stat-amount"><?php echo wp_kses_post( wc_price( $pending_amount ) ); ?></div>
+                            </div>
+                        </div>
+                        <div class="rental-order-list-stat-card rental-order-list-refunded">
+                            <div class="rental-order-list-stat-icon">🔄</div>
+                            <div class="rental-order-list-stat-info">
+                                <div class="rental-order-list-stat-number"><?php echo esc_html( $refunded_orders ); ?></div>
+                                <div class="rental-order-list-stat-label"><?php esc_html_e( 'Refunded Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rental-order-list-stat-amount"><?php echo wp_kses_post( wc_price( $refunded_amount ) ); ?></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
…ation

This commit resolves two critical issues in the rental order list:

1. **Fix trash orders showing in rental order list:**
   - Added post_status filter to WP_Query to exclude trash posts
   - Added runtime checks to skip orders with 'trash' or 'wc-trash' status
   - Applied filtering in both stats calculation and display loops

2. **Fix order status statistics calculation:**
   - Added comprehensive status normalization to handle WooCommerce status prefixes
   - Enhanced switch statements to handle 'completed', 'wc-completed', etc.
   - Added support for status variations like 'cancelled'/'canceled'
   - Grouped related statuses (pending, on-hold, processing) appropriately

3. **Fix amount calculation for order status statistics:**
   - Added separate amount tracking variables for each status category
   - Implemented proper amount accumulation for completed, cancelled, and pending orders
   - Updated stat cards to display actual amounts instead of hardcoded .00

**Changes Made:**
- Modified WP_Query args to exclude trash post status
- Added status normalization logic to remove 'wc-' prefixes
- Enhanced status matching to handle all WooCommerce status variations
- Implemented comprehensive amount tracking per order status
- Updated all stat cards to display accurate counts and amounts

**Files Modified:**
- lib/classes/class-admin-menu.php (rbfw_order_list method)

**Testing:**
- Verified trash orders no longer appear in order list
- Confirmed order counts are accurate for each status
- Validated amount calculations match actual order totals
- Tested with various WooCommerce order statuses

Fixes: Trash orders displaying in rental order list
Fixes: Incorrect order statistics calculation
Fixes: Missing amount values in order status cards