### PR TITLE
Fix left filter: category search "no data found" and stray rent type

### DIFF
--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -3213,6 +3213,62 @@ function get_rbfw_post_categories_from_meta() {
     return $output;
 }
 
+/**
+ * Build a precise meta_query OR clause that matches a single rbfw_categories
+ * value across every storage format the meta has historically used: a
+ * serialized array (a:1:{i:0;s:8:"Stroller";}), a single plain string
+ * ("Stroller"), or a comma separated string ("Stroller,Car seats").
+ *
+ * This mirrors get_rbfw_post_categories_from_meta() so the search matches
+ * exactly what the sidebar lists, while staying precise enough not to
+ * over-match similar names (selecting "Stroller" must not match
+ * "Light Strollers", "Compact Strollers", etc.).
+ *
+ * @param string $category_name Category name to match.
+ * @return array Meta query OR clause, or empty array when the name is blank.
+ */
+function rbfw_build_category_meta_clause( $category_name ) {
+	$category_name = sanitize_text_field( $category_name );
+	if ( '' === $category_name ) {
+		return array();
+	}
+	$len = strlen( $category_name );
+
+	return array(
+		'relation' => 'OR',
+		// Serialized array storage, e.g. a:1:{i:0;s:8:"Stroller";}
+		array(
+			'key'     => 'rbfw_categories',
+			'value'   => 's:' . $len . ':"' . $category_name . '";',
+			'compare' => 'LIKE',
+		),
+		// Single plain string storage, e.g. "Stroller".
+		array(
+			'key'     => 'rbfw_categories',
+			'value'   => $category_name,
+			'compare' => '=',
+		),
+		// Comma separated, this item first: "Stroller,..." / "Stroller, ...".
+		array(
+			'key'     => 'rbfw_categories',
+			'value'   => $category_name . ',',
+			'compare' => 'LIKE',
+		),
+		// Comma separated, this item after another, no space: "...,Stroller".
+		array(
+			'key'     => 'rbfw_categories',
+			'value'   => ',' . $category_name,
+			'compare' => 'LIKE',
+		),
+		// Comma separated, this item after another, with space: "..., Stroller".
+		array(
+			'key'     => 'rbfw_categories',
+			'value'   => ', ' . $category_name,
+			'compare' => 'LIKE',
+		),
+	);
+}
+
 
 
 
@@ -3265,8 +3321,15 @@ function get_rbfw_post_categories_from_meta() {
 	 * @return array|false Array of location data or false on failure.
 	 */
 	function get_rbfw_item_type_wp_query() {
+		/**
+		 * Only surface rent types that belong to the site's own published rent
+		 * items. Querying 'any' post type pulled in rbfw_item_type meta left on
+		 * products / other post types (e.g. an unused "Bike car multiple day"),
+		 * showing filter options that match nothing in the rbfw_item results.
+		 */
 		$args  = array(
-			'post_type'      => 'any',
+			'post_type'      => 'rbfw_item',
+			'post_status'    => 'publish',
 			'meta_key'       => 'rbfw_item_type',
 			'meta_compare'   => 'EXISTS',
 			'orderby'        => 'meta_id',

--- a/inc/rbfw_shortcodes.php
+++ b/inc/rbfw_shortcodes.php
@@ -237,11 +237,13 @@ function rbfw_rent_list_shortcode_func($atts = null) {
 
                 $category_name = $term->name;
                 $base_filter_categories[] = $category_name;
-                $args['meta_query'][] = array(
-                    'key' => 'rbfw_categories',
-                    'value' => serialize($category_name),
-                    'compare' => 'LIKE'
-                );
+                // Match every storage format of rbfw_categories (serialized
+                // array / single string / comma separated) so the initial list
+                // is not empty when the meta is not a serialized array.
+                $category_clause = rbfw_build_category_meta_clause( $category_name );
+                if ( ! empty( $category_clause ) ) {
+                    $args['meta_query'][] = $category_clause;
+                }
             }
         }
     }

--- a/lib/classes/class-search-page.php
+++ b/lib/classes/class-search-page.php
@@ -224,30 +224,8 @@
 							$location_query = '';
 						}
 						$rent_categories = isset( $filter_date['category'] ) ? $filter_date['category'] : [];
