### PR TITLE
fix: preserve rent-list filter scope and harden price formatting

### DIFF
--- a/assets/mp_script/md_script.js
+++ b/assets/mp_script/md_script.js
@@ -1545,10 +1545,20 @@ function rbfw_service_price_calculation(total_days){
 }
 
 function wc_price_rbfw(price) {
+    /**
+     * FIX: Normalize shared frontend price values before calling toFixed.
+     * AUTHOR: shahnur alam
+     * ISSUE: #RBFW-JS-001
+     * SOLVED: 2026-05-14
+     * CONTEXT: Some pricing flows pass string values from data attributes, so the
+     * shared formatter must coerce them safely instead of crashing.
+     */
+    const safePrice = Number.isFinite(Number(price)) ? Number(price) : 0;
+    const safeDecimals = Number.isInteger(Number(rbfw_js_variables.price_decimals)) ? Number(rbfw_js_variables.price_decimals) : 2;
     if(rbfw_js_variables.currency_format=='left'){
-        return rbfw_js_variables.currency + price.toFixed(rbfw_js_variables.price_decimals)
+        return rbfw_js_variables.currency + safePrice.toFixed(safeDecimals)
     }else{
-        return price.toFixed(rbfw_js_variables.price_decimals) + rbfw_js_variables.currency;
+        return safePrice.toFixed(safeDecimals) + rbfw_js_variables.currency;
     }
 }
 
@@ -1588,7 +1598,6 @@ function loadDisabledDates(post_id, year, month) {
         }
     });
 }
-
 
 
 

--- a/css/rbfw_rent_items.css
+++ b/css/rbfw_rent_items.css
@@ -863,6 +863,12 @@ ul.rbfw_show_all_cat_features li:last-child {
     margin: var(--dmp) 0;
 }
 
+.rbfw_search_result_empty_state{
+    min-height: 1100px;
+    display: flex;
+    align-items: flex-start;
+}
+
 #rbfw_feature_loadMore:hover {
     background-color: #0056b3;
 }
@@ -943,4 +949,3 @@ ul.rbfw_show_all_cat_features li:last-child {
         position: relative;
     }
 }
-

--- a/inc/rbfw_shortcodes.php
+++ b/inc/rbfw_shortcodes.php
@@ -75,6 +75,15 @@ function rbfw_rent_list_shortcode_func($atts = null) {
         'type_filter_shown'     => $attributes['left-type-filter'],
         'feature_filter_shown'  => $attributes['left-feature-filter'],
     );
+    /**
+     * FIX: Preserve the baseline Elementor/category-scoped list during left-filter resets.
+     * AUTHOR: shahnur alam
+     * ISSUE: #RBFW-FILTER-001
+     * SOLVED: 2026-05-14
+     * CONTEXT: The AJAX filter rebuild was losing the original widget category scope and
+     * showing uncategorized items after Clear All.
+     */
+    $base_filter_categories = array();
 
 
     if(isset($atts['rbfw_search_type'])){
@@ -186,6 +195,7 @@ function rbfw_rent_list_shortcode_func($atts = null) {
                 }
 
                 $category_name = $term->name;
+                $base_filter_categories[] = $category_name;
                 $args['meta_query'][] = array(
                     'key' => 'rbfw_categories',
                     'value' => serialize($category_name),
@@ -194,6 +204,8 @@ function rbfw_rent_list_shortcode_func($atts = null) {
             }
         }
     }
+
+    $base_filter_categories = array_values( array_unique( $base_filter_categories ) );
 
     $query = new WP_Query($args);
     $total_posts = $query->found_posts;
@@ -327,7 +339,7 @@ function rbfw_rent_list_shortcode_func($atts = null) {
             $rent_list_wrapper_cls = 'rbfw_rent_list_wrapper';
         }
         ?>
-        <div class="<?php echo esc_attr( $rent_list_wrapper_cls ) . ' ' . esc_attr( $grid_class ); ?> rbfw_rent_list_style_<?php echo esc_attr( $style ); ?>" id="rbfw_rent_list_wrapper">
+        <div class="<?php echo esc_attr( $rent_list_wrapper_cls ) . ' ' . esc_attr( $grid_class ); ?> rbfw_rent_list_style_<?php echo esc_attr( $style ); ?>" id="rbfw_rent_list_wrapper" data-base-categories="<?php echo esc_attr( wp_json_encode( $base_filter_categories ) ); ?>">
 
             <?php
             $d = 1;

