### PR TITLE
Add professional WooCommerce installer and demo import flow

### DIFF
--- a/assets/admin/css/rbfw_woo_installer.css
+++ b/assets/admin/css/rbfw_woo_installer.css
@@ -1,0 +1,389 @@
+/* ============================================
+   RBFW WooCommerce Installer & Dummy Import Popup
+   Light WordPress-native design with
+   beautiful accents and smooth animations
+   ============================================ */
+
+/* ---------- Overlay ---------- */
+.rbfw-woo-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 999999;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.45);
+	backdrop-filter: blur(4px);
+	-webkit-backdrop-filter: blur(4px);
+	animation: rbfwOverlayIn 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes rbfwOverlayIn {
+	from { opacity: 0; }
+	to   { opacity: 1; }
+}
+
+/* ---------- Popup Card ---------- */
+.rbfw-woo-popup {
+	position: relative;
+	width: 500px;
+	max-width: 92vw;
+	border-radius: 12px;
+	background: #fff;
+	box-shadow:
+		0 1px 3px rgba(0, 0, 0, 0.08),
+		0 20px 60px rgba(0, 0, 0, 0.15);
+	text-align: center;
+	overflow: hidden;
+	animation: rbfwPopupIn 0.4s cubic-bezier(0.16, 1, 0.3, 1) 0.08s both;
+}
+
+@keyframes rbfwPopupIn {
+	from {
+		opacity: 0;
+		transform: translateY(24px) scale(0.97);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+
+/* ---------- Header Strip ---------- */
+.rbfw-woo-header {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 14px 24px;
+	background: linear-gradient(135deg, #2271b1 0%, #38a0d8 100%);
+	color: #fff;
+}
+
+.rbfw-woo-header-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	background: rgba(255, 255, 255, 0.18);
+	border-radius: 8px;
+}
+
+.rbfw-woo-header-icon svg {
+	width: 18px;
+	height: 18px;
+}
+
+.rbfw-woo-header-text {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+}
+
+/* ---------- Icon ---------- */
+.rbfw-woo-icon-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding-top: 32px;
+	padding-bottom: 8px;
+}
+
+.rbfw-woo-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 72px;
+	height: 72px;
+	border-radius: 50%;
+	background: linear-gradient(135deg, #fef3f2 0%, #fee4e2 100%);
+	color: #d92d20;
+	border: 1px solid #fecdca;
+	animation: rbfwPulseIcon 3s ease-in-out infinite;
+}
+
+@keyframes rbfwPulseIcon {
+	0%, 100% { box-shadow: 0 0 0 0 rgba(217, 45, 32, 0.08); }
+	50%      { box-shadow: 0 0 0 12px rgba(217, 45, 32, 0.04); }
+}
+
+/* ---------- Content ---------- */
+.rbfw-woo-content {
+	padding: 16px 36px 0;
+}
+
+.rbfw-woo-title {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 21px;
+	font-weight: 600;
+	color: #1d2327;
+	margin: 0 0 10px;
+	line-height: 1.3;
+}
+
+.rbfw-woo-desc {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	line-height: 1.6;
+	color: #50575e;
+	margin: 0;
+}
+
+/* ---------- Feature Highlights ---------- */
+.rbfw-woo-features {
+	display: flex;
+	justify-content: center;
+	gap: 20px;
+	flex-wrap: wrap;
+	padding: 20px 36px 0;
+}
+
+.rbfw-woo-feature {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	color: #3c434a;
+}
+
+.rbfw-woo-feature-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: #ecfdf3;
+	color: #039855;
+	flex-shrink: 0;
+}
+
+.rbfw-woo-feature-icon svg {
+	width: 12px;
+	height: 12px;
+}
+
+/* ---------- Progress ---------- */
+.rbfw-woo-progress {
+	padding: 0 36px;
+	margin-bottom: 8px;
+	animation: rbfwFadeIn 0.35s ease both;
+}
+
+@keyframes rbfwFadeIn {
+	from { opacity: 0; transform: translateY(6px); }
+	to   { opacity: 1; transform: translateY(0); }
+}
+
+.rbfw-woo-progress-bar {
+	width: 100%;
+	height: 8px;
+	background: #f0f0f1;
+	border-radius: 100px;
+	overflow: hidden;
+}
+
+.rbfw-woo-progress-fill {
+	height: 100%;
+	width: 0%;
+	border-radius: 100px;
+	background: linear-gradient(90deg, #2271b1, #38a0d8);
+	transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+	position: relative;
+}
+
+.rbfw-woo-progress-fill::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.3) 50%, transparent 100%);
+	animation: rbfwShimmer 1.5s linear infinite;
+}
+
+@keyframes rbfwShimmer {
+	from { transform: translateX(-100%); }
+	to   { transform: translateX(100%); }
+}
+
+.rbfw-woo-status-text {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	color: #50575e;
+	margin: 10px 0 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+}
+
+/* Spinner for status text */
+.rbfw-woo-status-text::before {
+	content: '';
+	display: inline-block;
+	width: 14px;
+	height: 14px;
+	border: 2px solid #dcdde1;
+	border-top-color: #2271b1;
+	border-radius: 50%;
+	animation: rbfwSpin 0.7s linear infinite;
+	flex-shrink: 0;
+}
+
+@keyframes rbfwSpin {
+	to { transform: rotate(360deg); }
+}
+
+.rbfw-woo-status-text.rbfw-success {
+	color: #039855;
+}
+
+.rbfw-woo-status-text.rbfw-success::before {
+	display: none;
+}
+
+.rbfw-woo-status-text.rbfw-error {
+	color: #d92d20;
+}
+
+.rbfw-woo-status-text.rbfw-error::before {
+	display: none;
+}
+
+/* ---------- Action Buttons ---------- */
+.rbfw-woo-actions {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	align-items: center;
+	padding: 24px 36px 0;
+}
+
+.rbfw-woo-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	border: none;
+	border-radius: 8px;
+	cursor: pointer;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	font-weight: 600;
+	text-decoration: none;
+	transition: all 0.2s ease;
+	line-height: 1;
+}
+
+.rbfw-woo-btn-primary {
+	width: 100%;
+	padding: 14px 24px;
+	background: linear-gradient(135deg, #2271b1 0%, #38a0d8 100%);
+	color: #fff;
+	box-shadow: 0 1px 2px rgba(34, 113, 177, 0.2), 0 4px 12px rgba(34, 113, 177, 0.15);
+}
+
+.rbfw-woo-btn-primary:hover {
+	transform: translateY(-1px);
+	box-shadow: 0 2px 4px rgba(34, 113, 177, 0.25), 0 8px 24px rgba(34, 113, 177, 0.2);
+	color: #fff;
+}
+
+.rbfw-woo-btn-primary:active {
+	transform: translateY(0);
+}
+
+.rbfw-woo-btn-primary:disabled {
+	opacity: 0.55;
+	cursor: not-allowed;
+	transform: none !important;
+}
+
+.rbfw-woo-btn-secondary {
+	padding: 8px 16px;
+	background: transparent;
+	color: #50575e;
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.rbfw-woo-btn-secondary:hover {
+	color: #2271b1;
+	text-decoration: underline;
+}
+
+/* ---------- Footer Note ---------- */
+.rbfw-woo-footer-note {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 12px;
+	color: #8c8f94;
+	margin: 0;
+	padding: 16px 36px 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+}
+
+/* ---------- Success State ---------- */
+.rbfw-woo-popup.rbfw-state-success .rbfw-woo-icon {
+	background: linear-gradient(135deg, #ecfdf3 0%, #d1fadf 100%);
+	color: #039855;
+	border-color: #a6f4c5;
+	animation: rbfwSuccessBounce 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes rbfwSuccessBounce {
+	0%   { transform: scale(0.85); }
+	50%  { transform: scale(1.08); }
+	100% { transform: scale(1); }
+}
+
+.rbfw-woo-popup.rbfw-state-success .rbfw-woo-progress-fill {
+	background: linear-gradient(90deg, #039855, #12b76a);
+}
+
+.rbfw-woo-popup.rbfw-state-success .rbfw-woo-header {
+	background: linear-gradient(135deg, #039855 0%, #12b76a 100%);
+}
+
+/* ---------- Error State ---------- */
+.rbfw-woo-popup.rbfw-state-error .rbfw-woo-progress-fill {
+	background: linear-gradient(90deg, #d92d20, #f04438);
+}
+
+.rbfw-woo-popup.rbfw-state-error .rbfw-woo-header {
+	background: linear-gradient(135deg, #d92d20 0%, #f04438 100%);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 520px) {
+	.rbfw-woo-popup {
+		border-radius: 10px;
+	}
+
+	.rbfw-woo-content,
+	.rbfw-woo-features,
+	.rbfw-woo-actions,
+	.rbfw-woo-progress,
+	.rbfw-woo-footer-note {
+		padding-left: 24px;
+		padding-right: 24px;
+	}
+
+	.rbfw-woo-title {
+		font-size: 18px;
+	}
+
+	.rbfw-woo-desc {
+		font-size: 13px;
+	}
+
+	.rbfw-woo-features {
+		flex-direction: column;
+		align-items: center;
+		gap: 8px;
+	}
+}

--- a/assets/admin/js/rbfw_woo_installer.js
+++ b/assets/admin/js/rbfw_woo_installer.js
@@ -1,0 +1,178 @@
+/**
+ * RBFW WooCommerce Installer
+ * Handles AJAX installation & activation of WooCommerce
+ * with smooth progress animations.
+ * Popup shows on every admin page when WooCommerce is not active.
+ */
+(function ($) {
+	'use strict';
+
+	var config    = window.rbfw_woo_installer || {};
+	var $overlay  = null;
+	var $popup    = null;
+	var $btn      = null;
+	var $progress = null;
+	var $fill     = null;
+	var $status   = null;
+	var $actions  = null;
+	var isWorking = false;
+
+	/**
+	 * Initialize when DOM is ready.
+	 */
+	$(document).ready(function () {
+		$overlay  = $('#rbfw-woo-overlay');
+		$popup    = $overlay.find('.rbfw-woo-popup');
+		$btn      = $('#rbfw-woo-install-btn');
+		$progress = $('#rbfw-woo-progress');
+		$fill     = $('#rbfw-woo-progress-fill');
+		$status   = $('#rbfw-woo-status-text');
+		$actions  = $overlay.find('.rbfw-woo-actions');
+
+		if (!$overlay.length) {
+			return;
+		}
+
+		// Install / Activate button click
+		$btn.on('click', function (e) {
+			e.preventDefault();
+			if (isWorking) {
+				return;
+			}
+			startProcess();
+		});
+	});
+
+	/**
+	 * Start the install → activate → redirect process.
+	 */
+	function startProcess() {
+		isWorking = true;
+		$btn.prop('disabled', true);
+
+		// Show progress, hide actions
+		$actions.slideUp(250);
+		$progress.slideDown(300);
+
+		if (config.woo_installed === 'yes') {
+			// Already installed, just activate
+			setProgress(30, config.i18n.activating);
+			activateWooCommerce();
+		} else {
+			// Install first, then activate
+			setProgress(10, config.i18n.installing);
+			installWooCommerce();
+		}
+	}
+
+	/**
+	 * AJAX: Install WooCommerce.
+	 */
+	function installWooCommerce() {
+		$.ajax({
+			url:      config.ajax_url,
+			type:     'POST',
+			dataType: 'json',
+			data: {
+				action: 'rbfw_install_woocommerce',
+				nonce:  config.install_nonce
+			},
+			success: function (response) {
+				if (response.success) {
+					setProgress(60, config.i18n.activating);
+					activateWooCommerce();
+				} else {
+					showError(response.data && response.data.message
+						? response.data.message
+						: config.i18n.install_error);
+				}
+			},
+			error: function () {
+				showError(config.i18n.install_error);
+			}
+		});
+	}
+
+	/**
+	 * AJAX: Activate WooCommerce.
+	 */
+	function activateWooCommerce() {
+		$.ajax({
+			url:      config.ajax_url,
+			type:     'POST',
+			dataType: 'json',
+			data: {
+				action: 'rbfw_activate_woocommerce',
+				nonce:  config.activate_nonce
+			},
+			success: function (response) {
+				if (response.success) {
+					showSuccess();
+				} else {
+					showError(response.data && response.data.message
+						? response.data.message
+						: config.i18n.activate_error);
+				}
+			},
+			error: function () {
+				showError(config.i18n.activate_error);
+			}
+		});
+	}
+
+	/**
+	 * Update progress bar width and status text.
+	 */
+	function setProgress(percent, text) {
+		$fill.css('width', percent + '%');
+		$status.text(text).removeClass('rbfw-success rbfw-error');
+	}
+
+	/**
+	 * Show success state and redirect.
+	 */
+	function showSuccess() {
+		setProgress(100, config.i18n.success);
+		$popup.addClass('rbfw-state-success');
+		$status.addClass('rbfw-success');
+
+		// Change icon to checkmark
+		$popup.find('.rbfw-woo-icon').html(
+			'<svg width="40" height="40" viewBox="0 0 24 24" fill="none">' +
+			'<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>' +
+			'<path d="M8 12l3 3 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+			'</svg>'
+		);
+
+		// Update title
+		$popup.find('.rbfw-woo-title').text(config.i18n.success);
+		$popup.find('.rbfw-woo-desc').text(config.i18n.redirecting);
+
+		// Redirect after short delay
+		setTimeout(function () {
+			window.location.href = config.redirect_url;
+		}, 1500);
+	}
+
+	/**
+	 * Show error state with retry option.
+	 */
+	function showError(message) {
+		isWorking = false;
+		$popup.addClass('rbfw-state-error');
+		$status.text(message).addClass('rbfw-error');
+		$fill.css('width', '100%');
+
+		// Show actions again with retry
+		$btn.prop('disabled', false);
+		$actions.slideDown(250);
+
+		// Reset state for retry after a moment
+		setTimeout(function () {
+			$popup.removeClass('rbfw-state-error');
+			$progress.slideUp(250);
+			$fill.css('width', '0%');
+		}, 3000);
+	}
+
+})(jQuery);

--- a/inc/RBFW_Woo_Installer.php
+++ b/inc/RBFW_Woo_Installer.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * RBFW WooCommerce Installer
+ * Handles WooCommerce dependency check, beautiful popup display,
+ * and AJAX-based installation & activation.
+ * The popup shows on EVERY admin page when WooCommerce is not active.
+ *
+ * @package BookingAndRentalManager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Woo_Installer' ) ) {
+
+	class RBFW_Woo_Installer {
+
+		/**
+		 * Constructor – hooks into WordPress.
+		 */
+		public function __construct() {
+			// On admin_init, check if our plugin was just activated (for redirect)
+			add_action( 'admin_init', array( $this, 'handle_activation_redirect' ) );
+			// Enqueue popup assets on all admin pages (only outputs if WooCommerce is missing)
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+			// Render the popup markup in admin footer
+			add_action( 'admin_footer', array( $this, 'render_popup' ) );
+			// AJAX handlers for install, activate
+			add_action( 'wp_ajax_rbfw_install_woocommerce', array( $this, 'ajax_install_woocommerce' ) );
+			add_action( 'wp_ajax_rbfw_activate_woocommerce', array( $this, 'ajax_activate_woocommerce' ) );
+		}
+
+		/**
+		 * Check if WooCommerce plugin file exists (installed but maybe not active).
+		 *
+		 * @return bool
+		 */
+		private function is_woo_installed() {
+			$plugin_file = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+			return file_exists( $plugin_file );
+		}
+
+		/**
+		 * Check if WooCommerce is active.
+		 *
+		 * @return bool
+		 */
+		private function is_woo_active() {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+			return is_plugin_active( 'woocommerce/woocommerce.php' );
+		}
+
+		/**
+		 * Runs on admin_init. If the transient from activation exists
+		 * and WooCommerce IS active, redirect to rental lists page.
+		 */
+		public function handle_activation_redirect() {
+			if ( ! get_transient( 'rbfw_plugin_activated' ) ) {
+				return;
+			}
+
+			// Don't redirect on multi-site bulk activations
+			if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) {
+				delete_transient( 'rbfw_plugin_activated' );
+				return;
+			}
+
+			// WooCommerce is active → redirect immediately
+			if ( $this->is_woo_active() ) {
+				delete_transient( 'rbfw_plugin_activated' );
+				wp_safe_redirect( admin_url( 'edit.php?post_type=rbfw_item' ) );
+				exit;
+			}
+
+			// WooCommerce is NOT active → clear transient, popup will show via should_show_popup()
+			delete_transient( 'rbfw_plugin_activated' );
+		}
+
+		/**
+		 * Should we show the popup on this page load?
+		 * Always show when WooCommerce is not active and our plugin is active.
+		 *
+		 * @return bool
+		 */
+		private function should_show_popup() {
+			return ! $this->is_woo_active();
+		}
+
+		/**
+		 * Enqueue CSS & JS for the popup only when needed.
+		 */
+		public function enqueue_assets() {
+			if ( ! $this->should_show_popup() ) {
+				return;
+			}
+
+			wp_enqueue_style(
+				'rbfw-woo-installer',
+				RBFW_PLUGIN_URL . '/assets/admin/css/rbfw_woo_installer.css',
+				array(),
+				filemtime( RBFW_PLUGIN_DIR . '/assets/admin/css/rbfw_woo_installer.css' )
+			);
+
+			wp_enqueue_script(
+				'rbfw-woo-installer',
+				RBFW_PLUGIN_URL . '/assets/admin/js/rbfw_woo_installer.js',
+				array( 'jquery' ),
+				filemtime( RBFW_PLUGIN_DIR . '/assets/admin/js/rbfw_woo_installer.js' ),
+				true
+			);
+
+			wp_localize_script( 'rbfw-woo-installer', 'rbfw_woo_installer', array(
+				'ajax_url'         => admin_url( 'admin-ajax.php' ),
+				'install_nonce'    => wp_create_nonce( 'rbfw_install_woo' ),
+				'activate_nonce'   => wp_create_nonce( 'rbfw_activate_woo' ),
+				'redirect_url'     => admin_url( 'edit.php?post_type=rbfw_item' ),
+				'woo_installed'    => $this->is_woo_installed() ? 'yes' : 'no',
+				'i18n'             => array(
+					'installing'     => __( 'Installing WooCommerce...', 'booking-and-rental-manager-for-woocommerce' ),
+					'activating'     => __( 'Activating WooCommerce...', 'booking-and-rental-manager-for-woocommerce' ),
+					'success'        => __( 'WooCommerce activated successfully!', 'booking-and-rental-manager-for-woocommerce' ),
+					'redirecting'    => __( 'Redirecting...', 'booking-and-rental-manager-for-woocommerce' ),
+					'error'          => __( 'Something went wrong. Please try again.', 'booking-and-rental-manager-for-woocommerce' ),
+					'install_error'  => __( 'Installation failed. Please install WooCommerce manually.', 'booking-and-rental-manager-for-woocommerce' ),
+					'activate_error' => __( 'Activation failed. Please activate WooCommerce manually.', 'booking-and-rental-manager-for-woocommerce' ),
+				),
+			) );
+		}
+
+		/**
+		 * Render the popup HTML in admin footer.
+		 */
+		public function render_popup() {
+			if ( ! $this->should_show_popup() ) {
+				return;
+			}
+
+			$is_installed = $this->is_woo_installed();
+			$btn_text     = $is_installed
+				? __( 'Activate WooCommerce', 'booking-and-rental-manager-for-woocommerce' )
+				: __( 'Install & Activate WooCommerce', 'booking-and-rental-manager-for-woocommerce' );
+			?>
+			<!-- RBFW WooCommerce Installer Popup Overlay -->
+			<div id="rbfw-woo-overlay" class="rbfw-woo-overlay">
+				<div class="rbfw-woo-popup">
+
+					<!-- Header strip -->
+					<div class="rbfw-woo-header">
+						<div class="rbfw-woo-header-icon">
+							<svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+								<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							</svg>
+						</div>
+						<span class="rbfw-woo-header-text"><?php esc_html_e( 'Booking & Rental Manager', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+					</div>
+
+					<!-- Icon -->
+					<div class="rbfw-woo-icon-wrapper">
+						<div class="rbfw-woo-icon">
+							<svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+								<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>
+								<path d="M12 8v4M12 16h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+							</svg>
+						</div>
+					</div>
+
+					<!-- Content -->
+					<div class="rbfw-woo-content">
+						<h2 class="rbfw-woo-title"><?php esc_html_e( 'WooCommerce Required', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+						<p class="rbfw-woo-desc">
+							<?php esc_html_e( 'Booking & Rental Manager requires WooCommerce to manage bookings, rentals, and payments. Please install and activate WooCommerce to continue using this plugin.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+						</p>
+					</div>
+
+					<!-- Feature highlights -->
+					<div class="rbfw-woo-features">
+						<div class="rbfw-woo-feature">
+							<span class="rbfw-woo-feature-icon">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+							</span>
+							<span><?php esc_html_e( 'Booking & payments', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+						</div>
+						<div class="rbfw-woo-feature">
+							<span class="rbfw-woo-feature-icon">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+							</span>
+							<span><?php esc_html_e( 'Order management', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+						</div>
+						<div class="rbfw-woo-feature">
+							<span class="rbfw-woo-feature-icon">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+							</span>
+							<span><?php esc_html_e( 'Rental inventory', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+						</div>
+					</div>
+
+					<!-- Progress area (hidden by default) -->
+					<div id="rbfw-woo-progress" class="rbfw-woo-progress" style="display:none;">
+						<div class="rbfw-woo-progress-bar">
+							<div id="rbfw-woo-progress-fill" class="rbfw-woo-progress-fill"></div>
+						</div>
+						<p id="rbfw-woo-status-text" class="rbfw-woo-status-text"></p>
+					</div>
+
+					<!-- Action buttons -->
+					<div class="rbfw-woo-actions">
+						<button type="button" id="rbfw-woo-install-btn" class="rbfw-woo-btn rbfw-woo-btn-primary">
+							<span class="rbfw-woo-btn-icon">
+								<svg width="18" height="18" viewBox="0 0 20 20" fill="none">
+									<path d="M10 3v10m0 0l-4-4m4 4l4-4M3 17h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>
+							<span class="rbfw-woo-btn-text"><?php echo esc_html( $btn_text ); ?></span>
+						</button>
+						<a href="<?php echo esc_url( admin_url( 'plugin-install.php?s=woocommerce&tab=search&type=term' ) ); ?>" class="rbfw-woo-btn rbfw-woo-btn-secondary">
+							<?php esc_html_e( 'Install Manually', 'booking-and-rental-manager-for-woocommerce' ); ?>
+						</a>
+					</div>
+
+					<!-- Footer note -->
+					<p class="rbfw-woo-footer-note">
+						<svg width="14" height="14" viewBox="0 0 14 14" fill="none" style="vertical-align: -2px; flex-shrink: 0;">
+							<path d="M7 1a6 6 0 100 12A6 6 0 007 1zm0 8.5a.75.75 0 110-1.5.75.75 0 010 1.5zM7.75 6.25a.75.75 0 01-1.5 0V4a.75.75 0 011.5 0v2.25z" fill="currentColor"/>
+						</svg>
+						<?php esc_html_e( 'WooCommerce is free, open-source, and trusted by millions of stores worldwide.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+					</p>
+				</div>
+			</div>
+			<?php
+		}
+
+		/**
+		 * AJAX: Install WooCommerce from WordPress.org repository.
+		 */
+		public function ajax_install_woocommerce() {
+			check_ajax_referer( 'rbfw_install_woo', 'nonce' );
+
+			if ( ! current_user_can( 'install_plugins' ) ) {
+				wp_send_json_error( array( 'message' => __( 'You do not have permission to install plugins.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+			include_once ABSPATH . 'wp-admin/includes/file.php';
+			include_once ABSPATH . 'wp-admin/includes/misc.php';
+			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+			$api = plugins_api( 'plugin_information', array(
+				'slug'   => 'woocommerce',
+				'fields' => array(
+					'short_description' => false,
+					'sections'          => false,
+					'requires'          => false,
+					'rating'            => false,
+					'ratings'           => false,
+					'downloaded'        => false,
+					'last_updated'      => false,
+					'added'             => false,
+					'tags'              => false,
+					'compatibility'     => false,
+					'homepage'          => false,
+					'donate_link'       => false,
+				),
+			) );
+
+			if ( is_wp_error( $api ) ) {
+				wp_send_json_error( array( 'message' => $api->get_error_message() ) );
+			}
+
+			$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
+			$result   = $upgrader->install( $api->download_link );
+
+			if ( is_wp_error( $result ) ) {
+				wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+			}
+
+			if ( $result === false ) {
+				wp_send_json_error( array( 'message' => __( 'Installation failed.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			wp_send_json_success( array( 'message' => __( 'WooCommerce installed successfully.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+		}
+
+		/**
+		 * AJAX: Activate WooCommerce plugin.
+		 */
+		public function ajax_activate_woocommerce() {
+			check_ajax_referer( 'rbfw_activate_woo', 'nonce' );
+
+			if ( ! current_user_can( 'activate_plugins' ) ) {
+				wp_send_json_error( array( 'message' => __( 'You do not have permission to activate plugins.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			$result = activate_plugin( 'woocommerce/woocommerce.php' );
+
+			if ( is_wp_error( $result ) ) {
+				wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+			}
+
+			wp_send_json_success( array( 'message' => __( 'WooCommerce activated successfully!', 'booking-and-rental-manager-for-woocommerce' ) ) );
+		}
+	}
+
+	new RBFW_Woo_Installer();
+}

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -1045,11 +1045,18 @@ function rbfw_url_exclude_search_engine() {
 // Update Settings On Register the Plugin
 // Check pro plugin active
 	function rbfw_check_pro_active() {
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		if ( is_plugin_active( 'booking-and-rental-manager-for-woocommerce-pro/rent-pro.php' ) ) {
+			return true;
+		}
+
+		// Backward compatibility for any legacy/custom installation path.
 		if ( is_plugin_active( 'booking-and-rental-manager-for-woocommerce/rent-pro.php' ) ) {
 			return true;
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 // Hide wc hidden products
 	add_action( 'admin_head', 'rbfw_hide_date_from_order_page' );

--- a/inc/rbfw_import_demo.php
+++ b/inc/rbfw_import_demo.php
@@ -2,1387 +2,734 @@
 	/*
    * @Author 		engr.sumonazma@gmail.com
    * Copyright: 	mage-people.com
+   * Dummy Import with beautiful popup — same UX as MPWEM
    */
-	if (!defined('ABSPATH')) {
-		die;
-	} // Cannot access pages directly.
-	if (!class_exists('RbfwImportDemo')) {
-		require_once ABSPATH . 'wp-admin/includes/media.php';
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		require_once ABSPATH . 'wp-admin/includes/image.php';
-		class RbfwImportDemo {
-			public function __construct() {
-				$this->dummy_import();
-				// add_action('admin_init', [$this, 'dummy_import'], 99);
+if (!defined('ABSPATH')) {
+	die;
+} // Cannot access pages directly.
+
+require_once ABSPATH . 'wp-admin/includes/media.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+require_once ABSPATH . 'wp-admin/includes/image.php';
+
+if (!class_exists('RbfwImportDemo')) {
+	class RbfwImportDemo {
+		public function __construct() {
+			add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+			add_action('admin_footer', array($this, 'render_popup'));
+			add_action('wp_ajax_rbfw_import_dummy_data', array($this, 'ajax_import_dummy_data'));
+			add_action('wp_ajax_rbfw_dismiss_dummy_import', array($this, 'ajax_dismiss_dummy_import'));
+		}
+
+		/**
+		 * Check if dummy import is eligible.
+		 */
+		public function is_eligible() {
+			$dummy_post_inserted = get_option('rbfw_sample_rent_items');
+			if ($dummy_post_inserted == 'yes') {
+				return false;
 			}
 
-			public function dummy_import() {
-				$dummy_post_inserted = get_option('rbfw_sample_rent_items');
-				if ($dummy_post_inserted) {
-					return;
-				}
-				$count_existing_event = 0;
-				// $plugin_active = self::check_plugin('booking-and-rental-manager-for-woocommerce', 'rent-manager.php');
-				if ($count_existing_event == 0 && $dummy_post_inserted != 'yes') {
-					// $this->create_dummy_page();
-					$retnal_data = $this->retnal_data();
-					$retnal_ids = $this->insert_posts($retnal_data, 'rbfw_item');
-					$this->insert_thumbnails($retnal_ids,'');
-					$this->insert_gallery_images($retnal_ids);
-					$this->rbfw_update_related_products();
-					update_option('rbfw_sample_rent_items', 'yes');
-				}
+			// Wait for WooCommerce — the Woo Installer popup must be handled first
+			if (!function_exists('rbfw_woo_install_check') || rbfw_woo_install_check() !== 'Yes') {
+				return false;
 			}
 
-			public function rbfw_update_related_products() {
-				$args = array( 'fields' => 'ids', 'post_type' => 'rbfw_item', 'numberposts' => - 1, 'post_status' => 'publish' );
-				$ids  = get_posts( $args );
-				foreach ( $ids as $id ) {
-					update_post_meta( $id, 'rbfw_releted_rbfw', $ids );
-				}
+			$count_posts = wp_count_posts('rbfw_item');
+			$count_existing = isset($count_posts->publish) ? $count_posts->publish : 0;
+			$plugin_active = self::check_plugin('booking-and-rental-manager-for-woocommerce', 'rent-manager.php');
+
+			if (empty($count_existing) && $plugin_active == 1) {
+				return true;
 			}
+			return false;
+		}
 
-			public function insert_posts($posts, $post_type) {
-				$post_ids = [];
+		/**
+		 * Check if the popup should auto-show (not dismissed).
+		 */
+		private function should_auto_show_popup() {
+			if (!$this->is_eligible()) {
+				return false;
+			}
+			$dismissed = get_option('rbfw_dummy_import_dismissed');
+			if ($dismissed == 'yes') {
+				return false;
+			}
+			return true;
+		}
 
-				// Ensure $posts is an array to avoid foreach errors
-				if (!is_array($posts)) {
-					return $post_ids;
-				}
+		/**
+		 * Enqueue CSS for popup (reuses the woo installer CSS).
+		 */
+		public function enqueue_assets() {
+			if (!$this->is_eligible()) {
+				return;
+			}
+			wp_enqueue_style(
+				'rbfw-dummy-installer',
+				RBFW_PLUGIN_URL . '/assets/admin/css/rbfw_woo_installer.css',
+				array(),
+				filemtime(RBFW_PLUGIN_DIR . '/assets/admin/css/rbfw_woo_installer.css')
+			);
+		}
 
-				foreach ($posts as $data) {
-					// Use ?? to provide a default empty string if the key is missing
-					$post = [
-						'post_type' => $post_type,
-						'post_title' => isset($data['title']) ? $data['title'] : '',
-						'post_content' => isset($data['content']) ? $data['content'] : '',
-						'post_status' => 'publish',
-					];
+		/**
+		 * Render the dummy import popup in admin footer.
+		 */
+		public function render_popup() {
+			if (!$this->is_eligible()) {
+				return;
+			}
+			$display_style = $this->should_auto_show_popup() ? '' : 'display: none;';
+			?>
+			<!-- RBFW Dummy Import Popup Overlay -->
+			<div id="rbfw-woo-overlay" class="rbfw-woo-overlay rbfw-dummy-overlay" style="<?php echo esc_attr($display_style); ?>">
+				<div class="rbfw-woo-popup">
+					<div class="rbfw-woo-header">
+						<div class="rbfw-woo-header-icon">
+							<svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+								<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							</svg>
+						</div>
+						<span class="rbfw-woo-header-text"><?php esc_html_e('Booking & Rental Manager', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+					</div>
 
-					$post_id = wp_insert_post($post);
+					<div class="rbfw-woo-icon-wrapper">
+						<div class="rbfw-woo-icon">
+							<svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+								<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>
+								<path d="M12 8v4M12 16h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+							</svg>
+						</div>
+					</div>
 
-					// Add meta data only if the ID is valid and the key exists
-					if (!is_wp_error($post_id)) {
-						$meta_data = $data['postmeta'] ?? []; // Default to empty array if missing
-						
-						if (is_array($meta_data)) {
-							foreach ($meta_data as $meta_key => $meta_value) {
-								update_post_meta($post_id, $meta_key, $meta_value);
+					<div class="rbfw-woo-content">
+						<h2 class="rbfw-woo-title"><?php esc_html_e('Import Sample Rental Items?', 'booking-and-rental-manager-for-woocommerce'); ?></h2>
+						<p class="rbfw-woo-desc">
+							<?php esc_html_e('Would you like to import sample rental items with categories, pricing, and settings to see how Booking & Rental Manager works?', 'booking-and-rental-manager-for-woocommerce'); ?>
+						</p>
+					</div>
+
+					<div id="rbfw-woo-progress" class="rbfw-woo-progress" style="display:none;">
+						<div class="rbfw-woo-progress-bar">
+							<div id="rbfw-woo-progress-fill" class="rbfw-woo-progress-fill"></div>
+						</div>
+						<p id="rbfw-woo-status-text" class="rbfw-woo-status-text"></p>
+					</div>
+
+					<div class="rbfw-woo-actions">
+						<button type="button" id="rbfw-dummy-install-btn" class="rbfw-woo-btn rbfw-woo-btn-primary">
+							<span class="rbfw-woo-btn-icon">
+								<svg width="18" height="18" viewBox="0 0 20 20" fill="none">
+									<path d="M10 3v10m0 0l-4-4m4 4l4-4M3 17h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>
+							<span class="rbfw-woo-btn-text"><?php esc_html_e('Yes, Import Data', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+						</button>
+						<button type="button" id="rbfw-dummy-dismiss-btn" class="rbfw-woo-btn rbfw-woo-btn-secondary">
+							<?php esc_html_e('No, Skip', 'booking-and-rental-manager-for-woocommerce'); ?>
+						</button>
+					</div>
+				</div>
+			</div>
+
+			<script>
+			(function($) {
+				$(document).ready(function() {
+					var $overlay = $('#rbfw-woo-overlay.rbfw-dummy-overlay');
+					var $popup = $overlay.find('.rbfw-woo-popup');
+					var $btn = $('#rbfw-dummy-install-btn');
+					var $dismissBtn = $('#rbfw-dummy-dismiss-btn');
+					var $progress = $('#rbfw-woo-progress');
+					var $fill = $('#rbfw-woo-progress-fill');
+					var $status = $('#rbfw-woo-status-text');
+					var $actions = $overlay.find('.rbfw-woo-actions');
+					var isWorking = false;
+
+					if (!$overlay.length) return;
+
+					// Manual Trigger from other pages
+					$(document).on('click', '#rbfw-trigger-dummy-import-btn', function(e) {
+						e.preventDefault();
+						$overlay.css('display', 'flex').hide().fadeIn(300);
+					});
+
+					$btn.on('click', function(e) {
+						e.preventDefault();
+						if (isWorking) return;
+						isWorking = true;
+						$btn.prop('disabled', true);
+						$dismissBtn.prop('disabled', true);
+
+						$actions.slideUp(250);
+						$progress.slideDown(300);
+
+						$fill.css('width', '50%');
+						$status.text('<?php echo esc_js(__("Importing sample data. This may take a moment...", "booking-and-rental-manager-for-woocommerce")); ?>').removeClass('rbfw-success rbfw-error');
+
+						$.ajax({
+							url: ajaxurl,
+							type: 'POST',
+							data: {
+								action: 'rbfw_import_dummy_data',
+								nonce: '<?php echo wp_create_nonce("rbfw_import_dummy"); ?>'
+							},
+							success: function(response) {
+								if (response.success) {
+									$fill.css('width', '100%');
+									$status.text('<?php echo esc_js(__("Import complete!", "booking-and-rental-manager-for-woocommerce")); ?>').addClass('rbfw-success');
+									$popup.addClass('rbfw-state-success');
+									$popup.find('.rbfw-woo-icon').html(
+										'<svg width="40" height="40" viewBox="0 0 24 24" fill="none">' +
+										'<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>' +
+										'<path d="M8 12l3 3 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+										'</svg>'
+									);
+									$popup.find('.rbfw-woo-title').text('<?php echo esc_js(__("Success!", "booking-and-rental-manager-for-woocommerce")); ?>');
+									$popup.find('.rbfw-woo-desc').text('<?php echo esc_js(__("Sample data imported successfully. Redirecting to Rental List...", "booking-and-rental-manager-for-woocommerce")); ?>');
+
+									setTimeout(function() {
+										window.location.href = '<?php echo esc_url(admin_url('edit.php?post_type=rbfw_item')); ?>';
+									}, 1500);
+								} else {
+									showError(response.data && response.data.message ? response.data.message : '<?php echo esc_js(__("Failed to import.", "booking-and-rental-manager-for-woocommerce")); ?>');
+								}
+							},
+							error: function() {
+								showError('<?php echo esc_js(__("Failed to import. Please try again.", "booking-and-rental-manager-for-woocommerce")); ?>');
 							}
-						}
+						});
+					});
+
+					$dismissBtn.on('click', function(e) {
+						e.preventDefault();
+						if (isWorking) return;
+						isWorking = true;
+
+						$overlay.css('opacity', '0.5');
+
+						$.ajax({
+							url: ajaxurl,
+							type: 'POST',
+							data: {
+								action: 'rbfw_dismiss_dummy_import',
+								nonce: '<?php echo wp_create_nonce("rbfw_dismiss_dummy"); ?>'
+							},
+							success: function() {
+								$overlay.fadeOut(300, function() { $(this).remove(); });
+							},
+							error: function() {
+								$overlay.fadeOut(300, function() { $(this).remove(); });
+							}
+						});
+					});
+
+					function showError(message) {
+						isWorking = false;
+						$popup.addClass('rbfw-state-error');
+						$status.text(message).addClass('rbfw-error');
+						$fill.css('width', '100%');
+
+						$btn.prop('disabled', false);
+						$dismissBtn.prop('disabled', false);
+						$actions.slideDown(250);
+
+						setTimeout(function() {
+							$popup.removeClass('rbfw-state-error');
+							$progress.slideUp(250);
+							$fill.css('width', '0%');
+						}, 3000);
 					}
-					$post_ids[] = $post_id;
-				}
+				});
+			})(jQuery);
+			</script>
+			<?php
+		}
+
+		/**
+		 * AJAX: Import dummy data.
+		 */
+		public function ajax_import_dummy_data() {
+			check_ajax_referer('rbfw_import_dummy', 'nonce');
+			if (!current_user_can('manage_options')) {
+				wp_send_json_error(array('message' => 'Permission denied.'));
+			}
+			$this->dummy_import();
+			wp_send_json_success();
+		}
+
+		/**
+		 * AJAX: Dismiss dummy import popup.
+		 */
+		public function ajax_dismiss_dummy_import() {
+			check_ajax_referer('rbfw_dismiss_dummy', 'nonce');
+			if (!current_user_can('manage_options')) {
+				wp_send_json_error(array('message' => 'Permission denied.'));
+			}
+			update_option('rbfw_dummy_import_dismissed', 'yes');
+			wp_send_json_success();
+		}
+
+		/**
+		 * Public function for Quick Setup to call.
+		 */
+		public function rbfw_import_demo_function() {
+			$this->dummy_import();
+		}
+
+		public static function check_plugin($plugin_dir_name, $plugin_file): int {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+			$plugin_dir = ABSPATH . 'wp-content/plugins/' . $plugin_dir_name;
+			if (is_plugin_active($plugin_dir_name . '/' . $plugin_file)) {
+				return 1;
+			} elseif (is_dir($plugin_dir)) {
+				return 2;
+			} else {
+				return 0;
+			}
+		}
+
+		/**
+		 * Run the actual dummy import.
+		 */
+		public function dummy_import() {
+			$dummy_post_inserted = get_option('rbfw_sample_rent_items');
+			if ($dummy_post_inserted) {
+				return;
+			}
+			$count_existing_event = wp_count_posts('rbfw_item')->publish;
+			$plugin_active = self::check_plugin('booking-and-rental-manager-for-woocommerce', 'rent-manager.php');
+			if ($count_existing_event == 0 && $plugin_active == 1 && $dummy_post_inserted != 'yes') {
+				$retnal_data = $this->retnal_data();
+				$retnal_ids = $this->insert_posts($retnal_data, 'rbfw_item');
+				$this->insert_thumbnails($retnal_ids, '');
+				$this->insert_gallery_images($retnal_ids);
+				$this->rbfw_update_related_products();
+				update_option('rbfw_sample_rent_items', 'yes');
+			}
+		}
+
+		public function rbfw_update_related_products() {
+			$args = array('fields' => 'ids', 'post_type' => 'rbfw_item', 'numberposts' => -1, 'post_status' => 'publish');
+			$ids  = get_posts($args);
+			foreach ($ids as $id) {
+				update_post_meta($id, 'rbfw_releted_rbfw', $ids);
+			}
+		}
+
+		public function insert_posts($posts, $post_type) {
+			$post_ids = [];
+			if (!is_array($posts)) {
 				return $post_ids;
 			}
-
-			public function insert_gallery_images($retnal_ids){
-				$attachment_ids = self::dummy_images();
-				
-				$gallary_arr = [];
-				foreach ( $retnal_ids as $post_id ) {
-
-					// Example: assign all images to each post
-					$gallery_arr = array_map( 'intval', $attachment_ids );
-
-					update_post_meta( $post_id, 'rbfw_gallery_images', $gallery_arr );
-					update_post_meta( $post_id, 'rbfw_gallery_images_additional', $gallery_arr );
-				}
-			}
-			public function insert_thumbnails($postsids,$meta_key=''){
-				$attachment_ids = self::dummy_images();
-				foreach ( $postsids as $index => $post_id ) {
-					$attachment_id = $attachment_ids[ $index ];
-					set_post_thumbnail( $post_id, $attachment_id );
-					if($meta_key!=''){
-						update_post_meta( $post_id, $meta_key, $attachment_id );
-					}
-					
-				}
-			}
-
-			public function retnal_data(){
-				return[
-						[
-							'title'   => 'Bike/Car For Single Day Multiple Slot - Classic Template',
-							'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam...',
-
-							'postmeta' => [
-								
-
-								'rdfw_available_time' => [
-									'00:00','00:30','01:00','06:00','08:00','08:30','09:00','09:30',
-									'10:00','10:30','11:30','12:00','12:30','18:00','20:00','20:30',
-									'21:00','21:30','22:00','22:30','23:30'
-								],
-
-								'rbfw_item_type' => 'bike_car_sd',
-
-								'rbfw_extra_service_data' => [
-									[
-										'service_name'  => 'Tie',
-										'service_price'  => '10',
-										'service_qty'    => '100',
-									],
-									[
-										'service_name'  => 'Shoes',
-										'service_price'  => '10',
-										'service_qty'    => '100',
-									],
-								],
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'  => 'Morning Session',
-										'short_desc' => '9 am to 12pm',
-										'price'      => '10',
-										'qty'        => '100',
-										'start_time' => '09:00',
-										'end_time'   => '12:00',
-										'duration'   => '6',
-										'd_type'     => 'Hours',
-									],
-									[
-										'rent_type'  => 'Afternoon Session',
-										'short_desc' => '3 pm to 6pm',
-										'price'      => '10',
-										'qty'        => '',
-										'start_time' => '15:00',
-										'end_time'   => '18:00',
-										'duration'   => '6',
-										'd_type'     => 'Hours',
-									],
-									[
-										'rent_type'  => 'Full Day',
-										'short_desc' => '6 am to 12 pm',
-										'price'      => '18',
-										'qty'        => '',
-										'start_time' => '09:00',
-										'end_time'   => '18:00',
-										'duration'   => '24',
-										'd_type'     => 'Hours',
-									],
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => [],
-
-								'rbfw_enable_hourly_rate' => 'yes',
-								'rbfw_enable_daily_rate'  => 'yes',
-
-								'rbfw_hourly_rate' => '10',
-								'rbfw_daily_rate'  => '100',
-
-								'rbfw_item_stock_quantity' => '10',
-
-								'rbfw_time_slot_switch' => 'on',
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Bike Features',
-										'cat_features' => [
-											['title' => 'Disc Brakes'],
-											['title' => 'Shock Absorbers'],
-											['title' => 'Headlight and Taillight'],
-											['title' => 'Bottle Holder'],
-											['title' => 'Electric Horn'],
-										],
-									]
-								],
-
-								'rbfw_inventory' => [
-									53 => [
-										'rbfw_start_date_ymd' => '2025-03-20',
-										'rbfw_end_date_ymd'   => '2025-03-20',
-										'rbfw_start_time_24'  => '09:00',
-										'rbfw_end_time_24'    => '12:00',
-										'booked_dates'        => ['20-03-2025'],
-										'rbfw_item_quantity'  => 1,
-										'rbfw_order_status'   => 'processing',
-									],
-									61 => [
-										'rbfw_start_date_ymd' => '2025-03-21',
-										'rbfw_end_date_ymd'   => '2025-03-21',
-										'rbfw_start_time_24'  => '09:00',
-										'rbfw_end_time_24'    => '18:00',
-										'booked_dates'        => ['21-03-2025'],
-										'rbfw_item_quantity'  => 1,
-										'rbfw_order_status'   => 'processing',
-									],
-								],
-
-								'rbfw_gallery_images' => [],
-
-								'rbfw_single_template' => 'Default',
-							],
-						],
-						[
-							'title'   => 'Resort - Muffin Template',
-							'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua....',
-							'postmeta' => [
-								
-
-								'rdfw_available_time' => [
-									'10:00','11:00','12:00','13:00','14:00','15:00','14:00','17:00','21:00'
-								],
-
-								'rbfw_item_type' => 'resort',
-
-								'rbfw_extra_service_data' => [
-									[
-										'service_img'   => '1340',
-										'service_name'  => 'BBQ-party',
-										'service_price' => '10.99',
-										'service_qty'   => '10',
-									],
-									[
-										'service_img'   => '1339',
-										'service_name'  => 'Casino Royal',
-										'service_price' => '10.99',
-										'service_qty'   => '10',
-									],
-									[
-										'service_img'   => '1341',
-										'service_name'  => 'Spa and Cure',
-										'service_price' => '10.99',
-										'service_qty'   => '10',
-									],
-								],
-
-								'rbfw_resort_room_data' => [
-									[
-										'room_type'                 => 'Single',
-										'rbfw_room_image'           => '1335',
-										'rbfw_room_daylong_rate'    => '10.99',
-										'rbfw_room_daynight_rate'   => '40.99',
-										'rbfw_room_desc'            => 'Max. person: 2',
-										'rbfw_room_available_qty'   => '10',
-									],
-									[
-										'room_type'                 => 'Delux',
-										'rbfw_room_image'           => '1336',
-										'rbfw_room_daylong_rate'    => '20.99',
-										'rbfw_room_daynight_rate'   => '50.99',
-										'rbfw_room_desc'            => 'Max. person: 2',
-										'rbfw_room_available_qty'   => '10',
-									],
-									[
-										'room_type'                 => 'King',
-										'rbfw_room_image'           => '1334',
-										'rbfw_room_daylong_rate'    => '30.99',
-										'rbfw_room_daynight_rate'   => '60.99',
-										'rbfw_room_desc'            => 'Max. person: 2',
-										'rbfw_room_available_qty'   => '10',
-									],
-								],
-
-								'rbfw_enable_faq_content' => 'yes',
-
-								'mep_event_faq' => [
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'
-									],
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'
-									],
-								],
-
-								'rbfw_enable_dropoff_point' => 'no',
-								'rbfw_enable_daywise_price'  => 'no',
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'  => '',
-										'short_desc' => '',
-										'price'      => '',
-										'qty'        => '',
-									]
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => '',
-
-								'rbfw_enable_hourly_rate' => 'no',
-								'rbfw_enable_daily_rate'  => 'no',
-								'rbfw_enable_pick_point'  => 'no',
-
-								'rbfw_hourly_rate' => '',
-								'rbfw_daily_rate'  => '',
-
-								'rbfw_sun_hourly_rate' => '',
-								'rbfw_sun_daily_rate'  => '',
-								'rbfw_enable_sun_day'   => 'no',
-
-								'rbfw_mon_hourly_rate' => '',
-								'rbfw_mon_daily_rate'  => '',
-								'rbfw_enable_mon_day'  => 'no',
-
-								'rbfw_tue_hourly_rate' => '',
-								'rbfw_tue_daily_rate'  => '',
-								'rbfw_enable_tue_day'  => 'no',
-
-								'rbfw_wed_hourly_rate' => '',
-								'rbfw_wed_daily_rate'  => '',
-								'rbfw_enable_wed_day'  => 'no',
-
-								'rbfw_thu_hourly_rate' => '',
-								'rbfw_thu_daily_rate'  => '',
-								'rbfw_enable_thu_day'  => 'no',
-
-								'rbfw_fri_hourly_rate' => '',
-								'rbfw_fri_daily_rate'  => '',
-								'rbfw_enable_fri_day'  => 'no',
-
-								'rbfw_sat_hourly_rate' => '',
-								'rbfw_sat_daily_rate'  => '',
-								'rbfw_enable_sat_day'  => 'no',
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Room Services',
-										'cat_features' => [
-											['title' => 'Air Cooling'],
-											['title' => 'Wi-Fi'],
-											['title' => 'Smart Ironing'],
-											['title' => '24/7 Room Serivice'],
-											['title' => 'Garden Balcony'],
-											['title' => 'Swimming Pool'],
-											['title' => 'Bath Tab'],
-										],
-									],
-									[
-										'cat_title' => 'Hotel Services',
-										'cat_features' => [
-											['title' => 'Breakfast Included'],
-											['title' => 'Spa Center'],
-											['title' => 'Hill View'],
-											['title' => 'BBQ zone'],
-											['title' => 'Large Swimming Pool'],
-											['title' => 'Easy to Travel'],
-											['title' => 'Parking'],
-										],
-									],
-								],
-
-								'rbfw_single_template' => 'Muffin',
-
-								'rbfw_time_slot_switch' => 'on',
-								'rbfw_available_qty_info_switch' => 'no',
-								'rbfw_enable_extra_service_qty' => 'yes',
-
-								'rbfw_enable_variations' => 'no',
-								'rbfw_enable_md_type_item_qty' => 'no',
-
-								'rbfw_item_stock_quantity' => '0',
-								'rbfw_enable_resort_daylong_price' => 'yes',
-							],
-						],
-						[
-							'title'   => 'Doctor Appointment - Muffin Template',
-							'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua....',
-							'postmeta' => [
-								
-								'rdfw_available_time' => [
-									'10:00 AM','10:00 PM','10:30 AM','10:30 PM',
-									'11:00 AM','11:30 AM','11:30 PM','12:00 PM','12:30 PM'
-								],
-
-								'rbfw_item_type' => 'appointment',
-
-								'rbfw_extra_service_data' => [],
-
-								'rbfw_resort_room_data' => [
-									[
-										'room_type' => '',
-										'rbfw_room_image' => '',
-										'rbfw_room_daylong_rate' => '',
-										'rbfw_room_daynight_rate' => '',
-										'rbfw_room_desc' => '',
-										'rbfw_room_available_qty' => '',
-									]
-								],
-
-								'rbfw_enable_faq_content' => 'yes',
-
-								'mep_event_faq' => [
-									[
-										'rbfw_faq_title'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'
-									],
-									[
-										'rbfw_faq_title'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'
-									],
-								],
-
-								'rbfw_enable_dropoff_point' => 'no',
-								'rbfw_enable_daywise_price'  => 'no',
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'  => '30 Minute',
-										'short_desc' => 'Consult for 30 minutes',
-										'price'      => '100',
-										'qty'        => '90',
-									]
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => '',
-
-								'rbfw_enable_hourly_rate' => 'no',
-								'rbfw_enable_daily_rate'  => 'no',
-								'rbfw_enable_pick_point'  => 'no',
-
-								'rbfw_hourly_rate' => '',
-								'rbfw_daily_rate'  => '',
-
-								'rbfw_sun_hourly_rate' => '',
-								'rbfw_sun_daily_rate'  => '',
-								'rbfw_enable_sun_day'  => 'no',
-
-								'rbfw_mon_hourly_rate' => '',
-								'rbfw_mon_daily_rate'  => '',
-								'rbfw_enable_mon_day'  => 'no',
-
-								'rbfw_tue_hourly_rate' => '',
-								'rbfw_tue_daily_rate'  => '',
-								'rbfw_enable_tue_day'  => 'no',
-
-								'rbfw_wed_hourly_rate' => '',
-								'rbfw_wed_daily_rate'  => '',
-								'rbfw_enable_wed_day'  => 'no',
-
-								'rbfw_thu_hourly_rate' => '',
-								'rbfw_thu_daily_rate'  => '',
-								'rbfw_enable_thu_day'  => 'no',
-
-								'rbfw_fri_hourly_rate' => '',
-								'rbfw_fri_daily_rate'  => '',
-								'rbfw_enable_fri_day'  => 'no',
-
-								'rbfw_sat_hourly_rate' => '',
-								'rbfw_sat_daily_rate'  => '',
-								'rbfw_enable_sat_day'  => 'no',
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Bike Features',
-										'cat_features' => [
-											['title' => 'Disc Brakes'],
-											['title' => 'Shock Absorbers'],
-											['title' => 'Headlight and Taillight'],
-											['title' => 'Bottle Holder'],
-											['title' => 'Electric Horn'],
-										],
-									]
-								],
-
-								'rbfw_single_template' => 'Muffin',
-
-								'rbfw_time_slot_switch' => 'on',
-								'rbfw_enable_extra_service_qty' => 'yes',
-
-								'rbfw_enable_variations' => 'no',
-								'rbfw_enable_md_type_item_qty' => 'no',
-
-								'rbfw_item_stock_quantity' => '0',
-								'rbfw_enable_resort_daylong_price' => 'no',
-
-								'rbfw_sd_appointment_ondays' => [
-									'Monday','Tuesday','Wednesday','Thursday','Friday'
-								],
-
-								'rbfw_sd_appointment_max_qty_per_session' => '10',
-
-								'rbfw_variations_data' => [
-									[
-										'field_label' => '',
-										'field_id'    => 'rbfw_variation_id_0',
-										'value'       => [
-											[
-												'name'     => '',
-												'quantity' => '',
-											]
-										],
-										'selected_value' => '',
-									]
-								],
-
-
-
-							],
-						],
-						[
-							'title'   => 'Equipment - Muffin Template',
-
-							'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-
-							'postmeta' => [
-								
-
-								'rdfw_available_time' => [
-									'10:00','11:00','12:00','13:00','14:00','15:00','16:00','17:00','21:00'
-								],
-
-								'rbfw_item_type' => 'equipment',
-
-								'rbfw_extra_service_data' => [],
-
-								'rbfw_resort_room_data' => [
-									[
-										'room_type' => '',
-										'rbfw_room_image' => '',
-										'rbfw_room_daylong_rate' => '',
-										'rbfw_room_daynight_rate' => '',
-										'rbfw_room_desc' => '',
-										'rbfw_room_available_qty' => '',
-									]
-								],
-
-								'rbfw_enable_faq_content' => 'yes',
-
-								'mep_event_faq' => [
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'
-									],
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'
-									],
-								],
-
-								'rbfw_enable_dropoff_point' => 'no',
-								'rbfw_enable_daywise_price' => 'no',
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'  => '30 Minute',
-										'short_desc' => 'Consult for 30 minutes',
-										'price'      => '100',
-										'qty'        => '90',
-									]
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => '',
-
-								'rbfw_enable_hourly_rate' => 'yes',
-								'rbfw_enable_daily_rate'  => 'yes',
-								'rbfw_enable_pick_point'  => 'no',
-
-								'rbfw_hourly_rate' => '10',
-								'rbfw_daily_rate'  => '100',
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Highlighted Features',
-										'cat_features' => [
-											['title' => 'Brand: Bosch'],
-											['title' => 'Power Source: Corded Electric'],
-											['title' => 'Item Dimensions: 39.5 x 12 x 33 Centimeters'],
-											['title' => 'Weight: 4.4 Kilograms'],
-										],
-									]
-								],
-
-								'rbfw_single_template' => 'Muffin',
-
-								'rbfw_time_slot_switch' => 'on',
-								'rbfw_enable_extra_service_qty' => 'yes',
-
-								'rbfw_enable_variations' => 'no',
-								'rbfw_enable_md_type_item_qty' => 'no',
-
-								'rbfw_item_stock_quantity' => '10',
-								'rbfw_enable_resort_daylong_price' => 'no',
-
-								'rbfw_variations_data' => [
-									[
-										'field_label' => '',
-										'field_id'    => 'rbfw_variation_id_0',
-										'value'       => [
-											[
-												'name'     => '',
-												'quantity' => '',
-											]
-										],
-										'selected_value' => '',
-									]
-								],
-								'rbfw_sd_appointment_ondays' => [],
-								'rbfw_sd_appointment_max_qty_per_session' => '',
-							],
-						],
-						[
-							'title'   => 'Bike/Car For Multiple Day - Muffin Template',
-							'content' => 'A bike rental or bike hire business rents out bicycles for short periods of time, usually for a few hours. Most rentals are provided by bike shops as a sideline to their main businesses of sales and service, but shops specialize in rentals.',
-
-							'postmeta' => [
-								
-
-								'rdfw_available_time' => [
-									'10:00','11:00','12:00','13:00','14:00','15:00','16:00','17:00','21:00'
-								],
-
-								'rbfw_item_type' => 'bike_car_md',
-
-								'rbfw_enable_start_end_date' => 'yes',
-
-								'rbfw_extra_service_data' => [
-									[
-										'service_name'  => 'Extra Tire',
-										'service_price' => '5',
-										'service_qty'   => '10',
-									],
-									[
-										'service_name'  => 'Helmet',
-										'service_price' => '5',
-										'service_qty'   => '10',
-									],
-									[
-										'service_name'  => 'Extra engine Oil',
-										'service_price' => '2',
-										'service_qty'   => '10',
-									],
-									[
-										'service_name'  => 'Tool Box',
-										'service_price' => '2',
-										'service_qty'   => '10',
-									],
-								],
-
-								'rbfw_resort_room_data' => [
-									[
-										'room_type' => '',
-										'rbfw_room_image' => '',
-										'rbfw_room_daylong_rate' => '',
-										'rbfw_room_daynight_rate' => '',
-										'rbfw_room_desc' => '',
-										'rbfw_room_available_qty' => '',
-									]
-								],
-
-								'rbfw_enable_faq_content' => 'yes',
-
-								'mep_event_faq' => [
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-								],
-
-								'rbfw_enable_dropoff_point' => 'no',
-								'rbfw_enable_daywise_price' => 'no',
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'  => '',
-										'short_desc' => '',
-										'price'      => '',
-										'qty'        => '',
-									]
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => [],
-
-								'rbfw_enable_hourly_rate' => 'yes',
-								'rbfw_enable_daily_rate'  => 'yes',
-
-								'rbfw_hourly_rate' => '10',
-								'rbfw_daily_rate'  => '100',
-
-								'rbfw_sun_hourly_rate' => '',
-								'rbfw_sun_daily_rate'  => '',
-								'rbfw_enable_sun_day'  => 'no',
-
-								'rbfw_mon_hourly_rate' => '',
-								'rbfw_mon_daily_rate'  => '',
-								'rbfw_enable_mon_day'  => 'no',
-
-								'rbfw_tue_hourly_rate' => '',
-								'rbfw_tue_daily_rate'  => '',
-								'rbfw_enable_tue_day'  => 'no',
-
-								'rbfw_wed_hourly_rate' => '',
-								'rbfw_wed_daily_rate'  => '',
-								'rbfw_enable_wed_day'  => 'no',
-
-								'rbfw_thu_hourly_rate' => '',
-								'rbfw_thu_daily_rate'  => '',
-								'rbfw_enable_thu_day'  => 'no',
-
-								'rbfw_fri_hourly_rate' => '',
-								'rbfw_fri_daily_rate'  => '',
-								'rbfw_enable_fri_day'  => 'no',
-
-								'rbfw_sat_hourly_rate' => '',
-								'rbfw_sat_daily_rate'  => '',
-								'rbfw_enable_sat_day'  => 'no',
-
-								'rbfw_enable_pick_point' => 'no',
-
-								'rbfw_item_stock_quantity' => '10',
-
-								'rbfw_time_slot_switch' => 'on',
-
-								'rbfw_enable_extra_service_qty' => 'yes',
-
-								'rbfw_enable_variations' => 'no',
-
-								'rbfw_enable_md_type_item_qty' => 'yes',
-
-								'rbfw_variations_data' => [
-									[
-										'field_label' => '',
-										'field_id'    => 'rbfw_variation_id_0',
-										'value'       => [
-											[
-												'name'     => '',
-												'quantity' => '',
-											]
-										],
-										'selected_value' => '',
-									]
-								],
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Bike Features',
-										'cat_features' => [
-											['title' => 'Disc Brakes'],
-											['title' => 'Shock Absorbers'],
-											['title' => 'Headlight and Taillight'],
-											['title' => 'Bottle Holder'],
-											['title' => 'Electric Horn'],
-										],
-									]
-								],
-
-								'rbfw_dt_sidebar_switch' => 'off',
-								'rbfw_dt_sidebar_testimonials' => '',
-								'rbfw_dt_sidebar_content' => '',
-
-								'_thumbnail_id' => '',
-
-
-
-
-								'rbfw_single_template' => 'Muffin',
-							],
-						],
-						[
-							'title'   => 'Dress - Muffin Template',
-							'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-
-							'postmeta' => [
-								
-
-								'rdfw_available_time' => [
-									'10:00','11:00','12:00','13:00','14:00','3:00 PM','16:00','5:00 PM','21:00'
-								],
-
-								'rbfw_item_type' => 'dress',
-
-								'rbfw_extra_service_data' => [
-									[
-										'service_name'  => 'Tie',
-										'service_price' => '10',
-										'service_qty'   => '100',
-									],
-									[
-										'service_name'  => 'Shoes',
-										'service_price' => '10',
-										'service_qty'   => '100',
-									],
-								],
-
-								'rbfw_resort_room_data' => [
-									[
-										'room_type' => '',
-										'rbfw_room_image' => '',
-										'rbfw_room_daylong_rate' => '',
-										'rbfw_room_daynight_rate' => '',
-										'rbfw_room_desc' => '',
-										'rbfw_room_available_qty' => '',
-									]
-								],
-
-								'rbfw_enable_faq_content' => 'yes',
-
-								'mep_event_faq' => [
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-								],
-
-								'rbfw_enable_dropoff_point' => 'no',
-								'rbfw_enable_daywise_price' => 'no',
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'  => '',
-										'short_desc' => '',
-										'price'      => '',
-										'qty'        => '',
-									]
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => [],
-
-								'rbfw_enable_hourly_rate' => 'yes',
-								'rbfw_enable_daily_rate'  => 'yes',
-
-								'rbfw_hourly_rate' => '10',
-								'rbfw_daily_rate'  => '100',
-
-								'rbfw_sun_hourly_rate' => '',
-								'rbfw_sun_daily_rate'  => '',
-								'rbfw_enable_sun_day'  => 'no',
-
-								'rbfw_mon_hourly_rate' => '',
-								'rbfw_mon_daily_rate'  => '',
-								'rbfw_enable_mon_day'  => 'no',
-
-								'rbfw_tue_hourly_rate' => '',
-								'rbfw_tue_daily_rate'  => '',
-								'rbfw_enable_tue_day'  => 'no',
-
-								'rbfw_wed_hourly_rate' => '',
-								'rbfw_wed_daily_rate'  => '',
-								'rbfw_enable_wed_day'  => 'no',
-
-								'rbfw_thu_hourly_rate' => '',
-								'rbfw_thu_daily_rate'  => '',
-								'rbfw_enable_thu_day'  => 'no',
-
-								'rbfw_fri_hourly_rate' => '',
-								'rbfw_fri_daily_rate'  => '',
-								'rbfw_enable_fri_day'  => 'no',
-
-								'rbfw_sat_hourly_rate' => '',
-								'rbfw_sat_daily_rate'  => '',
-								'rbfw_enable_sat_day'  => 'no',
-
-								'rbfw_list_thumbnail' => '',
-								'rbfw_theme_file' => '',
-
-								'rbfw_available_qty_info_switch' => 'no',
-
-								'rbfw_single_template' => 'Muffin',
-
-								'rbfw_time_slot_switch' => 'on',
-
-								'rbfw_enable_extra_service_qty' => 'yes',
-								'rbfw_enable_variations' => 'yes',
-								'rbfw_enable_md_type_item_qty' => 'no',
-
-								'rbfw_item_stock_quantity' => '10',
-
-								'rbfw_enable_resort_daylong_price' => 'no',
-
-								'rbfw_variations_data' => [
-									[
-										'field_label' => 'Color',
-										'field_id'    => 'rbfw_variation_id_0',
-										'value'       => [
-											[
-												'name'     => 'Red',
-												'quantity' => '5',
-											],
-											[
-												'name'     => 'Blue',
-												'quantity' => '5',
-											],
-										],
-									],
-									[
-										'field_label' => 'Size',
-										'field_id'    => 'rbfw_variation_id_1',
-										'value'       => [
-											[
-												'name'     => 'Small',
-												'quantity' => '5',
-											],
-											[
-												'name'     => 'Medium',
-												'quantity' => '5',
-											],
-										],
-									],
-								],
-
-								'rbfw_sd_appointment_ondays' => [],
-								'rbfw_sd_appointment_max_qty_per_session' => '',
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Dress Features',
-										'cat_features' => [
-											['title' => 'Very High Quality Product'],
-											['title' => 'Various Sizeable'],
-											['title' => 'High Quality Fabric'],
-											['title' => 'Attractive To See'],
-											['title' => 'Well Fitting'],
-										],
-									]
-								],
-
-								'rbfw_dt_sidebar_switch' => 'off',
-								'rbfw_dt_sidebar_testimonials' => '',
-								'rbfw_dt_sidebar_content' => '',
-
-							],
-						],
-						[
-							'title'   => 'Bike/Car For Single Day - Classic Template',
-							'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-
-							'postmeta' => [
-								
-
-								'rdfw_available_time' => [
-									'10:00 AM','10:00 PM','10:30 AM','10:30 PM','11:30 AM','11:30 PM',
-									'12:00 AM','12:00 PM','12:30 AM','12:30 PM','1:00 AM','6:00 AM',
-									'6:00 PM','8:00 AM','8:00 PM','8:30 AM','8:30 PM','9:00 AM',
-									'9:00 PM','9:30 AM','9:30 PM'
-								],
-
-								'rbfw_item_type' => 'bike_car_sd',
-
-								'rbfw_extra_service_data' => [
-									[
-										'service_name'  => 'Tie',
-										'service_price' => '10',
-										'service_qty'   => '100',
-									],
-									[
-										'service_name'  => 'Shoes',
-										'service_price' => '10',
-										'service_qty'   => '100',
-									],
-								],
-
-								'rbfw_resort_room_data' => [
-									[
-										'room_type' => '',
-										'rbfw_room_image' => '',
-										'rbfw_room_daylong_rate' => '',
-										'rbfw_room_daynight_rate' => '',
-										'rbfw_room_desc' => '',
-										'rbfw_room_available_qty' => '',
-									]
-								],
-
-								'rbfw_enable_faq_content' => 'yes',
-
-								'mep_event_faq' => [
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-									[
-										'rbfw_faq_title'   => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-								],
-
-								'rbfw_enable_dropoff_point' => 'no',
-								'rbfw_enable_daywise_price' => 'no',
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'  => 'One Hour Rentals',
-										'short_desc' => 'Up to 1 hours',
-										'price'      => '7.99',
-										'qty'        => '100',
-									],
-									[
-										'rent_type'  => 'Two Hour Rentals',
-										'short_desc' => 'Up to 2 hours',
-										'price'      => '15.98',
-										'qty'        => '100',
-									],
-									[
-										'rent_type'  => 'Three Hour Rentals',
-										'short_desc' => 'Up to 3 hours',
-										'price'      => '19.97',
-										'qty'        => '100',
-									],
-									[
-										'rent_type'  => 'Four Hour Rentals',
-										'short_desc' => 'Up to 4 hours',
-										'price'      => '24.76',
-										'qty'        => '100',
-									],
-									[
-										'rent_type'  => 'Five Hour Rentals',
-										'short_desc' => 'Up to 5 hours',
-										'price'      => '28.75',
-										'qty'        => '100',
-									],
-									[
-										'rent_type'  => 'Half Day Rental',
-										'short_desc' => 'Up to 6 hours',
-										'price'      => '29.99',
-										'qty'        => '100',
-									],
-									[
-										'rent_type'  => 'All Day Rentals',
-										'short_desc' => 'Up to 10 Hours',
-										'price'      => '38.99',
-										'qty'        => '100',
-									],
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => [],
-
-								'rbfw_enable_hourly_rate' => 'yes',
-								'rbfw_enable_daily_rate'  => 'yes',
-
-								'rbfw_hourly_rate' => '10',
-								'rbfw_daily_rate'  => '100',
-
-								'rbfw_enable_pick_point' => 'no',
-
-								'rbfw_sun_hourly_rate' => '',
-								'rbfw_sun_daily_rate'  => '',
-								'rbfw_enable_sun_day'  => 'no',
-
-								'rbfw_mon_hourly_rate' => '',
-								'rbfw_mon_daily_rate'  => '',
-								'rbfw_enable_mon_day'  => 'no',
-
-								'rbfw_tue_hourly_rate' => '',
-								'rbfw_tue_daily_rate'  => '',
-								'rbfw_enable_tue_day'  => 'no',
-
-								'rbfw_wed_hourly_rate' => '',
-								'rbfw_wed_daily_rate'  => '',
-								'rbfw_enable_wed_day'  => 'no',
-
-								'rbfw_thu_hourly_rate' => '',
-								'rbfw_thu_daily_rate'  => '',
-								'rbfw_enable_thu_day'  => 'no',
-
-								'rbfw_fri_hourly_rate' => '',
-								'rbfw_fri_daily_rate'  => '',
-								'rbfw_enable_fri_day'  => 'no',
-
-								'rbfw_sat_hourly_rate' => '',
-								'rbfw_sat_daily_rate'  => '',
-								'rbfw_enable_sat_day'  => 'no',
-
-								'rbfw_list_thumbnail' => '',
-								'rbfw_theme_file' => '',
-
-								'rbfw_available_qty_info_switch' => 'no',
-								'rbfw_single_template' => 'Default',
-
-								'rbfw_time_slot_switch' => 'on',
-								'rbfw_enable_extra_service_qty' => 'yes',
-								'rbfw_enable_variations' => 'no',
-								'rbfw_enable_md_type_item_qty' => 'no',
-
-								'rbfw_item_stock_quantity' => '10',
-
-								'rbfw_enable_resort_daylong_price' => 'no',
-
-								'rbfw_variations_data' => [
-									[
-										'field_label' => '',
-										'field_id'    => 'rbfw_variation_id_0',
-										'value'       => [
-											[
-												'name'     => '',
-												'quantity' => '',
-											]
-										],
-										'selected_value' => '',
-									]
-								],
-
-								'rbfw_sd_appointment_ondays' => [],
-								'rbfw_sd_appointment_max_qty_per_session' => '',
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Bike Features',
-										'cat_features' => [
-											['title' => 'Disc Brakes'],
-											['title' => 'Shock Absorbers'],
-											['title' => 'Headlight and Taillight'],
-											['title' => 'Bottle Holder'],
-											['title' => 'Electric Horn'],
-										],
-									]
-								],
-
-								'rbfw_dt_sidebar_switch' => 'off',
-								'rbfw_dt_sidebar_testimonials' => '',
-								'rbfw_dt_sidebar_content' => '',
-
-							],
-						],
-						[
-							'title'   => 'Bike/Car For Single Day multi hour - Classic Template',
-							'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-
-							'postmeta' => [
-								
-
-								'rdfw_available_time' => [
-									'00:00','00:30','01:00','06:00','08:00','08:30','09:00','09:30',
-									'10:00','10:30','11:30','12:00','12:30','18:00','20:00','20:30',
-									'21:00','21:30','22:00','22:30','23:30'
-								],
-
-								'rbfw_item_type' => 'bike_car_sd',
-
-								'rbfw_extra_service_data' => [
-									[
-										'service_name'  => 'Tie',
-										'service_price' => '10',
-										'service_qty'   => '100',
-									],
-									[
-										'service_name'  => 'Shoes',
-										'service_price' => '10',
-										'service_qty'   => '100',
-									],
-								],
-
-								'rbfw_resort_room_data' => [
-									[
-										'room_type' => '',
-										'rbfw_room_image' => '',
-										'rbfw_room_daylong_rate' => '',
-										'rbfw_room_daynight_rate' => '',
-										'rbfw_room_desc' => '',
-										'rbfw_room_available_qty' => '',
-									]
-								],
-
-								'rbfw_enable_faq_content' => 'yes',
-
-								'mep_event_faq' => [
-									[
-										'rbfw_faq_title' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-									[
-										'rbfw_faq_title' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-										'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-									],
-								],
-
-								'rbfw_enable_dropoff_point' => 'no',
-								'rbfw_enable_daywise_price' => 'no',
-
-								'rbfw_bike_car_sd_data' => [
-									[
-										'rent_type'   => '1 Hour Rent',
-										'short_desc'  => 'Rent for 1 hour',
-										'price'       => '10',
-										'qty'         => '100',
-										'start_time'  => '09:00',
-										'end_time'    => '12:00',
-										'duration'    => '1',
-										'd_type'      => 'Hours',
-									],
-									[
-										'rent_type'   => '2 Hour Rent',
-										'short_desc'  => 'Rent for 2 hour',
-										'price'       => '15',
-										'qty'         => '',
-										'start_time'  => '15:00',
-										'end_time'    => '18:00',
-										'duration'    => '2',
-										'd_type'      => 'Hours',
-									],
-									[
-										'rent_type'   => '4 Hour Rent',
-										'short_desc'  => 'Rent for 4 hour',
-										'price'       => '25',
-										'qty'         => '',
-										'start_time'  => '09:00',
-										'end_time'    => '18:00',
-										'duration'    => '4',
-										'd_type'      => 'Hours',
-									],
-									[
-										'rent_type'   => '6 Hour Rent',
-										'short_desc'  => 'Rent for 6 hour',
-										'price'       => '30',
-										'qty'         => '',
-										'start_time'  => '',
-										'end_time'    => '',
-										'duration'    => '6',
-										'd_type'      => 'Hours',
-									],
-									[
-										'rent_type'   => 'Full Day Rent',
-										'short_desc'  => 'Rent for full day',
-										'price'       => '40',
-										'qty'         => '',
-										'start_time'  => '',
-										'end_time'    => '',
-										'duration'    => '24',
-										'd_type'      => 'Hours',
-									],
-								],
-
-								'rbfw_time_format' => '12',
-								'rbfw_off_dates'   => [],
-
-								'rbfw_enable_hourly_rate' => 'yes',
-								'rbfw_enable_daily_rate'  => 'yes',
-
-								'rbfw_enable_pick_point' => 'no',
-								'rbfw_hourly_rate' => '10',
-								'rbfw_daily_rate'  => '100',
-
-								'rbfw_enable_sun_day' => 'no',
-								'rbfw_enable_mon_day' => 'no',
-								'rbfw_enable_tue_day' => 'no',
-								'rbfw_enable_wed_day' => 'no',
-								'rbfw_enable_thu_day' => 'no',
-								'rbfw_enable_fri_day' => 'no',
-								'rbfw_enable_sat_day' => 'no',
-
-								'rbfw_available_qty_info_switch' => 'no',
-								'rbfw_single_template' => 'Default',
-
-								'rbfw_time_slot_switch' => 'on',
-								'rbfw_enable_extra_service_qty' => 'yes',
-								'rbfw_enable_variations' => 'no',
-								'rbfw_enable_md_type_item_qty' => 'no',
-
-								'rbfw_item_stock_quantity' => '10',
-
-								'rbfw_variations_data' => [
-									[
-										'field_label' => '',
-										'field_id'    => 'rbfw_variation_id_0',
-										'value'       => [
-											[
-												'name'     => '',
-												'quantity' => '',
-											]
-										],
-										'selected_value' => '',
-									]
-								],
-
-								'rbfw_feature_category' => [
-									[
-										'cat_title' => 'Bike Features',
-										'cat_features' => [
-											['title' => 'Disc Brakes'],
-											['title' => 'Shock Absorbers'],
-											['title' => 'Headlight and Taillight'],
-											['title' => 'Bottle Holder'],
-											['title' => 'Electric Horn'],
-										],
-									]
-								],
-
-								'rbfw_dt_sidebar_switch' => 'off',
-
-								'rbfw_gallery_images' => [],
-								'rbfw_gallery_images_additional' => [],
-
-								'rbfw_categories' => [],
-
-								'rbfw_inventory' => [],
-
-								'rbfw_single_template' => 'Default',
-							],
-						]
-					];
-			}
-
-			private function dummy_images() {
-				$urls = array(
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image1.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image2.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image3.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image4.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image5.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image6.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image7.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image8.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image9.jpeg',
-						'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image10.jpeg',
-					);
-
-				unset($image_ids);
-				$image_ids = array();
-				foreach ($urls as $url) {
-					$image_ids[] = media_sideload_image($url, '0', 'Dummy Images', 'id');
-				}
-				return $image_ids;
-			}
-
-			public function create_dummy_page() {
-				$pages_to_create = [
-					'find' => [
-						'slug' => 'booking',
-						'title' => 'Booking Ticket',
-						'content' => '[wtbm_ticket_booking]',
-						'option_key' => 'mptrs_booking_page_created',
-					]
+			foreach ($posts as $data) {
+				$post = [
+					'post_type'    => $post_type,
+					'post_title'   => isset($data['title']) ? $data['title'] : '',
+					'post_content' => isset($data['content']) ? $data['content'] : '',
+					'post_status'  => 'publish',
 				];
-				foreach ($pages_to_create as $page_data) {
-					$existing_page = get_page_by_path( $page_data['slug'], OBJECT, 'page' );
-					if ( $existing_page ) {
-						return;
+				$post_id = wp_insert_post($post);
+				if (!is_wp_error($post_id)) {
+					$meta_data = $data['postmeta'] ?? [];
+					if (is_array($meta_data)) {
+						foreach ($meta_data as $meta_key => $meta_value) {
+							update_post_meta($post_id, $meta_key, $meta_value);
+						}
 					}
-					$page = [
-						'post_type' => 'page',
-						'post_name' => $page_data['slug'],
-						'post_title' => $page_data['title'],
-						'post_content' => $page_data['content'],
-						'post_status' => 'publish',
-					];
-					$page_id = wp_insert_post($page);
-					if (is_wp_error($page_id)) {
-						printf('<div class="notice notice-error"><p>%s</p></div>', esc_html($page_id->get_error_message()));
-					} else {
-						update_option($page_data['option_key'], true);
-					}
-					
 				}
+				$post_ids[] = $post_id;
 			}
+			return $post_ids;
+		}
 
-			public static function check_plugin($plugin_dir_name, $plugin_file): int {
-				include_once ABSPATH . 'wp-admin/includes/plugin.php';
-				$plugin_dir = ABSPATH . 'wp-content/plugins/' . $plugin_dir_name;
-				if (is_plugin_active($plugin_dir_name . '/' . $plugin_file)) {
-					return 1;
-				}
-				elseif (is_dir($plugin_dir)) {
-					return 2;
-				}
-				else {
-					return 0;
+		public function insert_gallery_images($retnal_ids) {
+			$attachment_ids = self::dummy_images();
+			foreach ($retnal_ids as $post_id) {
+				$gallery_arr = array_map('intval', $attachment_ids);
+				update_post_meta($post_id, 'rbfw_gallery_images', $gallery_arr);
+				update_post_meta($post_id, 'rbfw_gallery_images_additional', $gallery_arr);
+			}
+		}
+
+		public function insert_thumbnails($postsids, $meta_key = '') {
+			$attachment_ids = self::dummy_images();
+			foreach ($postsids as $index => $post_id) {
+				$attachment_id = $attachment_ids[$index];
+				set_post_thumbnail($post_id, $attachment_id);
+				if ($meta_key != '') {
+					update_post_meta($post_id, $meta_key, $attachment_id);
 				}
 			}
 		}
-		$dummy_import = new RbfwImportDemo();		
+
+		private function dummy_images() {
+			$urls = array(
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image1.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image2.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image3.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image4.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image5.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image6.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image7.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image8.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image9.jpeg',
+				'https://raw.githubusercontent.com/magepeopleteam/dummy-images/main/rental/image10.jpeg',
+			);
+			$image_ids = array();
+			foreach ($urls as $url) {
+				$image_ids[] = media_sideload_image($url, '0', 'Dummy Images', 'id');
+			}
+			return $image_ids;
+		}
+
+		public function retnal_data() {
+			return [
+				[
+					'title'   => 'Bike/Car For Single Day Multiple Slot - Classic Template',
+					'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam...',
+					'postmeta' => [
+						'rdfw_available_time' => [
+							'00:00','00:30','01:00','06:00','08:00','08:30','09:00','09:30',
+							'10:00','10:30','11:30','12:00','12:30','18:00','20:00','20:30',
+							'21:00','21:30','22:00','22:30','23:30'
+						],
+						'rbfw_item_type' => 'bike_car_sd',
+						'rbfw_extra_service_data' => [
+							['service_name' => 'Tie', 'service_price' => '10', 'service_qty' => '100'],
+							['service_name' => 'Shoes', 'service_price' => '10', 'service_qty' => '100'],
+						],
+						'rbfw_bike_car_sd_data' => [
+							['rent_type' => 'Morning Session', 'short_desc' => '9 am to 12pm', 'price' => '10', 'qty' => '100', 'start_time' => '09:00', 'end_time' => '12:00', 'duration' => '6', 'd_type' => 'Hours'],
+							['rent_type' => 'Afternoon Session', 'short_desc' => '3 pm to 6pm', 'price' => '10', 'qty' => '', 'start_time' => '15:00', 'end_time' => '18:00', 'duration' => '6', 'd_type' => 'Hours'],
+							['rent_type' => 'Full Day', 'short_desc' => '6 am to 12 pm', 'price' => '18', 'qty' => '', 'start_time' => '09:00', 'end_time' => '18:00', 'duration' => '24', 'd_type' => 'Hours'],
+						],
+						'rbfw_time_format' => '12',
+						'rbfw_off_dates'   => [],
+						'rbfw_enable_hourly_rate' => 'yes',
+						'rbfw_enable_daily_rate'  => 'yes',
+						'rbfw_hourly_rate' => '10',
+						'rbfw_daily_rate'  => '100',
+						'rbfw_item_stock_quantity' => '10',
+						'rbfw_time_slot_switch' => 'on',
+						'rbfw_feature_category' => [
+							['cat_title' => 'Bike Features', 'cat_features' => [
+								['title' => 'Disc Brakes'], ['title' => 'Shock Absorbers'], ['title' => 'Headlight and Taillight'], ['title' => 'Bottle Holder'], ['title' => 'Electric Horn'],
+							]]
+						],
+						'rbfw_inventory' => [],
+						'rbfw_gallery_images' => [],
+						'rbfw_single_template' => 'Default',
+					],
+				],
+				[
+					'title'   => 'Resort - Muffin Template',
+					'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua....',
+					'postmeta' => [
+						'rdfw_available_time' => ['10:00','11:00','12:00','13:00','14:00','15:00','14:00','17:00','21:00'],
+						'rbfw_item_type' => 'resort',
+						'rbfw_extra_service_data' => [
+							['service_img' => '1340', 'service_name' => 'BBQ-party', 'service_price' => '10.99', 'service_qty' => '10'],
+							['service_img' => '1339', 'service_name' => 'Casino Royal', 'service_price' => '10.99', 'service_qty' => '10'],
+							['service_img' => '1341', 'service_name' => 'Spa and Cure', 'service_price' => '10.99', 'service_qty' => '10'],
+						],
+						'rbfw_resort_room_data' => [
+							['room_type' => 'Single', 'rbfw_room_image' => '1335', 'rbfw_room_daylong_rate' => '10.99', 'rbfw_room_daynight_rate' => '40.99', 'rbfw_room_desc' => 'Max. person: 2', 'rbfw_room_available_qty' => '10'],
+							['room_type' => 'Delux', 'rbfw_room_image' => '1336', 'rbfw_room_daylong_rate' => '20.99', 'rbfw_room_daynight_rate' => '50.99', 'rbfw_room_desc' => 'Max. person: 2', 'rbfw_room_available_qty' => '10'],
+							['room_type' => 'King', 'rbfw_room_image' => '1334', 'rbfw_room_daylong_rate' => '30.99', 'rbfw_room_daynight_rate' => '60.99', 'rbfw_room_desc' => 'Max. person: 2', 'rbfw_room_available_qty' => '10'],
+						],
+						'rbfw_enable_faq_content' => 'yes',
+						'mep_event_faq' => [
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+						],
+						'rbfw_enable_dropoff_point' => 'no',
+						'rbfw_enable_daywise_price'  => 'no',
+						'rbfw_bike_car_sd_data' => [['rent_type' => '', 'short_desc' => '', 'price' => '', 'qty' => '']],
+						'rbfw_time_format' => '12',
+						'rbfw_off_dates'   => '',
+						'rbfw_enable_hourly_rate' => 'no',
+						'rbfw_enable_daily_rate'  => 'no',
+						'rbfw_enable_pick_point'  => 'no',
+						'rbfw_hourly_rate' => '',
+						'rbfw_daily_rate'  => '',
+						'rbfw_enable_sun_day' => 'no', 'rbfw_enable_mon_day' => 'no', 'rbfw_enable_tue_day' => 'no',
+						'rbfw_enable_wed_day' => 'no', 'rbfw_enable_thu_day' => 'no', 'rbfw_enable_fri_day' => 'no', 'rbfw_enable_sat_day' => 'no',
+						'rbfw_feature_category' => [
+							['cat_title' => 'Room Services', 'cat_features' => [
+								['title' => 'Air Cooling'], ['title' => 'Wi-Fi'], ['title' => 'Smart Ironing'],
+								['title' => '24/7 Room Service'], ['title' => 'Garden Balcony'], ['title' => 'Swimming Pool'], ['title' => 'Bath Tab'],
+							]],
+							['cat_title' => 'Hotel Services', 'cat_features' => [
+								['title' => 'Breakfast Included'], ['title' => 'Spa Center'], ['title' => 'Hill View'],
+								['title' => 'BBQ zone'], ['title' => 'Large Swimming Pool'], ['title' => 'Easy to Travel'], ['title' => 'Parking'],
+							]],
+						],
+						'rbfw_single_template' => 'Muffin',
+						'rbfw_time_slot_switch' => 'on',
+						'rbfw_available_qty_info_switch' => 'no',
+						'rbfw_enable_extra_service_qty' => 'yes',
+						'rbfw_enable_variations' => 'no',
+						'rbfw_enable_md_type_item_qty' => 'no',
+						'rbfw_item_stock_quantity' => '0',
+						'rbfw_enable_resort_daylong_price' => 'yes',
+					],
+				],
+				[
+					'title'   => 'Doctor Appointment - Muffin Template',
+					'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua....',
+					'postmeta' => [
+						'rdfw_available_time' => ['10:00 AM','10:00 PM','10:30 AM','10:30 PM','11:00 AM','11:30 AM','11:30 PM','12:00 PM','12:30 PM'],
+						'rbfw_item_type' => 'appointment',
+						'rbfw_extra_service_data' => [],
+						'rbfw_resort_room_data' => [['room_type' => '', 'rbfw_room_image' => '', 'rbfw_room_daylong_rate' => '', 'rbfw_room_daynight_rate' => '', 'rbfw_room_desc' => '', 'rbfw_room_available_qty' => '']],
+						'rbfw_enable_faq_content' => 'yes',
+						'mep_event_faq' => [
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+						],
+						'rbfw_enable_dropoff_point' => 'no',
+						'rbfw_enable_daywise_price'  => 'no',
+						'rbfw_bike_car_sd_data' => [
+							['rent_type' => '30 Minute', 'short_desc' => 'Consult for 30 minutes', 'price' => '100', 'qty' => '90'],
+						],
+						'rbfw_time_format' => '12',
+						'rbfw_off_dates'   => '',
+						'rbfw_enable_hourly_rate' => 'no', 'rbfw_enable_daily_rate' => 'no', 'rbfw_enable_pick_point' => 'no',
+						'rbfw_hourly_rate' => '', 'rbfw_daily_rate' => '',
+						'rbfw_enable_sun_day' => 'no', 'rbfw_enable_mon_day' => 'no', 'rbfw_enable_tue_day' => 'no',
+						'rbfw_enable_wed_day' => 'no', 'rbfw_enable_thu_day' => 'no', 'rbfw_enable_fri_day' => 'no', 'rbfw_enable_sat_day' => 'no',
+						'rbfw_feature_category' => [
+							['cat_title' => 'Bike Features', 'cat_features' => [
+								['title' => 'Disc Brakes'], ['title' => 'Shock Absorbers'], ['title' => 'Headlight and Taillight'], ['title' => 'Bottle Holder'], ['title' => 'Electric Horn'],
+							]]
+						],
+						'rbfw_single_template' => 'Muffin',
+						'rbfw_time_slot_switch' => 'on', 'rbfw_enable_extra_service_qty' => 'yes',
+						'rbfw_enable_variations' => 'no', 'rbfw_enable_md_type_item_qty' => 'no',
+						'rbfw_item_stock_quantity' => '0', 'rbfw_enable_resort_daylong_price' => 'no',
+						'rbfw_sd_appointment_ondays' => ['Monday','Tuesday','Wednesday','Thursday','Friday'],
+						'rbfw_sd_appointment_max_qty_per_session' => '10',
+						'rbfw_variations_data' => [['field_label' => '', 'field_id' => 'rbfw_variation_id_0', 'value' => [['name' => '', 'quantity' => '']], 'selected_value' => '']],
+					],
+				],
+				[
+					'title'   => 'Equipment - Muffin Template',
+					'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+					'postmeta' => [
+						'rdfw_available_time' => ['10:00','11:00','12:00','13:00','14:00','15:00','16:00','17:00','21:00'],
+						'rbfw_item_type' => 'equipment',
+						'rbfw_extra_service_data' => [],
+						'rbfw_resort_room_data' => [['room_type' => '', 'rbfw_room_image' => '', 'rbfw_room_daylong_rate' => '', 'rbfw_room_daynight_rate' => '', 'rbfw_room_desc' => '', 'rbfw_room_available_qty' => '']],
+						'rbfw_enable_faq_content' => 'yes',
+						'mep_event_faq' => [
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+						],
+						'rbfw_enable_dropoff_point' => 'no', 'rbfw_enable_daywise_price' => 'no',
+						'rbfw_bike_car_sd_data' => [['rent_type' => '30 Minute', 'short_desc' => 'Consult for 30 minutes', 'price' => '100', 'qty' => '90']],
+						'rbfw_time_format' => '12', 'rbfw_off_dates' => '',
+						'rbfw_enable_hourly_rate' => 'yes', 'rbfw_enable_daily_rate' => 'yes', 'rbfw_enable_pick_point' => 'no',
+						'rbfw_hourly_rate' => '10', 'rbfw_daily_rate' => '100',
+						'rbfw_feature_category' => [
+							['cat_title' => 'Highlighted Features', 'cat_features' => [
+								['title' => 'Brand: Bosch'], ['title' => 'Power Source: Corded Electric'],
+								['title' => 'Item Dimensions: 39.5 x 12 x 33 Centimeters'], ['title' => 'Weight: 4.4 Kilograms'],
+							]]
+						],
+						'rbfw_single_template' => 'Muffin',
+						'rbfw_time_slot_switch' => 'on', 'rbfw_enable_extra_service_qty' => 'yes',
+						'rbfw_enable_variations' => 'no', 'rbfw_enable_md_type_item_qty' => 'no',
+						'rbfw_item_stock_quantity' => '10', 'rbfw_enable_resort_daylong_price' => 'no',
+						'rbfw_variations_data' => [['field_label' => '', 'field_id' => 'rbfw_variation_id_0', 'value' => [['name' => '', 'quantity' => '']], 'selected_value' => '']],
+						'rbfw_sd_appointment_ondays' => [], 'rbfw_sd_appointment_max_qty_per_session' => '',
+					],
+				],
+				[
+					'title'   => 'Bike/Car For Multiple Day - Muffin Template',
+					'content' => 'A bike rental or bike hire business rents out bicycles for short periods of time, usually for a few hours.',
+					'postmeta' => [
+						'rdfw_available_time' => ['10:00','11:00','12:00','13:00','14:00','15:00','16:00','17:00','21:00'],
+						'rbfw_item_type' => 'bike_car_md',
+						'rbfw_enable_start_end_date' => 'yes',
+						'rbfw_extra_service_data' => [
+							['service_name' => 'Extra Tire', 'service_price' => '5', 'service_qty' => '10'],
+							['service_name' => 'Helmet', 'service_price' => '5', 'service_qty' => '10'],
+							['service_name' => 'Extra engine Oil', 'service_price' => '2', 'service_qty' => '10'],
+							['service_name' => 'Tool Box', 'service_price' => '2', 'service_qty' => '10'],
+						],
+						'rbfw_resort_room_data' => [['room_type' => '', 'rbfw_room_image' => '', 'rbfw_room_daylong_rate' => '', 'rbfw_room_daynight_rate' => '', 'rbfw_room_desc' => '', 'rbfw_room_available_qty' => '']],
+						'rbfw_enable_faq_content' => 'yes',
+						'mep_event_faq' => [
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+						],
+						'rbfw_enable_dropoff_point' => 'no', 'rbfw_enable_daywise_price' => 'no',
+						'rbfw_bike_car_sd_data' => [['rent_type' => '', 'short_desc' => '', 'price' => '', 'qty' => '']],
+						'rbfw_time_format' => '12', 'rbfw_off_dates' => [],
+						'rbfw_enable_hourly_rate' => 'yes', 'rbfw_enable_daily_rate' => 'yes',
+						'rbfw_hourly_rate' => '10', 'rbfw_daily_rate' => '100',
+						'rbfw_enable_pick_point' => 'no',
+						'rbfw_item_stock_quantity' => '10',
+						'rbfw_time_slot_switch' => 'on', 'rbfw_enable_extra_service_qty' => 'yes',
+						'rbfw_enable_variations' => 'no', 'rbfw_enable_md_type_item_qty' => 'yes',
+						'rbfw_variations_data' => [['field_label' => '', 'field_id' => 'rbfw_variation_id_0', 'value' => [['name' => '', 'quantity' => '']], 'selected_value' => '']],
+						'rbfw_feature_category' => [
+							['cat_title' => 'Bike Features', 'cat_features' => [
+								['title' => 'Disc Brakes'], ['title' => 'Shock Absorbers'], ['title' => 'Headlight and Taillight'], ['title' => 'Bottle Holder'], ['title' => 'Electric Horn'],
+							]]
+						],
+						'rbfw_dt_sidebar_switch' => 'off',
+						'rbfw_single_template' => 'Muffin',
+					],
+				],
+				[
+					'title'   => 'Dress - Muffin Template',
+					'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+					'postmeta' => [
+						'rdfw_available_time' => ['10:00','11:00','12:00','13:00','14:00','3:00 PM','16:00','5:00 PM','21:00'],
+						'rbfw_item_type' => 'dress',
+						'rbfw_extra_service_data' => [
+							['service_name' => 'Tie', 'service_price' => '10', 'service_qty' => '100'],
+							['service_name' => 'Shoes', 'service_price' => '10', 'service_qty' => '100'],
+						],
+						'rbfw_resort_room_data' => [['room_type' => '', 'rbfw_room_image' => '', 'rbfw_room_daylong_rate' => '', 'rbfw_room_daynight_rate' => '', 'rbfw_room_desc' => '', 'rbfw_room_available_qty' => '']],
+						'rbfw_enable_faq_content' => 'yes',
+						'mep_event_faq' => [
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+						],
+						'rbfw_enable_dropoff_point' => 'no', 'rbfw_enable_daywise_price' => 'no',
+						'rbfw_bike_car_sd_data' => [['rent_type' => '', 'short_desc' => '', 'price' => '', 'qty' => '']],
+						'rbfw_time_format' => '12', 'rbfw_off_dates' => [],
+						'rbfw_enable_hourly_rate' => 'yes', 'rbfw_enable_daily_rate' => 'yes',
+						'rbfw_hourly_rate' => '10', 'rbfw_daily_rate' => '100',
+						'rbfw_enable_sun_day' => 'no', 'rbfw_enable_mon_day' => 'no', 'rbfw_enable_tue_day' => 'no',
+						'rbfw_enable_wed_day' => 'no', 'rbfw_enable_thu_day' => 'no', 'rbfw_enable_fri_day' => 'no', 'rbfw_enable_sat_day' => 'no',
+						'rbfw_list_thumbnail' => '', 'rbfw_theme_file' => '',
+						'rbfw_available_qty_info_switch' => 'no',
+						'rbfw_single_template' => 'Muffin',
+						'rbfw_time_slot_switch' => 'on', 'rbfw_enable_extra_service_qty' => 'yes',
+						'rbfw_enable_variations' => 'yes', 'rbfw_enable_md_type_item_qty' => 'no',
+						'rbfw_item_stock_quantity' => '10', 'rbfw_enable_resort_daylong_price' => 'no',
+						'rbfw_variations_data' => [
+							['field_label' => 'Color', 'field_id' => 'rbfw_variation_id_0', 'value' => [['name' => 'Red', 'quantity' => '5'], ['name' => 'Blue', 'quantity' => '5']]],
+							['field_label' => 'Size', 'field_id' => 'rbfw_variation_id_1', 'value' => [['name' => 'Small', 'quantity' => '5'], ['name' => 'Medium', 'quantity' => '5']]],
+						],
+						'rbfw_sd_appointment_ondays' => [], 'rbfw_sd_appointment_max_qty_per_session' => '',
+						'rbfw_feature_category' => [
+							['cat_title' => 'Dress Features', 'cat_features' => [
+								['title' => 'Very High Quality Product'], ['title' => 'Various Sizeable'], ['title' => 'High Quality Fabric'],
+								['title' => 'Attractive To See'], ['title' => 'Well Fitting'],
+							]]
+						],
+						'rbfw_dt_sidebar_switch' => 'off',
+					],
+				],
+				[
+					'title'   => 'Bike/Car For Single Day - Classic Template',
+					'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+					'postmeta' => [
+						'rdfw_available_time' => [
+							'10:00 AM','10:00 PM','10:30 AM','10:30 PM','11:30 AM','11:30 PM',
+							'12:00 AM','12:00 PM','12:30 AM','12:30 PM','1:00 AM','6:00 AM',
+							'6:00 PM','8:00 AM','8:00 PM','8:30 AM','8:30 PM','9:00 AM',
+							'9:00 PM','9:30 AM','9:30 PM'
+						],
+						'rbfw_item_type' => 'bike_car_sd',
+						'rbfw_extra_service_data' => [
+							['service_name' => 'Tie', 'service_price' => '10', 'service_qty' => '100'],
+							['service_name' => 'Shoes', 'service_price' => '10', 'service_qty' => '100'],
+						],
+						'rbfw_resort_room_data' => [['room_type' => '', 'rbfw_room_image' => '', 'rbfw_room_daylong_rate' => '', 'rbfw_room_daynight_rate' => '', 'rbfw_room_desc' => '', 'rbfw_room_available_qty' => '']],
+						'rbfw_enable_faq_content' => 'yes',
+						'mep_event_faq' => [
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+						],
+						'rbfw_enable_dropoff_point' => 'no', 'rbfw_enable_daywise_price' => 'no',
+						'rbfw_bike_car_sd_data' => [
+							['rent_type' => 'One Hour Rentals', 'short_desc' => 'Up to 1 hours', 'price' => '7.99', 'qty' => '100'],
+							['rent_type' => 'Two Hour Rentals', 'short_desc' => 'Up to 2 hours', 'price' => '15.98', 'qty' => '100'],
+							['rent_type' => 'Three Hour Rentals', 'short_desc' => 'Up to 3 hours', 'price' => '19.97', 'qty' => '100'],
+							['rent_type' => 'Four Hour Rentals', 'short_desc' => 'Up to 4 hours', 'price' => '24.76', 'qty' => '100'],
+							['rent_type' => 'Five Hour Rentals', 'short_desc' => 'Up to 5 hours', 'price' => '28.75', 'qty' => '100'],
+							['rent_type' => 'Half Day Rental', 'short_desc' => 'Up to 6 hours', 'price' => '29.99', 'qty' => '100'],
+							['rent_type' => 'All Day Rentals', 'short_desc' => 'Up to 10 Hours', 'price' => '38.99', 'qty' => '100'],
+						],
+						'rbfw_time_format' => '12', 'rbfw_off_dates' => [],
+						'rbfw_enable_hourly_rate' => 'yes', 'rbfw_enable_daily_rate' => 'yes',
+						'rbfw_hourly_rate' => '10', 'rbfw_daily_rate' => '100',
+						'rbfw_enable_pick_point' => 'no',
+						'rbfw_enable_sun_day' => 'no', 'rbfw_enable_mon_day' => 'no', 'rbfw_enable_tue_day' => 'no',
+						'rbfw_enable_wed_day' => 'no', 'rbfw_enable_thu_day' => 'no', 'rbfw_enable_fri_day' => 'no', 'rbfw_enable_sat_day' => 'no',
+						'rbfw_list_thumbnail' => '', 'rbfw_theme_file' => '',
+						'rbfw_available_qty_info_switch' => 'no', 'rbfw_single_template' => 'Default',
+						'rbfw_time_slot_switch' => 'on', 'rbfw_enable_extra_service_qty' => 'yes',
+						'rbfw_enable_variations' => 'no', 'rbfw_enable_md_type_item_qty' => 'no',
+						'rbfw_item_stock_quantity' => '10', 'rbfw_enable_resort_daylong_price' => 'no',
+						'rbfw_variations_data' => [['field_label' => '', 'field_id' => 'rbfw_variation_id_0', 'value' => [['name' => '', 'quantity' => '']], 'selected_value' => '']],
+						'rbfw_sd_appointment_ondays' => [], 'rbfw_sd_appointment_max_qty_per_session' => '',
+						'rbfw_feature_category' => [
+							['cat_title' => 'Bike Features', 'cat_features' => [
+								['title' => 'Disc Brakes'], ['title' => 'Shock Absorbers'], ['title' => 'Headlight and Taillight'], ['title' => 'Bottle Holder'], ['title' => 'Electric Horn'],
+							]]
+						],
+						'rbfw_dt_sidebar_switch' => 'off',
+					],
+				],
+				[
+					'title'   => 'Bike/Car For Single Day multi hour - Classic Template',
+					'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+					'postmeta' => [
+						'rdfw_available_time' => [
+							'00:00','00:30','01:00','06:00','08:00','08:30','09:00','09:30',
+							'10:00','10:30','11:30','12:00','12:30','18:00','20:00','20:30',
+							'21:00','21:30','22:00','22:30','23:30'
+						],
+						'rbfw_item_type' => 'bike_car_sd',
+						'rbfw_extra_service_data' => [
+							['service_name' => 'Tie', 'service_price' => '10', 'service_qty' => '100'],
+							['service_name' => 'Shoes', 'service_price' => '10', 'service_qty' => '100'],
+						],
+						'rbfw_resort_room_data' => [['room_type' => '', 'rbfw_room_image' => '', 'rbfw_room_daylong_rate' => '', 'rbfw_room_daynight_rate' => '', 'rbfw_room_desc' => '', 'rbfw_room_available_qty' => '']],
+						'rbfw_enable_faq_content' => 'yes',
+						'mep_event_faq' => [
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+							['rbfw_faq_title' => 'Lorem ipsum dolor sit amet', 'rbfw_faq_content' => 'Lorem ipsum dolor sit amet...'],
+						],
+						'rbfw_enable_dropoff_point' => 'no', 'rbfw_enable_daywise_price' => 'no',
+						'rbfw_bike_car_sd_data' => [
+							['rent_type' => '1 Hour Rent', 'short_desc' => 'Rent for 1 hour', 'price' => '10', 'qty' => '100', 'start_time' => '09:00', 'end_time' => '12:00', 'duration' => '1', 'd_type' => 'Hours'],
+							['rent_type' => '2 Hour Rent', 'short_desc' => 'Rent for 2 hour', 'price' => '15', 'qty' => '', 'start_time' => '15:00', 'end_time' => '18:00', 'duration' => '2', 'd_type' => 'Hours'],
+							['rent_type' => '4 Hour Rent', 'short_desc' => 'Rent for 4 hour', 'price' => '25', 'qty' => '', 'start_time' => '09:00', 'end_time' => '18:00', 'duration' => '4', 'd_type' => 'Hours'],
+							['rent_type' => '6 Hour Rent', 'short_desc' => 'Rent for 6 hour', 'price' => '30', 'qty' => '', 'start_time' => '', 'end_time' => '', 'duration' => '6', 'd_type' => 'Hours'],
+							['rent_type' => 'Full Day Rent', 'short_desc' => 'Rent for full day', 'price' => '40', 'qty' => '', 'start_time' => '', 'end_time' => '', 'duration' => '24', 'd_type' => 'Hours'],
+						],
+						'rbfw_time_format' => '12', 'rbfw_off_dates' => [],
+						'rbfw_enable_hourly_rate' => 'yes', 'rbfw_enable_daily_rate' => 'yes',
+						'rbfw_enable_pick_point' => 'no', 'rbfw_hourly_rate' => '10', 'rbfw_daily_rate' => '100',
+						'rbfw_enable_sun_day' => 'no', 'rbfw_enable_mon_day' => 'no', 'rbfw_enable_tue_day' => 'no',
+						'rbfw_enable_wed_day' => 'no', 'rbfw_enable_thu_day' => 'no', 'rbfw_enable_fri_day' => 'no', 'rbfw_enable_sat_day' => 'no',
+						'rbfw_available_qty_info_switch' => 'no', 'rbfw_single_template' => 'Default',
+						'rbfw_time_slot_switch' => 'on', 'rbfw_enable_extra_service_qty' => 'yes',
+						'rbfw_enable_variations' => 'no', 'rbfw_enable_md_type_item_qty' => 'no',
+						'rbfw_item_stock_quantity' => '10',
+						'rbfw_variations_data' => [['field_label' => '', 'field_id' => 'rbfw_variation_id_0', 'value' => [['name' => '', 'quantity' => '']], 'selected_value' => '']],
+						'rbfw_feature_category' => [
+							['cat_title' => 'Bike Features', 'cat_features' => [
+								['title' => 'Disc Brakes'], ['title' => 'Shock Absorbers'], ['title' => 'Headlight and Taillight'], ['title' => 'Bottle Holder'], ['title' => 'Electric Horn'],
+							]]
+						],
+						'rbfw_dt_sidebar_switch' => 'off',
+						'rbfw_gallery_images' => [], 'rbfw_gallery_images_additional' => [],
+						'rbfw_categories' => [], 'rbfw_inventory' => [],
+						'rbfw_single_template' => 'Default',
+					],
+				]
+			];
+		}
 	}
+	new RbfwImportDemo();
+}

--- a/inc/woocommerce/class-status.php
+++ b/inc/woocommerce/class-status.php
@@ -74,7 +74,12 @@ if (!class_exists('RBFW_Status')) {
                 ? esc_html__( 'Activate', 'booking-and-rental-manager-for-woocommerce' )
                 : esc_html__( 'Install & Activate', 'booking-and-rental-manager-for-woocommerce' );
 
-            return '<a href="#" class="rbfw_plugin_btn rbfw-trigger-pdf-popup" onclick="return false;">' . $label . '</a>';
+            $show_popup_url = wp_nonce_url(
+                admin_url( 'edit.php?post_type=rbfw_item&page=rbfw-status&rbfw_show_pdf_popup=1' ),
+                'rbfw_show_pdf_popup'
+            );
+
+            return '<a href="' . esc_url( $show_popup_url ) . '" class="rbfw_plugin_btn">' . $label . '</a>';
         }
 
         public function rbfw_status_page(){
@@ -168,28 +173,6 @@ if (!class_exists('RBFW_Status')) {
                     font-style: italic;
                 }
             </style>
-            <script>
-            jQuery(document).ready(function($) {
-                // When user clicks the Activate / Install & Activate button on the status page
-                $(document).on('click', '.rbfw-trigger-pdf-popup', function(e) {
-                    e.preventDefault();
-
-                    // Clear the dismissal so the popup shows again
-                    $.ajax({
-                        url: ajaxurl,
-                        type: 'POST',
-                        data: {
-                            action: 'rbfw_pro_clear_pdf_dismiss',
-                            nonce: '<?php echo esc_js( wp_create_nonce( "rbfw_pro_clear_pdf_dismiss" ) ); ?>'
-                        },
-                        complete: function() {
-                            // Reload the page — the popup will appear after reload
-                            window.location.reload();
-                        }
-                    });
-                });
-            });
-            </script>
             <?php
 
         }

--- a/inc/woocommerce/class-status.php
+++ b/inc/woocommerce/class-status.php
@@ -41,6 +41,42 @@ if (!class_exists('RBFW_Status')) {
             return $button_wc;
         }
 
+        /**
+         * PDF Support status row — shows on status page.
+         * Only visible when the Pro plugin is active and PDF feature is enabled.
+         */
+        public function rbfw_pdf_btn() {
+            // Only show if Pro plugin is active and PDF feature is enabled
+            if ( ! function_exists( 'rbfw_check_pro_active' ) || ! rbfw_check_pro_active() ) {
+                return '<span class="rbfw_plugin_na">' . esc_html__( 'Pro plugin not active', 'booking-and-rental-manager-for-woocommerce' ) . '</span>';
+            }
+
+            // Check if PDF feature is enabled in Pro settings
+            global $rbfw;
+            $send_pdf = 'no';
+            if ( $rbfw && method_exists( $rbfw, 'get_option' ) ) {
+                $send_pdf = $rbfw->get_option( 'rbfw_send_pdf', 'rbfw_basic_pdf_settings', 'no' );
+            }
+
+            if ( $send_pdf !== 'yes' ) {
+                return '<span class="rbfw_plugin_na">' . esc_html__( 'PDF feature is disabled in settings', 'booking-and-rental-manager-for-woocommerce' ) . '</span>';
+            }
+
+            $pdf_active    = is_plugin_active( 'magepeople-pdf-support-master/mage-pdf.php' );
+            $pdf_installed = $this->rbfw_free_chk_plugin_folder_exist( 'magepeople-pdf-support-master' );
+
+            if ( $pdf_active ) {
+                return '<span class="rbfw_plugin_status">' . esc_html__( 'Activated', 'booking-and-rental-manager-for-woocommerce' ) . '</span>';
+            }
+
+            // Not active — show button that triggers the popup
+            $label = $pdf_installed
+                ? esc_html__( 'Activate', 'booking-and-rental-manager-for-woocommerce' )
+                : esc_html__( 'Install & Activate', 'booking-and-rental-manager-for-woocommerce' );
+
+            return '<a href="#" class="rbfw_plugin_btn rbfw-trigger-pdf-popup" onclick="return false;">' . $label . '</a>';
+        }
+
         public function rbfw_status_page(){
             $button_wc = '';
 
@@ -54,6 +90,9 @@ if (!class_exists('RBFW_Status')) {
             else {
                 $button_wc = '<span class="rbfw_plugin_status">' . esc_html__('Activated', 'booking-and-rental-manager-for-woocommerce') . '</span>';
             }
+
+            // PDF Support
+            $button_pdf = $this->rbfw_pdf_btn();
             ?>
             <div class="rbfw-status-page-wrapper wrap">
                 <h3><?php esc_html_e( 'Booking and Rental Manager Required Plugin', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
@@ -61,13 +100,23 @@ if (!class_exists('RBFW_Status')) {
                     <thead>
                         <tr>
                             <th><?php esc_html_e( 'Plugin Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                            <th><?php esc_html_e( 'Description', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
                             <th><?php esc_html_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr>
-                            <td><?php esc_html_e( 'WooCommerce', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
-                            <td><?php echo wp_kses($button_wc,rbfw_allowed_html()); ?></td>
+                            <td><strong><?php esc_html_e( 'WooCommerce', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></td>
+                            <td><?php esc_html_e( 'Required for booking, payments and order management.', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
+                            <td><?php echo wp_kses($button_wc, rbfw_allowed_html()); ?></td>
+                        </tr>
+                        <tr>
+                            <td><strong><?php esc_html_e( 'MagePeople PDF Support', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></td>
+                            <td><?php esc_html_e( 'Required for PDF booking receipts and email attachments.', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
+                            <td><?php echo wp_kses($button_pdf, array(
+                                'a' => array( 'href' => array(), 'class' => array(), 'onclick' => array() ),
+                                'span' => array( 'class' => array() ),
+                            )); ?></td>
                         </tr>
                     </tbody>
                 </table>
@@ -98,21 +147,49 @@ if (!class_exists('RBFW_Status')) {
                     border-color: #ff982d;
                     color: #fff;
                     text-decoration: none;
-                    padding: 8px;
+                    padding: 8px 16px;
                     transition: 0.2s;
                     border-radius: 5px;
                     display: inline-block;
+                    cursor: pointer;
+                    font-weight: 500;
                 }
                 .rbfw-status-page-wrapper .rbfw_plugin_btn:hover{
-                    background-color: #ff982d;
-                    border-color: #ff982d;
+                    background-color: #e68a25;
                     color: #fff;
                     transition: 0.2s;
                 }
                 .rbfw_plugin_status{
                     color: #13df13;
+                    font-weight: 600;
+                }
+                .rbfw_plugin_na{
+                    color: #999;
+                    font-style: italic;
                 }
             </style>
+            <script>
+            jQuery(document).ready(function($) {
+                // When user clicks the Activate / Install & Activate button on the status page
+                $(document).on('click', '.rbfw-trigger-pdf-popup', function(e) {
+                    e.preventDefault();
+
+                    // Clear the dismissal so the popup shows again
+                    $.ajax({
+                        url: ajaxurl,
+                        type: 'POST',
+                        data: {
+                            action: 'rbfw_pro_clear_pdf_dismiss',
+                            nonce: '<?php echo esc_js( wp_create_nonce( "rbfw_pro_clear_pdf_dismiss" ) ); ?>'
+                        },
+                        complete: function() {
+                            // Reload the page — the popup will appear after reload
+                            window.location.reload();
+                        }
+                    });
+                });
+            });
+            </script>
             <?php
 
         }
@@ -143,7 +220,7 @@ if (!class_exists('RBFW_Status')) {
 	        if ( isset( $_GET['rbfw_plugin_activate'] ) && !is_plugin_active( sanitize_text_field( wp_unslash( $_GET['rbfw_plugin_activate'] ) ) ) ) {
 		        $slug = sanitize_text_field( wp_unslash( $_GET['rbfw_plugin_activate'] ) );
 		        $activate = activate_plugin( $slug );
-                $url = admin_url( 'edit.php?post_type=rbfw_item&page=rbfw_import' );
+                $url = admin_url( 'edit.php?post_type=rbfw_item&page=rbfw-status' );
                 echo wp_kses_post('<script>
                     var url = "' . esc_url( $url ) . '";
                     window.location.replace(url);

--- a/rent-manager.php
+++ b/rent-manager.php
@@ -44,10 +44,10 @@
 					add_action( 'admin_init', [ $this, 'flush_rules_rbfw_post_list_page' ] );
 				}
 				require_once RBFW_PLUGIN_DIR . '/admin/RBFW_Hidden_Product.php';
-				require_once RBFW_PLUGIN_DIR . '/admin/RBFW_Quick_Setup.php';
+				require_once RBFW_PLUGIN_DIR . '/inc/RBFW_Woo_Installer.php';
 				require_once RBFW_PLUGIN_DIR . '/inc/rbfw_import_demo.php';
-				
-				add_action( 'admin_init', [ $this, 'activation_redirect' ], 90 );
+				// Create default pages (Rent List, Grid, Search)
+				add_action( 'admin_init', 'rbfw_page_create', 20 );
 			}
 
 			public function define_contstants() {
@@ -115,30 +115,23 @@
 				if ( ! empty( $_POST['post_type'] ) && sanitize_text_field( wp_unslash( $_POST['post_type'] ) ) != 'rbfw_item' ) {
 					return;
 				}
-				flush_rewrite_rules(); 
+				flush_rewrite_rules();
 			}
 
 			function flush_rules_rbfw_post_list_page() {
-				
+
 				// if ( ! ( isset( $_POST['nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'rbfw_ajax_action' ) ) ) {
 				// 	return;
 				// }
 
 				if ( isset( $_GET['post_type'] ) && sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) == 'rbfw_item' ) {
-					flush_rewrite_rules(); 
+					flush_rewrite_rules();
 				}
 			}
 
-			public function activation_redirect( $plugin ) {
-
-				$rbfw_quick_setup_done = get_option( 'rbfw_quick_setup_done' ) ? get_option( 'rbfw_quick_setup_done' ) : 'no';
-				$first_redirect = get_option( 'first_redirect' ) ? get_option( 'first_redirect' ) : 'no';
-
-				if ( $rbfw_quick_setup_done == 'no' && $first_redirect == 'no' ) {						
-						wp_redirect( esc_url_raw( admin_url( 'edit.php?post_type=rbfw_item&page=rbfw_quick_setup' ) ) );
-						update_option( 'first_redirect', 'yes' );
-						exit();
-				}
+			public function activation_redirect() {
+				// RBFW_Woo_Installer handles activation redirect via transient.
+				// This method is kept for backward compatibility – no-op now.
 			}
 
 			public static function get_plugin_data( $data ) {
@@ -149,7 +142,7 @@
 			}
 
 			public static function activate() {
-				// rbfw_activation_redirect();
+				set_transient( 'rbfw_plugin_activated', true, 30 );
 				flush_rewrite_rules();
 				rbfw_update_settings();
 			}


### PR DESCRIPTION
Implement a polished admin popup flow for Booking and Rental Manager free plugin.\n\nChanges included:\n- Add AJAX-based WooCommerce installer/activator popup that appears when WooCommerce is missing.\n- Add shared installer UI assets for the popup experience.\n- Replace automatic sample import with a user-controlled dummy import popup.\n- Ensure dummy import waits until WooCommerce is active so only one popup appears at a time.\n- Redirect WooCommerce activation and demo import completion to the Rental List screen.\n- Remove old Quick Setup loading and keep automatic default page creation.\n- Update Status page to include MagePeople PDF Support status and a button to re-open the PDF installer popup when dismissed.\n\nValidation:\n- PHP syntax checked for all modified PHP files.