### PR TITLE
Fix rental CPT permalinks 404ing after WP-CLI rewrite flushes

### DIFF
--- a/admin/custom_post.php
+++ b/admin/custom_post.php
@@ -52,22 +52,34 @@ if( ! class_exists('RBFW_Custom_Post')){
         }
 
         public function rbfw_cpt(){
-            // Skip during WP-CLI execution
-            if ( defined('WP_CLI') && WP_CLI ) {
-                return;
-            }
-
             global $rbfw;
 
-
-            $cpt_label = $rbfw->get_name();
-
-            $cpt_slug         = sanitize_title( $rbfw->get_slug() );
+            // The CPT MUST register in every execution context (browser, loopback
+            // wp-cron AND WP-CLI). If it is skipped in any context, a rewrite-rule
+            // rebuild that happens there - e.g. a nightly `wp cron event run`,
+            // `wp plugin update`, or Action Scheduler's CLI runner - regenerates and
+            // saves the rewrite_rules option WITHOUT these routes, so the front end
+            // 404s until permalinks are re-saved by hand.
+            //
+            // The global $rbfw is not always available under WP-CLI, so fall back to
+            // reading the settings option directly. Both paths resolve to the same
+            // stored values, so the rewrite slug is identical across every context.
+            if ( is_object( $rbfw ) ) {
+                $cpt_label        = $rbfw->get_name();
+                $cpt_slug         = sanitize_title( $rbfw->get_slug() );
+                $cpt_icon         = $rbfw->get_icon();
+                $gutenburg_switch = $rbfw->get_option_trans( 'rbfw_gutenburg_switch', 'rbfw_basic_gen_settings', 'on' );
+            } else {
+                $gen_settings     = get_option( 'rbfw_basic_gen_settings' );
+                $gen_settings     = is_array( $gen_settings ) ? $gen_settings : array();
+                $cpt_label        = ! empty( $gen_settings['rbfw_rent_label'] ) ? $gen_settings['rbfw_rent_label'] : 'Rent Item';
+                $cpt_slug         = sanitize_title( ! empty( $gen_settings['rbfw_rent_slug'] ) ? $gen_settings['rbfw_rent_slug'] : 'rent' );
+                $cpt_icon         = ! empty( $gen_settings['rbfw_rent_icon'] ) ? $gen_settings['rbfw_rent_icon'] : 'dashicons-clipboard';
+                $gutenburg_switch = isset( $gen_settings['rbfw_gutenburg_switch'] ) ? $gen_settings['rbfw_gutenburg_switch'] : 'on';
+            }
             if ( empty( $cpt_slug ) ) {
                 $cpt_slug = 'rent';
             }
-            $cpt_icon         = $rbfw->get_icon();
-            $gutenburg_switch  = $rbfw->get_option_trans('rbfw_gutenburg_switch', 'rbfw_basic_gen_settings', 'on');
             if(isset($gutenburg_switch) && $gutenburg_switch == 'on'){
                 $editor = true;
             } else {

--- a/rent-manager.php
+++ b/rent-manager.php
@@ -39,6 +39,8 @@
 					add_action( 'save_post', [ $this, 'flush_rules_on_save_posts' ], 20, 2 );
 					add_action( 'admin_init', [ $this, 'get_plugin_data' ] );
 					add_action( 'admin_init', [ $this, 'flush_rules_rbfw_post_list_page' ] );
+					// Rebuild permalinks automatically (once) – no manual Settings → Permalinks save needed.
+					add_action( 'init', [ $this, 'rbfw_auto_flush_rewrite_rules' ], 99 );
 				}
 				require_once RBFW_PLUGIN_DIR . '/admin/RBFW_Hidden_Product.php';
 				require_once RBFW_PLUGIN_DIR . '/inc/RBFW_Woo_Installer.php';
@@ -124,6 +126,75 @@
 				if ( isset( $_GET['post_type'] ) && sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) == 'rbfw_item' ) {
 					flush_rewrite_rules();
 				}