--- a/js/rbfw_script.js
+++ b/js/rbfw_script.js
@@ -319,11 +319,24 @@
             });
         }
 
+        let baseCategories = [];
+        const baseCategoryData = $('#rbfw_rent_list_wrapper').attr('data-base-categories');
+        if (baseCategoryData) {
+            try {
+                const parsedBaseCategories = JSON.parse(baseCategoryData);
+                if (Array.isArray(parsedBaseCategories)) {
+                    baseCategories = parsedBaseCategories;
+                }
+            } catch (error) {
+                baseCategories = [];
+            }
+        }
         var selectedLocation = [];
         var selectedcategory = [];
         var selectedType = [];
         var selectedFeatures = [];
         var get_filters = {
+            base_category: baseCategories,
             location: [],
             category: [],
             type: [],
@@ -463,7 +476,12 @@
 
         $(document).on('click', '.rbfw_left_filter_clearButton',function() {
             $('.rbfw_location, .rbfw_category, .rbfw_rent_type, .rbfw_rent_feature').prop('checked', false);
+            selectedLocation = [];
+            selectedcategory = [];
+            selectedType = [];
+            selectedFeatures = [];
             get_filters = {
+                base_category: baseCategories,
                 location: [],
                 category: [],
                 type: [],
@@ -595,7 +613,6 @@ jQuery(document).ready(function($){
         }
     });
 });
-
 
 
 

--- a/js/rbfw_script.js
+++ b/js/rbfw_script.js
@@ -303,7 +303,7 @@
                         let display_markup = response.data.display_date;
 
                         if (!display_markup) {
-                            display_markup = '<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">Sorry, no data found!</div>';
+                            display_markup = '<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">Sorry, no data found!</div></div>';
                         }
 
                         // $('#rbfw_rent_list_wrapper').html( response.data.display_date );
@@ -313,12 +313,12 @@
 
                         $('#rbfw_shoe_result_text').html('<span >'+text_display+'</span>');
                     }else{
-                        $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
+                        $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div></div>');
                         $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
                     }
                 },
                 error: function () {
-                    $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
+                    $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div></div>');
                     $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
                 },
                 complete: function () {
@@ -622,6 +622,5 @@ jQuery(document).ready(function($){
         }
     });
 });
-
 
 

--- a/js/rbfw_script.js
+++ b/js/rbfw_script.js
@@ -300,22 +300,31 @@
                     if( response.success ){
 
                         let text_display = response.data.show_text;
+                        let display_markup = response.data.display_date;
 
-                        $("#rbfw_left_filter_cover").hide();
+                        if (!display_markup) {
+                            display_markup = '<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">Sorry, no data found!</div>';
+                        }
 
                         // $('#rbfw_rent_list_wrapper').html( response.data.display_date );
                         $('#rbfw_rent_list_wrapper').fadeOut(200, function () {
-                            $(this).html(response.data.display_date).fadeIn(300);
+                            $(this).html(display_markup).fadeIn(300);
                         });
 
                         $('#rbfw_shoe_result_text').html('<span >'+text_display+'</span>');
-                        $(".rbfw_left_filter_button").text(rbfw_translation.filter);
                     }else{
-                        alert('ok');
+                        $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
                         $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
                     }
-
                 },
+                error: function () {
+                    $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
+                    $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
+                },
+                complete: function () {
+                    $("#rbfw_left_filter_cover").hide();
+                    $(".rbfw_left_filter_button").text(rbfw_translation.filter);
+                }
             });
         }
 
@@ -613,7 +622,6 @@ jQuery(document).ready(function($){
         }
     });
 });
-
 
 
 

--- a/lib/classes/class-search-page.php
+++ b/lib/classes/class-search-page.php
@@ -299,40 +299,50 @@
 								$post_ids[] = get_the_ID();
 								$response   .= $this->display_filter_rent_items( get_the_ID(), get_the_title(), get_the_content(), $item_style, $d );
 								$d ++;
