### PR TITLE
fix: show English AM/PM in frontend pickup time instead of browser locale

### DIFF
--- a/assets/mp_script/rbfw_script.js
+++ b/assets/mp_script/rbfw_script.js
@@ -522,17 +522,37 @@ function getAvailableTimes(schedule, givenDate,rdfw_available_time,pickup_time_p
 
 
 function formatTime(date, format) {
-    // Map WP PHP formats to JS Intl options
-    let options = {};
-    if (format.includes('a') || format.includes('A')) {
-        options.hour12 = true;
-    } else {
-        options.hour12 = false;
-    }
-    options.hour = 'numeric';
-    options.minute = '2-digit';
+    // Build the time string directly from the WordPress "Time Format"
+    // setting (Settings > General > Time Format) so the frontend always
+    // shows English AM/PM instead of the browser locale (e.g. Hungarian de./du.).
+    format = format || 'g:i a';
 
-    return new Intl.DateTimeFormat([], options).format(date);
+    let hours   = date.getHours();
+    let minutes = date.getMinutes();
+    let mm      = minutes < 10 ? '0' + minutes : '' + minutes;
+
+    // 12-hour format when the WP format contains 'a' (am/pm) or 'A' (AM/PM)
+    if (format.includes('a') || format.includes('A')) {
+        let ampm = hours >= 12 ? 'PM' : 'AM';
+        if (format.includes('a')) {
+            ampm = ampm.toLowerCase(); // lowercase "am/pm" if WP uses lowercase 'a'
+        }
+
+        let h12 = hours % 12;
+        if (h12 === 0) {
+            h12 = 12;
+        }
+
+        // 'h' = leading zero (01-12), 'g' = no leading zero (1-12)
+        let hh = format.includes('h') ? (h12 < 10 ? '0' + h12 : '' + h12) : '' + h12;
+
+        return hh + ':' + mm + ' ' + ampm;
+    }
+
+    // 24-hour format: 'H' = leading zero (00-23), 'G' = no leading zero (0-23)
+    let hh = format.includes('H') ? (hours < 10 ? '0' + hours : '' + hours) : '' + hours;
+
+    return hh + ':' + mm;
 }
 
 


### PR DESCRIPTION


The pickup/return time dropdown (and calendar time picker) rendered the 12-hour AM/PM marker using the visitor's browser locale, e.g. on a Hungarian locale it displayed "de." (délelőtt) and "du." (délután) instead of "AM"/"PM".

Root cause:
formatTime() in assets/mp_script/rbfw_script.js formatted times with `new Intl.DateTimeFormat([], options)`. The empty locale array makes Intl fall back to the browser/OS locale, so the AM/PM wording was outside the site's control and varied per visitor.

Fix:
Rewrite formatTime() to build the time string directly from the WordPress "Time Format" setting (Settings > General > Time Format, passed through as rbfw_js_variables.timeFormat = get_option('time_format')) and emit English AM/PM. The function now honors the PHP date tokens:
  - 'a' -> lowercase am/pm, 'A' -> uppercase AM/PM (12-hour)
  - 'g' -> hour 1-12 no leading zero, 'h' -> 01-12 leading zero
  - 'G' -> hour 0-23 no leading zero, 'H' -> 00-23 leading zero
  - no a/A token -> 24-hour output This removes the locale dependency entirely, so the WordPress admin setting is now the single source of truth for the frontend.

Verified output (format "g:i A"): 8:30 AM, 12:00 PM, 12:30 PM, 2:30 PM.
Edge cases: 00:00 -> 12:00 AM, 12:00 -> 12:00 PM, 23:59 -> 11:59 PM.