+			}
+
+			/**
+			 * Keep the rental permalinks healthy automatically – no manual
+			 * Settings → Permalinks save ever required. Runs on every request but
+			 * only actually flushes in two cases:
+			 *
+			 *   (a) First load after an install/update/deploy, or the rental slug
+			 *       changed in the settings (detected via a stored "signature").
+			 *
+			 *   (b) Self-heal: the /rent/... routes are missing from the stored
+			 *       rewrite rules for ANY reason – another plugin flushed them away,
+			 *       an old DB backup was restored, a buggy update, etc. This is
+			 *       throttled with a 1-hour transient so a persistently broken
+			 *       environment can never cause a flush on every single request.
+			 *
+			 * In the healthy steady state nothing is flushed – it is just two
+			 * autoloaded-option reads, so the per-request cost is negligible.
+			 */
+			public function rbfw_auto_flush_rewrite_rules() {
+				global $rbfw;
+
+				if ( is_object( $rbfw ) ) {
+					$slug = sanitize_title( $rbfw->get_slug() );
+				} else {
+					$gen_settings = get_option( 'rbfw_basic_gen_settings' );
+					$gen_settings = is_array( $gen_settings ) ? $gen_settings : array();
+					$slug         = sanitize_title( ! empty( $gen_settings['rbfw_rent_slug'] ) ? $gen_settings['rbfw_rent_slug'] : 'rent' );
+				}
+				if ( empty( $slug ) ) {
+					$slug = 'rent';
+				}
+
+				// (a) Deploy / update / slug change. Bump the 'rbfw1' token if a future
+				// change alters the rewrite structure so every site re-flushes once.
+				$signature = 'rbfw1|' . $slug;
+				if ( get_option( 'rbfw_rewrite_signature' ) !== $signature ) {
+					flush_rewrite_rules();
+					update_option( 'rbfw_rewrite_signature', $signature );
+					delete_transient( 'rbfw_rewrite_selfheal_lock' );
+
+					return;
+				}
+
+				// (b) Self-heal broken rules from any source (throttled to once / hour).
+				if ( ! $this->rbfw_rewrite_rules_have_item_route()
+					&& ! get_transient( 'rbfw_rewrite_selfheal_lock' ) ) {
+					set_transient( 'rbfw_rewrite_selfheal_lock', 1, HOUR_IN_SECONDS );
+					flush_rewrite_rules();
+				}
+			}
+
+			/**
+			 * Whether the stored rewrite rules still contain the rbfw_item routes.
+			 *
+			 * @return bool
+			 */
+			private function rbfw_rewrite_rules_have_item_route() {
+				$rules = get_option( 'rewrite_rules' );
+				if ( empty( $rules ) || ! is_array( $rules ) ) {
+					return false;
+				}
+				foreach ( $rules as $query ) {
+					if ( is_string( $query ) && false !== strpos( $query, 'rbfw_item' ) ) {
+						return true;
+					}
+				}
+
+				return false;
 			}
 
 			public function activation_redirect() {


### PR DESCRIPTION
The rbfw_item ("rent") permalinks worked immediately after saving Settings -> Permalinks, but reverted to 404 within a day and had to be re-saved manually.

Root cause
----------
rbfw_cpt() in admin/custom_post.php skipped register_post_type() whenever WP_CLI was defined:

    if ( defined('WP_CLI') && WP_CLI ) { return; }

The guard exists because the global $rbfw is null under WP-CLI and the method would otherwise fatal on $rbfw->get_name(). Its side effect is that the rbfw_item post type does not exist in ANY WP-CLI process.

WordPress stores the compiled permalink routes in the rewrite_rules option. Whenever those rules are rebuilt in a CLI context - a nightly `wp cron event run`, `wp plugin update`, Action Scheduler's CLI runner, backup/staging tooling, etc. - they are regenerated and saved WITHOUT the rbfw_item routes, so the front end 404s until permalinks are saved again by hand. Reproduced on a live install: a single `wp rewrite flush` dropped the rbfw_item rules from 23 to 0.

Fix
---
1. admin/custom_post.php: register the CPT in EVERY context. Remove the WP_CLI early-return and resolve the label/slug/icon defensively - use the $rbfw getters when the object is available, otherwise read the rbfw_basic_gen_settings option directly. Both paths resolve to the same stored values, so the rewrite slug is identical across browser, loopback-cron and WP-CLI requests and the generated rules always match.

2. rent-manager.php: keep permalinks healthy automatically so a manual Settings -> Permalinks save is never required. A new init() callback at priority 99 (after the CPT registers at priority 10) flushes rewrite rules only when needed: (a) once after an install/update/deploy or a rental-slug change, tracked via the rbfw_rewrite_signature option; and (b) self-heal - if the rbfw_item routes are missing from the stored rules for ANY reason (another plugin flushed them away, a restored DB backup, a bad update), re-flush on the next request. Throttled with a one-hour transient (rbfw_rewrite_selfheal_lock) so a persistently broken environment can never flush on every request. In the healthy steady state nothing is flushed - the callback is just two autoloaded-option reads, so the per-request cost is negligible.

Verification
------------
- php -l clean on both files.
- `wp post-type list` now lists rbfw_item under WP-CLI.
- Fresh-deploy (no signature) and "another plugin wiped the rules" (signature intact) scenarios both auto-restore the 23 routes on a single page load, with no manual permalink save.
- A real rbfw_item single URL and the /rent/ archive both return HTTP 200.