+								}
+								wp_reset_postdata();
+							} else {
+								$response = '<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' . esc_html__( 'Sorry, no data found!', 'booking-and-rental-manager-for-woocommerce' ) . '</div>';
 							}
-							wp_reset_postdata();
-						}
 
                         global $rbfw;
 
-                        $show_result = $total_posts;
+                        /**
+                         * FIX: Keep the left filter usable when the AJAX result set is empty.
+                         * AUTHOR: shahnur alam
+                         * ISSUE: #RBFW-FILTER-002
+                         * SOLVED: 2026-05-14
+                         * CONTEXT: An empty wrapper collapses the layout because the sidebar is
+                         * absolutely positioned, so the AJAX response must still render a block.
+                         */
+                        $show_result = $total_posts . ' ';
                         $show_result .= (
                         ( $rbfw->get_option_trans( 'rbfw_text_results', 'rbfw_basic_translation_settings' ) && want_loco_translate() == 'no' )
                             ? esc_html( $rbfw->get_option_trans( 'rbfw_text_results', 'rbfw_basic_translation_settings' ) )
                             : esc_html__( 'results', 'booking-and-rental-manager-for-woocommerce' )
-                        );
+                        ) . '. ';
                         $show_result .= (
                         ( $rbfw->get_option_trans( 'rbfw_text_showings', 'rbfw_basic_translation_settings' ) && want_loco_translate() == 'no' )
                             ? esc_html( $rbfw->get_option_trans( 'rbfw_text_showings', 'rbfw_basic_translation_settings' ) )
                             : esc_html__( 'Showing', 'booking-and-rental-manager-for-woocommerce' )
-                        );
-                        $show_result .= $post_count;
+                        ) . ' ';
+                        $show_result .= $post_count . ' ';
                         $show_result .= (
                         ( $rbfw->get_option_trans( 'rbfw_text_of', 'rbfw_basic_translation_settings' ) && want_loco_translate() == 'no' )
                             ? esc_html( $rbfw->get_option_trans( 'rbfw_text_of', 'rbfw_basic_translation_settings' ) )
                             : esc_html__( 'of', 'booking-and-rental-manager-for-woocommerce' )
-                        );
-                        $show_result .=  $total_posts ;
+                        ) . ' ';
+                        $show_result .=  $total_posts . ' ';
                         $show_result .= (
                         ( $rbfw->get_option_trans( 'rbfw_text_of', 'rbfw_basic_translation_settings' ) && want_loco_translate() == 'no' )
                             ? esc_html( $rbfw->get_option_trans( 'rbfw_text_of', 'rbfw_basic_translation_settings' ) )
                             : esc_html__( 'of', 'booking-and-rental-manager-for-woocommerce' )
-                        );
+                        ) . ' ';
                         $show_result .= (
                         ( $rbfw->get_option_trans( 'rbfw_text_total', 'rbfw_basic_translation_settings' ) && want_loco_translate() == 'no' )
                             ? esc_html( $rbfw->get_option_trans( 'rbfw_text_total', 'rbfw_basic_translation_settings' ) )
                             : esc_html__( 'total', 'booking-and-rental-manager-for-woocommerce' )
-                        );
+                        ) . '.';
 					}
 
 				$result = array(

--- a/lib/classes/class-search-page.php
+++ b/lib/classes/class-search-page.php
@@ -302,7 +302,7 @@
 								}
 								wp_reset_postdata();
 							} else {
-								$response = '<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' . esc_html__( 'Sorry, no data found!', 'booking-and-rental-manager-for-woocommerce' ) . '</div>';
+								$response = '<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' . esc_html__( 'Sorry, no data found!', 'booking-and-rental-manager-for-woocommerce' ) . '</div></div>';
 							}
 
                         global $rbfw;

--- a/lib/classes/class-search-page.php
+++ b/lib/classes/class-search-page.php
@@ -161,6 +161,15 @@
 						if ( ! empty( $text_search ) ) {
 							$search_by_title = $text_search;
 						}
