### PR TITLE
Apply Count Extra Day to monthly/weekly pricing breakdown

### DIFF
--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -2666,6 +2666,21 @@ function rbfw_md_duration_price_calculation($post_id = 0, $pickup_datetime = 0, 
 
     $start = new DateTime($pickup_datetime);
     $end = new DateTime($dropoff_datetime);
+
+    /**
+     * Count Extra Day: the daily-rate path bills the return day (total_days++)
+     * when the setting is on and the time picker is off. The monthly/weekly
+     * breakdown below derives from $interval and previously ignored this, so
+     * monthly/weekly-enabled items billed one day short (and could miss a
+     * weekly-rate threshold). Extend the interval end by one day here so the
+     * month/week/day split is consistent with the daily path. The daily path
+     * uses a separate $diff and is unaffected.
+     */
+    if ( $rbfw_enable_time_slot === 'no'
+        && $rbfw->get_option_trans( 'rbfw_count_extra_day_enable', 'rbfw_basic_gen_settings', 'on' ) === 'on' ) {
+        $end->modify( '+1 day' );
+    }
+
     $interval = $start->diff($end);
     $totalMonths = ($interval->y * 12) + $interval->m;
     $remainingDays = $interval->d;


### PR DESCRIPTION
The "Count Extra Day" setting (bill the return day) was only honoured in the daily-rate path of rbfw_md_duration_price_calculation(). The monthly and weekly branches derive their month/week/day split straight from the date interval, so monthly/weekly-enabled items billed one day short and could also miss a weekly-rate threshold (e.g. a 7-day booking billed 6 days instead of 1 week). This is why toggling Count Extra Day appeared to do nothing on such items.

Fix: when Count Extra Day is on and the time picker is off, extend the interval end by one day before computing the month/week/day breakdown, so the monthly/weekly branches are consistent with the daily path. The daily path uses a separate $diff (with its own +1) and is unaffected. The same-day guard still covers the Count-Extra-Day-off case.

Verified across durations (monthly 5000/thr28, weekly 1200/thr7, daily 250): same day $250, 3 days $750, 7 days $1200 (1 week), 8 days $1450 (1 week + 1 day), 30 days $5000 (1 month).

php -l clean.