### PR TITLE
Fix missing feature icon notices in general info settings

### DIFF
--- a/admin/settings/General_Info.php
+++ b/admin/settings/General_Info.php
@@ -118,8 +118,8 @@
 																		if ( ! empty( $value['cat_features'] ) ) {
 																			$c = 0;
 																			foreach ( $value['cat_features'] as $feature ) {
-																				$icon  = $feature['icon'];
-																				$title = $feature['title'];
+																				$icon  = isset( $feature['icon'] ) ? $feature['icon'] : '';
+																				$title = isset( $feature['title'] ) ? $feature['title'] : '';
 																				?>
                                                                                 <div class="item">
                                                                                     <a href="#rbfw_features_icon_list_wrapper" class="rbfw_feature_icon_btn btn" data-key="<?php echo esc_attr( $c ); ?>"><i class="fas fa-circle-plus"></i> <?php _e('Icon','booking-and-rental-manager-for-woocommerce'); ?></a>

--- a/templates/archive/grid_new.php
+++ b/templates/archive/grid_new.php
@@ -42,6 +42,14 @@
         $pricing_display_for_listing = rbfw_get_option( 'pricing_display_for_listing', 'rbfw_basic_gen_settings' );
 
         $price = 0;
+        $price_label = $prices_start_at;
+        $price_sun = 0;
+        $price_mon = 0;
+        $price_tue = 0;
+        $price_wed = 0;
+        $price_thu = 0;
+        $price_fri = 0;
+        $price_sat = 0;
 
         if ($rbfw_rent_type == 'bike_car_md') {
 


### PR DESCRIPTION
Guard optional feature category fields before rendering the General Info feature category UI.\n\nThis fixes PHP warnings like Undefined array key 'icon' when older/demo feature category data contains titles but no icon key.