### PR TITLE
Fix #671 #670: Category taxonomy - multi-select creates new term & parent/child hierarchy

### DIFF
--- a/admin/custom_post.php
+++ b/admin/custom_post.php
@@ -31,12 +31,24 @@ if( ! class_exists('RBFW_Custom_Post')){
                     endforeach;
                 break;
                 case 'rbfw_categories':
-                    $cats = get_post_meta($post_id,'rbfw_categories',true);
-                    if ( ! empty($cats) ) {
+                    // Read from taxonomy (source of truth)
+                    $cats = wp_get_object_terms( $post_id, 'rbfw_item_caregory', array( 'fields' => 'names' ) );
+                    if ( ! is_wp_error( $cats ) && ! empty( $cats ) ) {
                         foreach ($cats as $key => $cat) {
                             echo "<a href='edit.php?post_type=rbfw_item&rbfw_categories=".esc_attr($cat)."'>".esc_html($cat)."</a>";
                             if ($key !== count($cats) - 1) {
                                 echo ', ';
+                            }
+                        }
+                    } else {
+                        // Fallback to post meta for backward compatibility
+                        $meta_cats = get_post_meta($post_id,'rbfw_categories',true);
+                        if ( ! empty($meta_cats) && is_array($meta_cats) ) {
+                            foreach ($meta_cats as $key => $cat) {
+                                echo "<a href='edit.php?post_type=rbfw_item&rbfw_categories=".esc_attr($cat)."'>".esc_html($cat)."</a>";
+                                if ($key !== count($meta_cats) - 1) {
+                                    echo ', ';
+                                }
                             }
                         }
                     }

--- a/admin/rbfw_custom_tables.php
+++ b/admin/rbfw_custom_tables.php
@@ -16,7 +16,14 @@ function rbfw_custom_tables(){
     // Handle the value for each of the new columns.
     add_action( "manage_{$post_type}_posts_custom_column", function ( $column_name, $post_id ) {
         if ( $column_name == 'Categories' ) {
-            $categories = implode(', ', get_post_meta($post_id,'rbfw_categories',true));
+            $cats = wp_get_object_terms( $post_id, 'rbfw_item_caregory', array( 'fields' => 'names' ) );
+            if ( ! is_wp_error( $cats ) && ! empty( $cats ) ) {
+                $categories = implode(', ', $cats);
+            } else {
+                // Fallback to post meta for backward compatibility
+                $meta_cats = get_post_meta($post_id,'rbfw_categories',true);
+                $categories = is_array($meta_cats) ? implode(', ', $meta_cats) : '';
+            }
             if($categories){
                 echo esc_html($categories);
             }else{

--- a/admin/settings/General_Info.php
+++ b/admin/settings/General_Info.php
@@ -40,15 +40,23 @@
 			}
 
 			public function select_category( $post_id ) {
-				$rbfw_categories = get_post_meta( $post_id, 'rbfw_categories', true ) ? maybe_unserialize( get_post_meta( $post_id, 'rbfw_categories', true ) ) : [];
+				// Get categories assigned to this post via taxonomy (source of truth)
+				$post_terms = wp_get_object_terms( $post_id, 'rbfw_item_caregory', array( 'fields' => 'names' ) );
+				$rbfw_categories_array = ! is_wp_error( $post_terms ) ? $post_terms : [];
+				// Also check post meta for backward compatibility
+				if ( empty( $rbfw_categories_array ) ) {
+					$meta_categories = get_post_meta( $post_id, 'rbfw_categories', true ) ? maybe_unserialize( get_post_meta( $post_id, 'rbfw_categories', true ) ) : [];
+					if ( ! empty( $meta_categories ) ) {
+						$rbfw_categories_array = is_array( $meta_categories ) ? $meta_categories : array_filter( array_map( 'trim', explode( ',', $meta_categories ) ) );
+					}
+				}
+				$rbfw_categories_items = implode( ',', $rbfw_categories_array );
 				$terms = get_terms( array(
                     'taxonomy'   => 'rbfw_item_caregory',
                     'hide_empty' => false,
                 ) );
                 global $rbfw;
 				$label = $rbfw->get_name();
-                $rbfw_categories_items = implode(',', $rbfw_categories);
-                $rbfw_categories_array = $rbfw_categories_items ? explode(',', $rbfw_categories_items) : [];
 				?>
                 <section class="bg-light mt-5">
                     <div>
@@ -359,7 +367,15 @@
 					return;
 				}
 				if ( get_post_type( $post_id ) == 'rbfw_item' ) {
-					$rbfw_categories = isset( $_POST['rbfw_categories'] ) ? RBFW_Function::data_sanitize( wp_unslash( $_POST['rbfw_categories'] ) ) : [];
+					$rbfw_categories_raw = isset( $_POST['rbfw_categories'] ) ? RBFW_Function::data_sanitize( wp_unslash( $_POST['rbfw_categories'] ) ) : [];
+					// The hidden input sends a comma-separated string like "Bike,Car" as a single array element.
+					// Split it into individual category names so wp_set_object_terms() sets each one separately.
+					$rbfw_categories = [];
+					foreach ( $rbfw_categories_raw as $cat_string ) {
+						$parts = array_map( 'trim', explode( ',', $cat_string ) );
+						$rbfw_categories = array_merge( $rbfw_categories, $parts );
+					}
+					$rbfw_categories = array_filter( array_unique( $rbfw_categories ) );
 					wp_set_object_terms( $post_id, $rbfw_categories, 'rbfw_item_caregory' );
 					$feature_category_input = isset( $_POST['rbfw_feature_category'] ) ? wp_unslash( $_POST['rbfw_feature_category'] ) : array();
 					$feature_category = rbfw_prepare_feature_category_meta_value( $feature_category_input );

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -3165,6 +3165,21 @@ function rbfw_security_deposit( $post_id, $sub_total_price ) {
 
 function get_rbfw_post_categories_from_meta() {
 
+    // Get all terms from the rbfw_item_caregory taxonomy (proper way)
+    $terms = get_terms( array(
+        'taxonomy'   => 'rbfw_item_caregory',
+        'hide_empty' => false,
+    ) );
+
+    if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+        $output = array();
+        foreach ( $terms as $term ) {
+            $output[] = $term->name;
+        }
+        return $output;
+    }
+
+    // Fallback: read from post meta for backward compatibility
     $args = [
         'post_type'      => 'rbfw_item',
         'post_status'    => 'publish',

--- a/inc/rbfw_shortcodes.php
+++ b/inc/rbfw_shortcodes.php
@@ -134,11 +134,31 @@ function rbfw_rent_list_shortcode_func($atts = null) {
 
         if( !empty( $rbfw_search_type ) ) {
             $search_category_name = $rbfw_search_type;
-            $args['meta_query'][] = array(
-                    'key' => 'rbfw_categories',
-                'value' => $search_category_name,
-                'compare' => 'LIKE'
-            );
+            // Use tax_query instead of meta_query for proper taxonomy filtering with child term support
+            $term = get_term_by( 'name', $search_category_name, 'rbfw_item_caregory' );
+            if ( $term && ! is_wp_error( $term ) ) {
+                $args['tax_query'] = array(
+                    array(
+                        'taxonomy'         => 'rbfw_item_caregory',
+                        'field'            => 'term_id',
+                        'terms'            => $term->term_id,
+                        'include_children' => true,
+                    )
+                );
+            } else {
+                // Fallback: try matching by slug if name lookup fails
+                $term = get_term_by( 'slug', sanitize_title( $search_category_name ), 'rbfw_item_caregory' );
+                if ( $term && ! is_wp_error( $term ) ) {
+                    $args['tax_query'] = array(
+                        array(
+                            'taxonomy'         => 'rbfw_item_caregory',
+                            'field'            => 'term_id',
+                            'terms'            => $term->term_id,
+                            'include_children' => true,
+                        )
+                    );
+                }
+            }
         }
 
 
@@ -178,12 +198,27 @@ function rbfw_rent_list_shortcode_func($atts = null) {
 
         if(!empty($category)) {
             $category = explode(',', $category);
+            // Use tax_query instead of meta_query for proper taxonomy filtering with child term support
+            $term_ids = array();
             foreach ($category as $cat) {
-                $category_name = isset(get_term($cat)->name) ? get_term($cat)->name : '';
-                $args['meta_query'][] = array(
-                    'key' => 'rbfw_categories',
-                    'value' => serialize($category_name),
-                    'compare' => 'LIKE'
+                $cat = trim($cat);
+                if ( is_numeric( $cat ) ) {
+                    $term_ids[] = absint( $cat );
+                } else {
+                    $term = get_term_by( 'name', $cat, 'rbfw_item_caregory' );
+                    if ( $term && ! is_wp_error( $term ) ) {
+                        $term_ids[] = $term->term_id;
+                    }
+                }
+            }
+            if ( ! empty( $term_ids ) ) {
+                $args['tax_query'] = array(
+                    array(
+                        'taxonomy'         => 'rbfw_item_caregory',
+                        'field'            => 'term_id',
+                        'terms'            => $term_ids,
+                        'include_children' => true,
+                    )
                 );
             }
         }

--- a/lib/classes/class-search-page.php
+++ b/lib/classes/class-search-page.php
@@ -216,16 +216,34 @@
 						}
 						$rent_categories = isset( $filter_date['category'] ) ? $filter_date['category'] : [];
 						if ( is_array( $rent_categories ) && count( $rent_categories ) > 0 ) {
-							$category_query = array( 'relation' => 'OR' );
+							// Use tax_query instead of meta_query for proper taxonomy filtering with child term support
+							$cat_term_ids = array();
 							foreach ( $rent_categories as $category_name ) {
-								$category_query[] = ! empty( $category_name ) ? array(
-									'key'     => 'rbfw_categories',
-									'value'   => sanitize_text_field( $category_name ),
-									'compare' => 'LIKE'
-								) : '';
+								$category_name = sanitize_text_field( $category_name );
+								if ( ! empty( $category_name ) ) {
+									$term = get_term_by( 'name', $category_name, 'rbfw_item_caregory' );
+									if ( $term && ! is_wp_error( $term ) ) {
+										$cat_term_ids[] = $term->term_id;
+									} else {
+										$term = get_term_by( 'slug', sanitize_title( $category_name ), 'rbfw_item_caregory' );
+										if ( $term && ! is_wp_error( $term ) ) {
+											$cat_term_ids[] = $term->term_id;
+										}
+									}
+								}
 							}
+							$category_query = '';
+							$category_tax_query = ! empty( $cat_term_ids ) ? array(
+								array(
+									'taxonomy'         => 'rbfw_item_caregory',
+									'field'            => 'term_id',
+									'terms'            => $cat_term_ids,
+									'include_children' => true,
+								)
+							) : '';
 						} else {
 							$category_query = '';
+							$category_tax_query = '';
 						}
 						$posts_per_page = 100;
 						$number_of_page = 1;
@@ -238,13 +256,15 @@
 								$feature_meta_queries,
 								$rent_type,
 								$location_query,
-								$category_query,
 							),
 							'orderby'        => 'ID',
 							'order'          => 'DESC',
 							'paged'          => $number_of_page,
 							'posts_per_page' => $posts_per_page,
 						);
+						if ( ! empty( $category_tax_query ) ) {
+							$args['tax_query'] = $category_tax_query;
+						}
 						$query          = new WP_Query( $args );
 						$total_posts    = $query->found_posts;
 						$post_count     = $query->post_count;

--- a/templates/rental_lists.php
+++ b/templates/rental_lists.php
@@ -40,7 +40,15 @@ function render_mep_events_by_status( $posts ) {
             $price_type = $item_type[$rbfw_rent_type];
 
 
-            $rbfw_categories = get_post_meta( $rental_id, 'rbfw_categories', true ) ? maybe_unserialize( get_post_meta( $rental_id, 'rbfw_categories', true ) ) : [];
+            $rbfw_categories = wp_get_object_terms( $rental_id, 'rbfw_item_caregory', array( 'fields' => 'names' ) );
+            $rbfw_categories = ! is_wp_error( $rbfw_categories ) ? $rbfw_categories : [];
+            // Fallback to post meta for backward compatibility
+            if ( empty( $rbfw_categories ) ) {
+                $meta_cats = get_post_meta( $rental_id, 'rbfw_categories', true ) ? maybe_unserialize( get_post_meta( $rental_id, 'rbfw_categories', true ) ) : [];
+                if ( ! empty( $meta_cats ) && is_array( $meta_cats ) ) {
+                    $rbfw_categories = $meta_cats;
+                }
+            }
             $rbfw_categories_items = implode(',', $rbfw_categories);
             $status = get_post_status( $rental_id );
             $edit_link   = get_edit_post_link( $rental_id );
@@ -99,28 +107,46 @@ function render_mep_events_by_status( $posts ) {
 
 function fount_post_number_by_category(){
 
-    global $wpdb;
-    $results = $wpdb->get_results("
-    SELECT post_id, meta_value 
-    FROM {$wpdb->prefix}postmeta 
-    WHERE meta_key = 'rbfw_categories'
-");
-
+    // Use proper taxonomy queries instead of direct SQL on post meta
     $category_counts = [];
-
-    foreach ( $results as $row ) {
-        $categories = maybe_unserialize( $row->meta_value );
-        if ( is_array($categories) && count($categories) === 1 ) {
-            $cat = strtolower(trim($categories[0]));
-
-            if ( !empty($cat) ) {
-                if ( !isset($category_counts[$cat]) ) {
-                    $category_counts[$cat] = 0;
+    $terms = get_terms( array(
+        'taxonomy'   => 'rbfw_item_caregory',
+        'hide_empty' => false,
+    ) );
+    if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+        foreach ( $terms as $term ) {
+            $cat = strtolower( trim( $term->name ) );
+            if ( ! empty( $cat ) ) {
+                $count = $term->count;
+                if ( $count > 0 ) {
+                    $category_counts[ $cat ] = $count;
                 }
-                $category_counts[$cat]++;
             }
         }
+    }
 
+    // Fallback: also count from post meta for backward compatibility
+    if ( empty( $category_counts ) ) {
+        global $wpdb;
+        $results = $wpdb->get_results("
+        SELECT post_id, meta_value 
+        FROM {$wpdb->prefix}postmeta 
+        WHERE meta_key = 'rbfw_categories'
+    ");
+        foreach ( $results as $row ) {
+            $categories = maybe_unserialize( $row->meta_value );
+            if ( is_array($categories) ) {
+                foreach ( $categories as $cat_val ) {
+                    $cat = strtolower(trim($cat_val));
+                    if ( !empty($cat) ) {
+                        if ( !isset($category_counts[$cat]) ) {
+                            $category_counts[$cat] = 0;
+                        }
+                        $category_counts[$cat]++;
+                    }
+                }
+            }
+        }
     }
 
     return $category_counts;


### PR DESCRIPTION


Issue #671: Selecting multiple categories creates a new combined term --------------------------------------------------------------------- Root Cause: The category checkbox UI uses a hidden input that stores all selected categories as a comma-separated string (e.g. "Bike,Car"). When the form is submitted, $_POST['rbfw_categories'] becomes ["Bike,Car"] — a single array element. Then wp_set_object_terms() treats the entire string "Bike,Car" as ONE term name and creates a new category with that name instead of assigning the item to the two separate categories.

Fix in General_Info.php (settings_save):
- Split the comma-separated string from the hidden input into individual category names before calling wp_set_object_terms()
- Added array_filter + array_unique to handle edge cases

Fix in General_Info.php (select_category):
- Now reads categories from the taxonomy (wp_get_object_terms) as the source of truth instead of only from post meta
- Falls back to post meta for backward compatibility with items that were saved before this fix
- Removed the redundant implode/explode round-trip

Issue #670: Parent category doesn't include items from child categories ------------------------------------------------------------------------ Root Cause: The plugin registers rbfw_item_caregory as a hierarchical taxonomy (supports parent/child terms), but the search and shortcode queries filter by category using meta_query on the rbffw_categories post meta field instead of using WordPress tax_query. The meta_query approach completely ignores the taxonomy hierarchy, so items in child categories are never found when filtering by the parent category.

Fix in rbfw_shortcodes.php:
- Replaced meta_query filtering on rbfw_categories with proper tax_query on the rbfw_item_caregory taxonomy
- Added 'include_children' => true to all tax_query arrays so filtering by a parent category automatically includes items from all child/sub categories
- Search by rbfw_search_type: looks up term by name (with slug fallback) and queries by term_id with include_children
- Shortcode category attribute: resolves category IDs/names to term_ids and queries with include_children

These changes maintain backward compatibility with existing data while properly leveraging the WordPress taxonomy system.