+						/**
+						 * FIX: Keep the original widget/category scope when the left filter resets.
+						 * AUTHOR: shahnur alam
+						 * ISSUE: #RBFW-FILTER-001
+						 * SOLVED: 2026-05-14
+						 * CONTEXT: The AJAX query must keep the baseline categorized items scoped
+						 * even when the sidebar sends an empty category filter after Clear All.
+						 */
+						$base_categories = isset( $filter_date['base_category'] ) && is_array( $filter_date['base_category'] ) ? array_filter( array_map( 'sanitize_text_field', $filter_date['base_category'] ) ) : [];
 						$filter_by_price = isset( $filter_date['price'] ) ? $filter_date['price'] : [];
 
 						if ( is_array( $filter_by_price ) && count( $filter_by_price ) > 0 ) {
@@ -220,31 +229,65 @@
 							foreach ( $rent_categories as $category_name ) {
 								$category_query[] = ! empty( $category_name ) ? array(
 									'key'     => 'rbfw_categories',
-									'value'   => sanitize_text_field( $category_name ),
+									'value'   => serialize( sanitize_text_field( $category_name ) ),
 									'compare' => 'LIKE'
 								) : '';
 							}
 						} else {
 							$category_query = '';
 						}
+						if ( is_array( $base_categories ) && count( $base_categories ) > 0 ) {
+							$base_category_query = array( 'relation' => 'OR' );
+							foreach ( $base_categories as $base_category_name ) {
+								$base_category_query[] = ! empty( $base_category_name ) ? array(
+									'key'     => 'rbfw_categories',
+									'value'   => serialize( sanitize_text_field( $base_category_name ) ),
+									'compare' => 'LIKE'
+								) : '';
+							}
+						} else {
+							$base_category_query = '';
+						}
 						$posts_per_page = 100;
 						$number_of_page = 1;
-						$args           = array(
-							'post_type'      => 'rbfw_item',
-							's'              => $search_by_title,
-							'meta_query'     => array(
-								'relation' => 'OR',
+						$meta_query     = array(
+							'relation' => 'AND',
+						);
+						if ( ! empty( $base_category_query ) ) {
+							$meta_query[] = $base_category_query;
+						}
+						$active_filter_queries = array_filter(
+							array(
 								$price_filter_query,
 								$feature_meta_queries,
 								$rent_type,
 								$location_query,
 								$category_query,
 							),
+							static function ( $query_part ) {
+								return is_array( $query_part ) && ! empty( $query_part );
+							}
+						);
+						if ( ! empty( $active_filter_queries ) ) {
+							$optional_filter_query = array(
+								'relation' => 'OR',
+							);
+							foreach ( $active_filter_queries as $query_part ) {
+								$optional_filter_query[] = $query_part;
+							}
+							$meta_query[] = $optional_filter_query;
+						}
+						$args           = array(
+							'post_type'      => 'rbfw_item',
+							's'              => $search_by_title,
 							'orderby'        => 'ID',
 							'order'          => 'DESC',
 							'paged'          => $number_of_page,
 							'posts_per_page' => $posts_per_page,
 						);
+						if ( count( $meta_query ) > 1 ) {
+							$args['meta_query'] = $meta_query;
+						}
 						$query          = new WP_Query( $args );
 						$total_posts    = $query->found_posts;
 						$post_count     = $query->post_count;


### PR DESCRIPTION
Preserve the initial Elementor rent-list category scope when the left filter runs over AJAX so clearing filters returns the original categorized items instead of exposing uncategorized posts.

- collect baseline category names in the rent-list shortcode from the configured term ids
- expose those baseline categories on the list wrapper for the frontend filter flow
- send the baseline category scope with left-filter AJAX requests and fully reset transient filter arrays on Clear All
- require the baseline category group in the AJAX meta query while still allowing user-selected filters to narrow the result set
- align category meta matching with serialized category storage used by the plugin

Also harden the shared frontend price formatter used across single-day, multi-day, and resort flows.

- coerce formatter input into a safe numeric value before calling toFixed
- fall back to a safe decimal precision when the localized decimals value is invalid
- prevent single-day pricing UI updates from crashing when price values arrive as strings from data attributes

Verification:
- php -l inc/rbfw_shortcodes.php
- php -l lib/classes/class-search-page.php
- node parse check for js/rbfw_script.js and assets/mp_script/md_script.js