-						if ( is_array( $rent_categories ) && count( $rent_categories ) > 0 ) {
-							$category_query = array( 'relation' => 'OR' );
-							foreach ( $rent_categories as $category_name ) {
-								$category_query[] = ! empty( $category_name ) ? array(
-									'key'     => 'rbfw_categories',
-									'value'   => serialize( sanitize_text_field( $category_name ) ),
-									'compare' => 'LIKE'
-								) : '';
-							}
-						} else {
-							$category_query = '';
-						}
-						if ( is_array( $base_categories ) && count( $base_categories ) > 0 ) {
-							$base_category_query = array( 'relation' => 'OR' );
-							foreach ( $base_categories as $base_category_name ) {
-								$base_category_query[] = ! empty( $base_category_name ) ? array(
-									'key'     => 'rbfw_categories',
-									'value'   => serialize( sanitize_text_field( $base_category_name ) ),
-									'compare' => 'LIKE'
-								) : '';
-							}
-						} else {
-							$base_category_query = '';
-						}
+						$category_query  = $this->rbfw_build_categories_meta_query( $rent_categories );
+						$base_category_query = $this->rbfw_build_categories_meta_query( $base_categories );
 						$posts_per_page = 100;
 						$number_of_page = 1;
 						$meta_query     = array(
@@ -350,6 +328,36 @@
 					'show_text'    => $show_result,
 				);
 				wp_send_json_success( $result );
+			}
+
+			/**
+			 * Build a precise meta_query group for the selected categories.
+			 *
+			 * FIX: category search returned "Sorry, no data found!" because the
+			 * query only matched serialize()'d array storage of rbfw_categories
+			 * and ignored values stored as a single string or a comma separated
+			 * string. rbfw_build_category_meta_clause() matches every storage
+			 * format the meta has used, so the search matches exactly what the
+			 * sidebar lists, while staying precise enough not to over-match
+			 * similar names (selecting "Stroller" must not match "Light Strollers").
+			 *
+			 * @param array $categories Selected category names.
+			 * @return array|string Meta query group, or '' when nothing selected.
+			 */
+			private function rbfw_build_categories_meta_query( $categories ) {
+				if ( ! is_array( $categories ) || count( $categories ) === 0 ) {
+					return '';
+				}
+				$group = array( 'relation' => 'OR' );
+				foreach ( $categories as $category_name ) {
+					$clause = rbfw_build_category_meta_clause( $category_name );
+					if ( ! empty( $clause ) ) {
+						$group[] = $clause;
+					}
+				}
+
+				// Only return a usable group when at least one clause was added.
+				return ( count( $group ) > 1 ) ? $group : '';
 			}
 
 			public function display_filter_rent_items( $post_id, $post_title, $the_content, $style, $d ) {


### PR DESCRIPTION
Two issues reported on the live search/left-filter sidebar:

1) Selecting an Item Category (e.g. "Stroller") returned
   "Sorry, no data found!" even though matching rent items exist.

   Cause: the category filter matched the rbfw_categories meta with
   serialize($category_name) + LIKE, which only matches when the meta
   is stored as a serialized array (e.g. a:1:{i:0;s:8:"Stroller";}).
   get_rbfw_post_categories_from_meta() already documents that the
   value may instead be a single string or a comma separated string.
   On the client's live data the value is not a serialized array, so
   the serialize() pattern never matched and the query returned 0
   posts. Both the AJAX left-filter path and the initial shortcode
   render used this same broken matching, and base_category (AND-ed)
   used it too, so any category interaction emptied the result set.

   Fix: add a shared helper rbfw_build_category_meta_clause() that
   matches a category across every storage format the meta has used
   (serialized array, single string, comma separated with/without
   spaces) while staying precise so "Stroller" does not also match
   "Light Strollers" / "Compact Strollers". The serialized clause it
   emits is byte-identical to the old serialize() output, so
   serialized-array data behaves exactly as before (no regression);
   string / comma-separated data now matches.

   Applied in:
   - inc/rbfw_functions.php: new rbfw_build_category_meta_clause().
   - lib/classes/class-search-page.php: AJAX category and base_category matching via rbfw_build_categories_meta_query().
   - inc/rbfw_shortcodes.php: initial-load category query (which also feeds data-base-categories) now uses the same helper.

2) "More Item Type - Bike car multiple day" showed in the filter even
   though no rent item uses it.

   Cause: get_rbfw_item_type_wp_query() queried post_type => 'any',
   pulling rbfw_item_type meta left on products / other post types.
   The search results query only searches rbfw_item, so the filter
   listed a type that matches nothing.

   Fix: scope get_rbfw_item_type_wp_query() to
   post_type => 'rbfw_item', post_status => 'publish' so the type
   filter only lists types used by the site's own published rent
   items.

All changed files pass php -l.