### PR TITLE
feat(admin): add responsive Rental Items list design with grid/table ……& trash

### DIFF
--- a/admin/RBFW_Rental_List.php
+++ b/admin/RBFW_Rental_List.php
@@ -7,13 +7,479 @@ if (!defined('ABSPATH')) {
     die;
 } // Cannot access pages directly.
 if (!class_exists('RBFW_Rental_List')) {
+    /**
+     * Modern responsive card/table design for the Rental items list screen.
+     *
+     * Controlled by the global setting "New Rental List Design" (General Settings).
+     * When enabled the default edit.php?post_type=rbfw_item list is replaced by a
+     * fully responsive grid/table view; when disabled the classic WordPress list
+     * is shown, so the toggle works in both directions without side effects.
+     */
     class RBFW_Rental_List
     {
+        const PAGE_SLUG = 'rbfw_item_list';
+
         public function __construct()
         {
-            add_action('admin_menu', array($this, 'rental_list_menu'));
-
+            add_action('admin_menu', array($this, 'register_page'));
             add_action('admin_action_rbfw_duplicate_post', [$this, 'rbfw_duplicate_post_function']);
+            // New design wiring.
+            add_filter('rbfw_settings_field', [$this, 'register_setting']);
+            add_action('load-edit.php', [$this, 'maybe_redirect_to_new_design']);
+            add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
+            add_filter('parent_file', [$this, 'highlight_menu']);
+            add_filter('submenu_file', [$this, 'highlight_submenu']);
+            add_filter('admin_title', [$this, 'admin_title'], 10, 2);
+        }
+
+        /**
+         * Whether the new design is currently turned on.
+         */
+        public static function is_enabled(): bool
+        {
+            return RBFW_Function::get_general_settings('rbfw_new_list_design', 'enable') === 'enable';
+        }
+
+        public static function cpt_label(): string
+        {
+            return RBFW_Function::get_general_settings('rbfw_rent_label', 'Rent');
+        }
+
+        /**
+         * Append the enable/disable toggle to the General settings tab.
+         */
+        public function register_setting($settings_fields)
+        {
+            $settings_fields['rbfw_basic_gen_settings'][] = array(
+                'name'    => 'rbfw_new_list_design',
+                'label'   => esc_html__('New Rental List Design', 'booking-and-rental-manager-for-woocommerce'),
+                'desc'    => esc_html__('Enable the new responsive card/table design for the rental items list. Disable to use the classic WordPress list.', 'booking-and-rental-manager-for-woocommerce'),
+                'type'    => 'select',
+                'default' => 'enable',
+                'options' => array(
+                    'enable'  => esc_html__('Enable', 'booking-and-rental-manager-for-woocommerce'),
+                    'disable' => esc_html__('Disable', 'booking-and-rental-manager-for-woocommerce'),
+                ),
+            );
+
+            return $settings_fields;
+        }
+
+        /**
+         * Register the hidden admin page that renders the new design.
+         */
+        public function register_page()
+        {
+            add_submenu_page(
+                '',
+                esc_html__('Rental Items', 'booking-and-rental-manager-for-woocommerce'),
+                esc_html__('Rental Items', 'booking-and-rental-manager-for-woocommerce'),
+                'edit_posts',
+                self::PAGE_SLUG,
+                array($this, 'render_page')
+            );
+        }
+
+        /**
+         * Send the default CPT list to the new design when the setting is on.
+         */
+        public function maybe_redirect_to_new_design()
+        {
+            if (!self::is_enabled()) {
+                return;
+            }
+            if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'GET') {
+                return;
+            }
+            // phpcs:disable WordPress.Security.NonceVerification.Recommended
+            $post_type = isset($_GET['post_type']) ? sanitize_text_field(wp_unslash($_GET['post_type'])) : '';
+            if ($post_type !== 'rbfw_item') {
+                return;
+            }
+            $status = isset($_GET['post_status']) ? sanitize_text_field(wp_unslash($_GET['post_status'])) : '';
+            $view   = isset($_GET['rbfw_view']) ? sanitize_text_field(wp_unslash($_GET['rbfw_view'])) : '';
+            // phpcs:enable WordPress.Security.NonceVerification.Recommended
+            if ($status === 'trash' || $view === 'classic') {
+                return;
+            }
+            if (!current_user_can('edit_posts')) {
+                return;
+            }
+            wp_safe_redirect(admin_url('admin.php?page=' . self::PAGE_SLUG));
+            exit;
+        }
+
+        public function enqueue_assets($hook)
+        {
+            if ($hook !== 'admin_page_' . self::PAGE_SLUG) {
+                return;
+            }
+            wp_enqueue_style('rbfw-rental-list-font', 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap', array(), null);
+            wp_enqueue_style('rbfw_rental_list', RBFW_PLUGIN_URL . '/assets/admin/rbfw_rental_list.css', array(), time());
+            wp_enqueue_script('rbfw_rental_list', RBFW_PLUGIN_URL . '/assets/admin/rbfw_rental_list.js', array('jquery'), time(), true);
+        }
+
+        /**
+         * Keep the Rental CPT top menu open while viewing the orphan page.
+         */
+        public function highlight_menu($parent_file)
+        {
+            global $pagenow;
+            if ($pagenow === 'admin.php' && ($_GET['page'] ?? '') === self::PAGE_SLUG) {
+                return 'edit.php?post_type=rbfw_item';
+            }
+
+            return $parent_file;
+        }
+
+        public function highlight_submenu($submenu_file)
+        {
+            if (($_GET['page'] ?? '') === self::PAGE_SLUG) {
+                return 'edit.php?post_type=rbfw_item';
+            }
+
+            return $submenu_file;
+        }
+
+        public function admin_title($admin_title, $title)
+        {
+            if (($_GET['page'] ?? '') !== self::PAGE_SLUG) {
+                return $admin_title;
+            }
+            $is_trash = isset($_GET['rbfw_status']) && sanitize_text_field(wp_unslash($_GET['rbfw_status'])) === 'trash';
+            $label    = self::cpt_label() . ' ' . esc_html__('Items', 'booking-and-rental-manager-for-woocommerce');
+            if ($is_trash) {
+                $label = esc_html__('Trash', 'booking-and-rental-manager-for-woocommerce') . ' - ' . $label;
+            }
+
+            return $label . ' &lsaquo; ' . get_bloginfo('name') . ' &#8212; WordPress';
+        }
+
+        /**
+         * Collect rental items for the current view.
+         */
+        private function get_items($statuses = array('publish', 'draft', 'pending', 'private')): array
+        {
+            $query = new WP_Query(array(
+                'post_type'      => 'rbfw_item',
+                'post_status'    => $statuses,
+                'posts_per_page' => -1,
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'no_found_rows'  => true,
+            ));
+            $rent_types = RBFW_Function::rbfw_rent_types();
+            $items = array();
+            foreach ($query->posts as $post) {
+                $pid       = $post->ID;
+                $type_key  = RBFW_Function::get_post_info($pid, 'rbfw_item_type');
+                $type_lbl  = isset($rent_types[$type_key]) ? $rent_types[$type_key] : ($type_key ?: '');
+                $cats      = get_post_meta($pid, 'rbfw_categories', true);
+                $cats      = is_array($cats) ? array_filter($cats) : array();
+                $items[]   = array(
+                    'id'         => $pid,
+                    'title'      => get_the_title($pid) ?: esc_html__('(no title)', 'booking-and-rental-manager-for-woocommerce'),
+                    'type_key'   => $type_key,
+                    'type_label' => $type_lbl,
+                    'cats'       => $cats,
+                    'price'      => $this->get_price_label($pid),
+                    'status'     => $post->post_status,
+                    'thumb'      => get_the_post_thumbnail_url($pid, 'medium_large'),
+                    'author'     => get_the_author_meta('display_name', $post->post_author),
+                    'edit_link'  => get_edit_post_link($pid, 'raw'),
+                    'view_link'  => get_permalink($pid),
+                    'trash_link' => get_delete_post_link($pid),
+                    'restore_link' => wp_nonce_url(admin_url(sprintf('post.php?post=%d&action=untrash', $pid)), 'untrash-post_' . $pid),
+                    'delete_link'  => get_delete_post_link($pid, '', true),
+                );
+            }
+
+            return $items;
+        }
+
+        private function get_price_label($pid): string
+        {
+            $daily  = RBFW_Function::get_post_info($pid, 'rbfw_daily_rate');
+            $hourly = RBFW_Function::get_post_info($pid, 'rbfw_hourly_rate');
+            $amount = '';
+            $suffix = '';
+            if ($daily !== '' && (float) $daily > 0) {
+                $amount = $daily;
+                $suffix = esc_html__('/day', 'booking-and-rental-manager-for-woocommerce');
+            } elseif ($hourly !== '' && (float) $hourly > 0) {
+                $amount = $hourly;
+                $suffix = esc_html__('/hour', 'booking-and-rental-manager-for-woocommerce');
+            }
+            if ($amount === '') {
+                return '';
+            }
+            $formatted = function_exists('wc_price') ? wp_strip_all_tags(wc_price($amount)) : number_format_i18n((float) $amount, 2);
+
+            return $formatted . ' ' . $suffix;
+        }
+
+        private function initials($name): string
+        {
+            $name = trim(wp_strip_all_tags((string) $name));
+            if ($name === '') {
+                return '?';
+            }
+            $parts = preg_split('/\s+/', $name);
+            $first = mb_substr($parts[0], 0, 1);
+            $last  = count($parts) > 1 ? mb_substr(end($parts), 0, 1) : '';
+
+            return mb_strtoupper($first . $last);
+        }
+
+        private function status_label($status): string
+        {
+            switch ($status) {
+                case 'publish':
+                    return esc_html__('Published', 'booking-and-rental-manager-for-woocommerce');
+                case 'draft':
+                    return esc_html__('Draft', 'booking-and-rental-manager-for-woocommerce');
+                case 'pending':
+                    return esc_html__('Pending', 'booking-and-rental-manager-for-woocommerce');
+                case 'private':
+                    return esc_html__('Private', 'booking-and-rental-manager-for-woocommerce');
+                default:
+                    return esc_html(ucfirst($status));
+            }
+        }
+
+        public function render_page()
+        {
+            $name = self::cpt_label();
+            // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $is_trash = isset($_GET['rbfw_status']) && sanitize_text_field(wp_unslash($_GET['rbfw_status'])) === 'trash';
+
+            $active    = $this->get_items();
+            $total     = count($active);
+            $published = 0;
+            $draft     = 0;
+            $cats_all  = array();
+            foreach ($active as $it) {
+                if ($it['status'] === 'publish') {
+                    $published++;
+                } elseif ($it['status'] === 'draft') {
+                    $draft++;
+                }
+                foreach ($it['cats'] as $c) {
+                    $cats_all[$c] = true;
+                }
+            }
+            $cat_count = count($cats_all);
+
+            $status_counts = wp_count_posts('rbfw_item');
+            $trash         = isset($status_counts->trash) ? (int) $status_counts->trash : 0;
+
+            $items     = $is_trash ? $this->get_items(array('trash')) : $active;
+            $base_url  = admin_url('admin.php?page=' . self::PAGE_SLUG);
+            $trash_url = add_query_arg('rbfw_status', 'trash', $base_url);
+            $add_url   = admin_url('post-new.php?post_type=rbfw_item');
+            $classic   = admin_url('edit.php?post_type=rbfw_item&rbfw_view=classic');
+            $rent_types = RBFW_Function::rbfw_rent_types();
+            ?>
+            <div class="wrap rbfw-fleet-wrap">
+                <div class="rbfw-fleet">
+
+                    <div class="rbfw-page-header">
+                        <div class="rbfw-page-title"><?php echo esc_html($name); ?> <?php esc_html_e('Items', 'booking-and-rental-manager-for-woocommerce'); ?>
+                            <span><?php echo esc_html(sprintf(_n('%d item', '%d items', $total, 'booking-and-rental-manager-for-woocommerce'), $total)); ?></span>
+                        </div>
+                        <div class="rbfw-header-actions">
+                            <a class="rbfw-classic-link" href="<?php echo esc_url($classic); ?>">
+                                <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+                                <?php esc_html_e('Classic view', 'booking-and-rental-manager-for-woocommerce'); ?>
+                            </a>
+                            <a class="rbfw-add-btn" href="<?php echo esc_url($add_url); ?>">
+                                <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                <?php printf(esc_html__('Add New %s', 'booking-and-rental-manager-for-woocommerce'), esc_html($name)); ?>
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="rbfw-stats">
+                        <div class="rbfw-stat-card">
+                            <div class="rbfw-stat-icon red">
+                                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M20 7L12 3 4 7v10l8 4 8-4V7z"/><path d="M4 7l8 4 8-4"/><path d="M12 21V11"/></svg>
+                            </div>
+                            <div><div class="rbfw-stat-num"><?php echo esc_html($total); ?></div><div class="rbfw-stat-label"><?php printf(esc_html__('Total %s', 'booking-and-rental-manager-for-woocommerce'), esc_html($name)); ?></div></div>
+                        </div>
+                        <div class="rbfw-stat-card">
+                            <div class="rbfw-stat-icon green">
+                                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
+                            </div>
+                            <div><div class="rbfw-stat-num"><?php echo esc_html($published); ?></div><div class="rbfw-stat-label"><?php esc_html_e('Published', 'booking-and-rental-manager-for-woocommerce'); ?></div></div>
+                        </div>
+                        <div class="rbfw-stat-card">
+                            <div class="rbfw-stat-icon orange">
+                                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+                            </div>
+                            <div><div class="rbfw-stat-num"><?php echo esc_html($draft); ?></div><div class="rbfw-stat-label"><?php esc_html_e('Draft', 'booking-and-rental-manager-for-woocommerce'); ?></div></div>
+                        </div>
+                        <div class="rbfw-stat-card">
+                            <div class="rbfw-stat-icon blue">
+                                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+                            </div>
+                            <div><div class="rbfw-stat-num"><?php echo esc_html($cat_count); ?></div><div class="rbfw-stat-label"><?php esc_html_e('Categories', 'booking-and-rental-manager-for-woocommerce'); ?></div></div>
+                        </div>
+                    </div>
+
+                    <div class="rbfw-filters">
+                        <div class="rbfw-tab-pills">
+                            <?php if ($is_trash) : ?>
+                                <a class="rbfw-tab-pill" href="<?php echo esc_url($base_url); ?>"><?php printf(esc_html__('All (%d)', 'booking-and-rental-manager-for-woocommerce'), $total); ?></a>
+                                <a class="rbfw-tab-pill" href="<?php echo esc_url($base_url); ?>"><?php printf(esc_html__('Published (%d)', 'booking-and-rental-manager-for-woocommerce'), $published); ?></a>
+                                <a class="rbfw-tab-pill" href="<?php echo esc_url($base_url); ?>"><?php printf(esc_html__('Draft (%d)', 'booking-and-rental-manager-for-woocommerce'), $draft); ?></a>
+                                <span class="rbfw-tab-pill rbfw-tab-trash active">
+                                    <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                    <?php printf(esc_html__('Trash (%d)', 'booking-and-rental-manager-for-woocommerce'), $trash); ?>
+                                </span>
+                            <?php else : ?>
+                                <button class="rbfw-tab-pill rbfw-filter-pill active" data-status=""><?php printf(esc_html__('All (%d)', 'booking-and-rental-manager-for-woocommerce'), $total); ?></button>
+                                <button class="rbfw-tab-pill rbfw-filter-pill" data-status="publish"><?php printf(esc_html__('Published (%d)', 'booking-and-rental-manager-for-woocommerce'), $published); ?></button>
+                                <button class="rbfw-tab-pill rbfw-filter-pill" data-status="draft"><?php printf(esc_html__('Draft (%d)', 'booking-and-rental-manager-for-woocommerce'), $draft); ?></button>
+                                <a class="rbfw-tab-pill rbfw-tab-trash" href="<?php echo esc_url($trash_url); ?>" title="<?php esc_attr_e('View trashed items', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                    <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                    <?php printf(esc_html__('Trash (%d)', 'booking-and-rental-manager-for-woocommerce'), $trash); ?>
+                                </a>
+                            <?php endif; ?>
+                        </div>
+                        <div class="rbfw-search-box">
+                            <svg class="rbfw-search-icon" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                            <input type="text" placeholder="<?php esc_attr_e('Search items...', 'booking-and-rental-manager-for-woocommerce'); ?>" id="rbfwSearchInput" autocomplete="off">
+                            <button type="button" class="rbfw-search-clear" id="rbfwSearchClear" aria-label="<?php esc_attr_e('Clear search', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                            </button>
+                        </div>
+                        <select class="rbfw-filter-select" id="rbfwTypeFilter">
+                            <option value=""><?php esc_html_e('All Types', 'booking-and-rental-manager-for-woocommerce'); ?></option>
+                            <?php foreach ($rent_types as $tk => $tl) : ?>
+                                <option value="<?php echo esc_attr($tk); ?>"><?php echo esc_html($tl); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <div class="rbfw-view-toggle">
+                            <button class="rbfw-vtog active" id="rbfwGridBtn" title="<?php esc_attr_e('Grid view', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                            </button>
+                            <button class="rbfw-vtog" id="rbfwListBtn" title="<?php esc_attr_e('List view', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <?php if (empty($items)) : ?>
+                        <div class="rbfw-no-data">
+                            <?php if ($is_trash) : ?>
+                                <p><?php esc_html_e('Trash is empty.', 'booking-and-rental-manager-for-woocommerce'); ?></p>
+                                <a class="rbfw-classic-link" href="<?php echo esc_url($base_url); ?>"><?php esc_html_e('Back to list', 'booking-and-rental-manager-for-woocommerce'); ?></a>
+                            <?php else : ?>
+                                <p><?php printf(esc_html__('No %s items found yet.', 'booking-and-rental-manager-for-woocommerce'), esc_html(strtolower($name))); ?></p>
+                                <a class="rbfw-add-btn" href="<?php echo esc_url($add_url); ?>"><?php printf(esc_html__('Add your first %s', 'booking-and-rental-manager-for-woocommerce'), esc_html($name)); ?></a>
+                            <?php endif; ?>
+                        </div>
+                    <?php else : ?>
+
+                    <div class="rbfw-grid" id="rbfwGrid">
+                        <?php foreach ($items as $it) :
+                            $first_cat = !empty($it['cats']) ? reset($it['cats']) : '';
+                            ?>
+                            <div class="rbfw-card" data-name="<?php echo esc_attr(strtolower($it['title'] . ' ' . implode(' ', $it['cats']))); ?>" data-type="<?php echo esc_attr($it['type_key']); ?>" data-status="<?php echo esc_attr($it['status']); ?>">
+                                <div class="rbfw-thumb">
+                                    <?php if ($it['thumb']) : ?>
+                                        <img src="<?php echo esc_url($it['thumb']); ?>" alt="<?php echo esc_attr($it['title']); ?>">
+                                    <?php else : ?>
+                                        <div class="rbfw-thumb-placeholder">
+                                            <svg width="46" height="46" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M20 7L12 3 4 7v10l8 4 8-4V7z"/><path d="M4 7l8 4 8-4"/><path d="M12 21V11"/></svg>
+                                        </div>
+                                    <?php endif; ?>
+                                    <div class="rbfw-thumb-overlay"></div>
+                                    <div class="rbfw-thumb-badges">
+                                        <?php if ($it['type_label']) : ?><span class="rbfw-thumb-badge type"><?php echo esc_html($it['type_label']); ?></span><?php endif; ?>
+                                        <?php if ($it['price']) : ?><span class="rbfw-thumb-badge price"><?php echo esc_html($it['price']); ?></span><?php endif; ?>
+                                    </div>
+                                    <div class="rbfw-actions-top">
+                                        <?php if ($is_trash) : ?>
+                                            <a class="rbfw-act-btn restore" href="<?php echo esc_url($it['restore_link']); ?>" title="<?php esc_attr_e('Restore', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 12a9 9 0 109-9 9 9 0 00-7 3.3"/><polyline points="3 4 3 8 7 8"/></svg>
+                                            </a>
+                                            <a class="rbfw-act-btn del" href="<?php echo esc_url($it['delete_link']); ?>" title="<?php esc_attr_e('Delete Permanently', 'booking-and-rental-manager-for-woocommerce'); ?>" onclick="return confirm('<?php echo esc_js(__('Permanently delete this item? This cannot be undone.', 'booking-and-rental-manager-for-woocommerce')); ?>');">
+                                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                            </a>
+                                        <?php else : ?>
+                                            <a class="rbfw-act-btn edit" href="<?php echo esc_url($it['edit_link']); ?>" title="<?php esc_attr_e('Edit', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                                            </a>
+                                            <a class="rbfw-act-btn del" href="<?php echo esc_url($it['trash_link']); ?>" title="<?php esc_attr_e('Move to Trash', 'booking-and-rental-manager-for-woocommerce'); ?>" onclick="return confirm('<?php echo esc_js(__('Move this item to Trash?', 'booking-and-rental-manager-for-woocommerce')); ?>');">
+                                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                            </a>
+                                        <?php endif; ?>
+                                    </div>
+                                </div>
+                                <div class="rbfw-body">
+                                    <?php if ($is_trash) : ?>
+                                        <span class="rbfw-name"><?php echo esc_html($it['title']); ?></span>
+                                    <?php else : ?>
+                                        <a class="rbfw-name" href="<?php echo esc_url($it['edit_link']); ?>"><?php echo esc_html($it['title']); ?></a>
+                                    <?php endif; ?>
+                                    <div class="rbfw-meta">
+                                        <?php if ($it['type_label']) : ?><span class="rbfw-meta-pill type"><?php echo esc_html($it['type_label']); ?></span><?php endif; ?>
+                                        <?php if ($first_cat) : ?><span class="rbfw-meta-pill cat"><?php echo esc_html($first_cat); ?></span><?php endif; ?>
+                                    </div>
+                                    <div class="rbfw-footer">
+                                        <div class="rbfw-author"><span class="rbfw-author-avatar"><?php echo esc_html($this->initials($it['author'])); ?></span> <?php echo esc_html($it['author']); ?></div>
+                                        <span class="rbfw-status-dot status-<?php echo esc_attr($it['status']); ?>"><?php echo esc_html($this->status_label($it['status'])); ?></span>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+
+                    <table class="rbfw-table" id="rbfwTable">
+                        <thead>
+                            <tr>
+                                <th><?php printf(esc_html__('%s Name', 'booking-and-rental-manager-for-woocommerce'), esc_html($name)); ?></th>
+                                <th><?php esc_html_e('Price Type', 'booking-and-rental-manager-for-woocommerce'); ?></th>
+                                <th><?php esc_html_e('Rent Type', 'booking-and-rental-manager-for-woocommerce'); ?></th>
+                                <th><?php esc_html_e('Price', 'booking-and-rental-manager-for-woocommerce'); ?></th>
+                                <th><?php esc_html_e('Status', 'booking-and-rental-manager-for-woocommerce'); ?></th>
+                                <th><?php esc_html_e('Actions', 'booking-and-rental-manager-for-woocommerce'); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($items as $it) : ?>
+                                <tr class="rbfw-row" data-name="<?php echo esc_attr(strtolower($it['title'] . ' ' . implode(' ', $it['cats']))); ?>" data-type="<?php echo esc_attr($it['type_key']); ?>" data-status="<?php echo esc_attr($it['status']); ?>">
+                                    <td data-label="<?php esc_attr_e('Name', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php if ($is_trash) : ?><?php echo esc_html($it['title']); ?><?php else : ?><a href="<?php echo esc_url($it['edit_link']); ?>"><?php echo esc_html($it['title']); ?></a><?php endif; ?></td>
+                                    <td data-label="<?php esc_attr_e('Price Type', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php echo $it['type_label'] ? '<span class="rbfw-t-badge type">' . esc_html($it['type_label']) . '</span>' : '-'; ?></td>
+                                    <td data-label="<?php esc_attr_e('Rent Type', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php echo $it['cats'] ? esc_html(implode(', ', $it['cats'])) : '-'; ?></td>
+                                    <td data-label="<?php esc_attr_e('Price', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php echo esc_html($it['price'] ?: '-'); ?></td>
+                                    <td data-label="<?php esc_attr_e('Status', 'booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw-status-dot status-<?php echo esc_attr($it['status']); ?>"><?php echo esc_html($this->status_label($it['status'])); ?></span></td>
+                                    <td data-label="<?php esc_attr_e('Actions', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                        <?php if ($is_trash) : ?>
+                                            <a class="rbfw-table-edit" href="<?php echo esc_url($it['restore_link']); ?>"><?php esc_html_e('Restore', 'booking-and-rental-manager-for-woocommerce'); ?></a>
+                                            <a class="rbfw-table-del" href="<?php echo esc_url($it['delete_link']); ?>" onclick="return confirm('<?php echo esc_js(__('Permanently delete this item? This cannot be undone.', 'booking-and-rental-manager-for-woocommerce')); ?>');"><?php esc_html_e('Delete', 'booking-and-rental-manager-for-woocommerce'); ?></a>
+                                        <?php else : ?>
+                                            <a class="rbfw-table-edit" href="<?php echo esc_url($it['edit_link']); ?>"><?php esc_html_e('Edit', 'booking-and-rental-manager-for-woocommerce'); ?></a>
+                                            <a class="rbfw-table-del" href="<?php echo esc_url($it['trash_link']); ?>" onclick="return confirm('<?php echo esc_js(__('Move this item to Trash?', 'booking-and-rental-manager-for-woocommerce')); ?>');"><?php esc_html_e('Trash', 'booking-and-rental-manager-for-woocommerce'); ?></a>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+
+                    <div class="rbfw-empty" id="rbfwEmptyMsg"><?php esc_html_e('No items found matching your search.', 'booking-and-rental-manager-for-woocommerce'); ?></div>
+
+                    <div class="rbfw-pagination" id="rbfwPagination">
+                        <div class="rbfw-page-info" id="rbfwPageInfo"></div>
+                        <div class="rbfw-page-btns" id="rbfwPageBtns"></div>
+                    </div>
+
+                    <?php endif; ?>
+                </div>
+            </div>
+            <?php
         }
 
         function rbfw_duplicate_post_function()
@@ -48,16 +514,6 @@ if (!class_exists('RBFW_Rental_List')) {
             }
             wp_redirect(admin_url('post.php?action=edit&post=' . $new_post_id));
             exit;
-        }
-
-        public function rental_list_menu()
-        {
-            //add_submenu_page('edit.php?post_type=rbfw_item', __('Rental Lists', 'booking-and-rental-manager-for-woocommerce'), __('Rental Lists', 'booking-and-rental-manager-for-woocommerce'), 'manage_options', 'rbfw_rental_lists', array($this, 'display_rental_lists'));
-        }
-
-        public function display_rental_lists()
-        {
-            include( RBFW_Function::get_template_path( 'rental_lists.php' ) );
         }
 
     }

--- a/assets/admin/rbfw_rental_list.css
+++ b/assets/admin/rbfw_rental_list.css
@@ -1,0 +1,172 @@
+/* ==========================================================================
+   RBFW Rental Items - modern responsive list design
+   Scoped under .rbfw-fleet so it never leaks into the rest of wp-admin.
+   ========================================================================== */
+.rbfw-fleet-wrap{margin:0;}
+.rbfw-fleet *,.rbfw-fleet *::before,.rbfw-fleet *::after{box-sizing:border-box;}
+.rbfw-fleet{
+  --rb-bg:#f0f2f7;--rb-white:#fff;--rb-ink:#0f1523;--rb-ink2:#3a3f55;
+  --rb-muted:#8b93b0;--rb-border:#e4e7f0;--rb-red:#e63946;--rb-red-soft:#fdedef;
+  --rb-green:#16a34a;--rb-green-soft:#dcfce7;--rb-blue:#1d4ed8;--rb-blue-soft:#dbeafe;
+  --rb-orange:#ea580c;--rb-orange-soft:#ffedd5;
+  --rb-shadow:0 2px 16px rgba(15,21,35,.08);--rb-shadow-hover:0 8px 32px rgba(15,21,35,.14);
+  font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  background:var(--rb-bg);color:var(--rb-ink);
+  margin:10px 20px 40px 0;padding:28px;border-radius:18px;
+}
+.rbfw-fleet a{box-shadow:none;}
+.rbfw-fleet a:focus{box-shadow:none;outline:none;}
+
+/* HEADER */
+.rbfw-page-header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:24px;flex-wrap:wrap;}
+.rbfw-page-title{font-size:25px;font-weight:800;color:var(--rb-ink);letter-spacing:-.02em;}
+.rbfw-page-title span{color:var(--rb-muted);font-weight:400;font-size:15px;margin-left:8px;}
+.rbfw-header-actions{display:flex;align-items:center;gap:10px;}
+.rbfw-classic-link{display:inline-flex;align-items:center;gap:7px;font-size:13px;font-weight:700;color:var(--rb-ink2) !important;text-decoration:none;background:var(--rb-white);border:1px solid var(--rb-border);padding:9px 16px;border-radius:10px;transition:border-color .2s,color .2s,box-shadow .2s,transform .15s;}
+.rbfw-classic-link svg{color:var(--rb-muted);transition:color .2s;}
+.rbfw-classic-link:hover{color:var(--rb-red) !important;border-color:var(--rb-red);box-shadow:var(--rb-shadow);transform:translateY(-1px);}
+.rbfw-classic-link:hover svg{color:var(--rb-red);}
+.rbfw-add-btn{display:inline-flex;align-items:center;gap:8px;background:var(--rb-red);color:#fff !important;font-size:13px;font-weight:700;padding:10px 20px;border-radius:10px;border:none;cursor:pointer;text-decoration:none;transition:background .2s,transform .15s;}
+.rbfw-add-btn:hover{background:#c62a35;color:#fff !important;transform:translateY(-1px);}
+
+/* STATS */
+.rbfw-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:24px;}
+.rbfw-stat-card{background:var(--rb-white);border-radius:14px;padding:18px 20px;border:1px solid var(--rb-border);display:flex;align-items:center;gap:14px;transition:box-shadow .2s;}
+.rbfw-stat-card:hover{box-shadow:var(--rb-shadow);}
+.rbfw-stat-icon{width:44px;height:44px;border-radius:12px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.rbfw-stat-icon.red{background:var(--rb-red-soft);color:var(--rb-red);}
+.rbfw-stat-icon.green{background:var(--rb-green-soft);color:var(--rb-green);}
+.rbfw-stat-icon.blue{background:var(--rb-blue-soft);color:var(--rb-blue);}
+.rbfw-stat-icon.orange{background:var(--rb-orange-soft);color:var(--rb-orange);}
+.rbfw-stat-num{font-size:22px;font-weight:800;color:var(--rb-ink);line-height:1;}
+.rbfw-stat-label{font-size:11px;color:var(--rb-muted);margin-top:3px;font-weight:500;}
+
+/* FILTERS */
+.rbfw-filters{display:flex;align-items:center;gap:12px;margin-bottom:20px;flex-wrap:wrap;}
+.rbfw-tab-pills{display:flex;gap:6px;background:var(--rb-white);padding:5px;border-radius:10px;border:1px solid var(--rb-border);}
+.rbfw-tab-pill{display:inline-flex;align-items:center;gap:5px;padding:6px 14px;border-radius:7px;font-size:12px;font-weight:600;cursor:pointer;color:var(--rb-muted);transition:all .2s;border:none;background:none;font-family:inherit;text-decoration:none;line-height:1.5;}
+.rbfw-tab-pill.active{background:var(--rb-red);color:#fff;}
+.rbfw-tab-trash{color:var(--rb-muted) !important;}
+.rbfw-tab-trash svg{opacity:.8;}
+.rbfw-tab-trash:not(.active):hover{background:var(--rb-red-soft);color:var(--rb-red) !important;}
+.rbfw-tab-trash.active{background:var(--rb-red);color:#fff !important;}
+.rbfw-tab-trash.active svg{opacity:1;}
+.rbfw-search-box{display:flex;align-items:center;gap:8px;background:var(--rb-white);border:1px solid var(--rb-border);border-radius:10px;padding:6px 14px;flex:1;max-width:300px;min-width:180px;color:var(--rb-muted);transition:border-color .2s,box-shadow .2s;}
+.rbfw-search-box.is-focused{border-color:var(--rb-red);box-shadow:0 0 0 3px var(--rb-red-soft);}
+.rbfw-search-box .rbfw-search-icon{flex-shrink:0;transition:color .2s;}
+.rbfw-search-box.is-focused .rbfw-search-icon{color:var(--rb-red);}
+.rbfw-search-box input{border:none;outline:none;box-shadow:none;font-size:13px;font-family:inherit;color:var(--rb-ink);width:100%;background:transparent;margin:0;min-height:auto;padding:0;}
+.rbfw-search-box input:focus{outline:none;box-shadow:none;border:none;}
+.rbfw-search-clear{display:none;align-items:center;justify-content:center;flex-shrink:0;width:20px;height:20px;border:none;border-radius:50%;background:var(--rb-bg);color:var(--rb-muted);cursor:pointer;padding:0;transition:background .15s,color .15s;}
+.rbfw-search-clear:hover{background:var(--rb-red-soft);color:var(--rb-red);}
+.rbfw-search-box.has-value .rbfw-search-clear{display:inline-flex;}
+
+/* CUSTOM DROPDOWN */
+.rbfw-filter-select{display:none;}
+.rbfw-dropdown{position:relative;font-family:inherit;}
+.rbfw-dropdown-toggle{display:inline-flex;align-items:center;gap:10px;min-width:170px;justify-content:space-between;background:var(--rb-white);border:1px solid var(--rb-border);border-radius:10px;padding:9px 14px;font-size:13px;font-weight:600;font-family:inherit;color:var(--rb-ink2);cursor:pointer;transition:border-color .2s,box-shadow .2s;}
+.rbfw-dropdown-toggle:hover{border-color:#cfd5e6;}
+.rbfw-dropdown.open .rbfw-dropdown-toggle{border-color:var(--rb-red);box-shadow:0 0 0 3px var(--rb-red-soft);}
+.rbfw-dropdown-toggle .rbfw-caret{transition:transform .2s;color:var(--rb-muted);flex-shrink:0;}
+.rbfw-dropdown.open .rbfw-dropdown-toggle .rbfw-caret{transform:rotate(180deg);}
+.rbfw-dropdown-menu{position:absolute;top:calc(100% + 6px);left:0;right:0;z-index:20;background:var(--rb-white);border:1px solid var(--rb-border);border-radius:12px;box-shadow:var(--rb-shadow-hover);padding:6px;opacity:0;visibility:hidden;transform:translateY(-6px);transition:opacity .18s,transform .18s,visibility .18s;max-height:280px;overflow-y:auto;}
+.rbfw-dropdown.open .rbfw-dropdown-menu{opacity:1;visibility:visible;transform:translateY(0);}
+.rbfw-dropdown-option{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 12px;border-radius:8px;font-size:13px;font-weight:600;color:var(--rb-ink2);cursor:pointer;transition:background .15s,color .15s;}
+.rbfw-dropdown-option:hover{background:var(--rb-bg);}
+.rbfw-dropdown-option.selected{background:var(--rb-red-soft);color:var(--rb-red);}
+.rbfw-dropdown-option .rbfw-check{opacity:0;transition:opacity .15s;}
+.rbfw-dropdown-option.selected .rbfw-check{opacity:1;}
+.rbfw-view-toggle{display:flex;gap:4px;background:var(--rb-white);padding:4px;border-radius:8px;border:1px solid var(--rb-border);margin-left:auto;}
+.rbfw-vtog{width:32px;height:32px;border:none;border-radius:6px;cursor:pointer;background:none;display:flex;align-items:center;justify-content:center;color:var(--rb-muted);transition:all .15s;}
+.rbfw-vtog.active{background:var(--rb-red);color:#fff;}
+
+/* GRID */
+.rbfw-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(270px,1fr));gap:18px;}
+.rbfw-card{background:var(--rb-white);border-radius:16px;border:1px solid var(--rb-border);overflow:hidden;transition:box-shadow .25s,transform .2s;animation:rbfwFadeUp .4s ease both;}
+.rbfw-card:hover{box-shadow:var(--rb-shadow-hover);transform:translateY(-3px);}
+@keyframes rbfwFadeUp{from{opacity:0;transform:translateY(16px);}to{opacity:1;transform:translateY(0);}}
+.rbfw-thumb{height:150px;position:relative;overflow:hidden;background:linear-gradient(135deg,#1a1a2e,#2d2d44);}
+.rbfw-thumb img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .4s;}
+.rbfw-card:hover .rbfw-thumb img{transform:scale(1.06);}
+.rbfw-thumb-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:rgba(255,255,255,.35);}
+.rbfw-thumb-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(15,21,35,.7) 0%,transparent 55%);}
+.rbfw-thumb-badges{position:absolute;top:12px;left:12px;display:flex;gap:6px;flex-wrap:wrap;max-width:85%;}
+.rbfw-thumb-badge{font-size:10px;font-weight:700;letter-spacing:.04em;padding:3px 9px;border-radius:6px;backdrop-filter:blur(6px);}
+.rbfw-thumb-badge.type{background:rgba(230,57,70,.85);color:#fff;text-transform:uppercase;letter-spacing:.06em;}
+.rbfw-thumb-badge.price{background:rgba(255,255,255,.92);color:var(--rb-ink);}
+.rbfw-actions-top{position:absolute;top:10px;right:10px;display:flex;gap:6px;opacity:0;transition:opacity .2s;z-index:3;}
+.rbfw-card:hover .rbfw-actions-top,.rbfw-card:focus-within .rbfw-actions-top{opacity:1;}
+.rbfw-act-btn{width:32px;height:32px;border-radius:9px;border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;backdrop-filter:blur(6px);transition:background .15s,transform .15s;text-decoration:none;box-shadow:0 2px 6px rgba(15,21,35,.25);}
+.rbfw-act-btn:hover{transform:translateY(-1px);}
+.rbfw-act-btn.edit{background:rgba(255,255,255,.92);color:var(--rb-ink);}
+.rbfw-act-btn.edit:hover{background:#fff;}
+.rbfw-act-btn.del{background:rgba(230,57,70,.95);color:#fff;}
+.rbfw-act-btn.del:hover{background:var(--rb-red);}
+.rbfw-act-btn.restore{background:rgba(22,163,74,.95);color:#fff;}
+.rbfw-act-btn.restore:hover{background:var(--rb-green);}
+.rbfw-body{padding:16px;}
+.rbfw-name{display:block;font-size:15px;font-weight:700;color:var(--rb-ink) !important;margin-bottom:10px;line-height:1.3;text-decoration:none;}
+.rbfw-name:hover{color:var(--rb-red) !important;}
+.rbfw-meta{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;}
+.rbfw-meta-pill{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;padding:4px 10px;border-radius:20px;}
+.rbfw-meta-pill.type{background:var(--rb-red-soft);color:var(--rb-red);}
+.rbfw-meta-pill.cat{background:var(--rb-blue-soft);color:var(--rb-blue);}
+.rbfw-footer{display:flex;align-items:center;justify-content:space-between;gap:8px;padding-top:12px;border-top:1px solid var(--rb-border);}
+.rbfw-author{font-size:11px;color:var(--rb-muted);display:flex;align-items:center;gap:5px;overflow:hidden;}
+.rbfw-author-avatar{width:22px;height:22px;border-radius:50%;background:var(--rb-red);display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:700;color:#fff;flex-shrink:0;}
+.rbfw-status-dot{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;white-space:nowrap;}
+.rbfw-status-dot::before{content:'';width:6px;height:6px;border-radius:50%;display:block;background:var(--rb-muted);}
+.rbfw-status-dot.status-publish{color:var(--rb-green);}
+.rbfw-status-dot.status-publish::before{background:var(--rb-green);}
+.rbfw-status-dot.status-draft{color:var(--rb-orange);}
+.rbfw-status-dot.status-draft::before{background:var(--rb-orange);}
+.rbfw-status-dot.status-pending{color:var(--rb-blue);}
+.rbfw-status-dot.status-pending::before{background:var(--rb-blue);}
+
+/* TABLE */
+.rbfw-table{width:100%;border-collapse:separate;border-spacing:0 8px;display:none;}
+.rbfw-table th{font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--rb-muted);padding:0 16px 4px;text-align:left;}
+.rbfw-table tr.rbfw-row{background:var(--rb-white);transition:box-shadow .2s,transform .15s;animation:rbfwFadeUp .35s ease both;}
+.rbfw-table tr.rbfw-row:hover{box-shadow:var(--rb-shadow-hover);transform:translateY(-2px);}
+.rbfw-table td{padding:14px 16px;font-size:13px;color:var(--rb-ink2);border-top:1px solid var(--rb-border);border-bottom:1px solid var(--rb-border);vertical-align:middle;}
+.rbfw-table td:first-child{border-left:1px solid var(--rb-border);border-radius:12px 0 0 12px;font-weight:700;}
+.rbfw-table td:first-child a{color:var(--rb-ink) !important;text-decoration:none;}
+.rbfw-table td:first-child a:hover{color:var(--rb-red) !important;}
+.rbfw-table td:last-child{border-right:1px solid var(--rb-border);border-radius:0 12px 12px 0;}
+.rbfw-t-badge{display:inline-flex;align-items:center;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:600;}
+.rbfw-t-badge.type{background:var(--rb-red-soft);color:var(--rb-red);}
+.rbfw-table-edit,.rbfw-table-del{padding:4px 12px;border-radius:6px;border:1px solid var(--rb-border);background:var(--rb-white);font-size:11px;font-weight:600;cursor:pointer;text-decoration:none;color:var(--rb-ink2) !important;display:inline-block;}
+.rbfw-table-edit:hover{border-color:var(--rb-blue);color:var(--rb-blue) !important;}
+.rbfw-table-del{margin-left:4px;}
+.rbfw-table-del:hover{border-color:var(--rb-red);color:var(--rb-red) !important;}
+
+/* PAGINATION */
+.rbfw-pagination{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:24px;flex-wrap:wrap;}
+.rbfw-page-info{font-size:13px;color:var(--rb-muted);}
+.rbfw-page-btns{display:flex;gap:6px;flex-wrap:wrap;}
+.rbfw-page-btn{min-width:34px;height:34px;padding:0 8px;border-radius:8px;border:1px solid var(--rb-border);background:var(--rb-white);font-size:13px;font-weight:600;color:var(--rb-ink2);cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all .15s;font-family:inherit;}
+.rbfw-page-btn:hover:not(:disabled),.rbfw-page-btn.active{background:var(--rb-red);color:#fff;border-color:var(--rb-red);}
+.rbfw-page-btn:disabled{opacity:.4;cursor:not-allowed;}
+
+.rbfw-empty{display:none;text-align:center;padding:60px 20px;color:var(--rb-muted);font-size:14px;font-weight:500;}
+.rbfw-no-data{text-align:center;padding:60px 20px;color:var(--rb-muted);}
+.rbfw-no-data p{font-size:15px;margin-bottom:18px;}
+
+/* RESPONSIVE */
+@media (max-width:1200px){.rbfw-stats{grid-template-columns:repeat(2,1fr);}}
+@media (max-width:782px){
+  .rbfw-fleet{margin:10px 0 30px 0;padding:18px;border-radius:14px;}
+  .rbfw-page-header{align-items:flex-start;}
+  .rbfw-view-toggle{margin-left:0;}
+  .rbfw-search-box{max-width:none;flex:1 1 100%;order:5;}
+  .rbfw-grid{grid-template-columns:1fr;}
+  .rbfw-table thead{display:none;}
+  .rbfw-table,.rbfw-table tbody,.rbfw-table tr.rbfw-row,.rbfw-table td{display:block;width:100%;}
+  .rbfw-table tr.rbfw-row{background:var(--rb-white);border:1px solid var(--rb-border);border-radius:12px;margin-bottom:12px;padding:6px 0;}
+  .rbfw-table td{border:none !important;border-radius:0 !important;padding:8px 16px;display:flex;justify-content:space-between;align-items:center;gap:12px;text-align:right;}
+  .rbfw-table td::before{content:attr(data-label);font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--rb-muted);text-align:left;}
+}
+@media (max-width:480px){
+  .rbfw-stats{grid-template-columns:1fr;}
+  .rbfw-tab-pills{width:100%;justify-content:space-between;}
+}

--- a/assets/admin/rbfw_rental_list.js
+++ b/assets/admin/rbfw_rental_list.js
@@ -1,0 +1,191 @@
+/* ==========================================================================
+   RBFW Rental Items - list interactions
+   View toggle, live search, custom type dropdown, status tabs, pagination.
+   ========================================================================== */
+(function () {
+	'use strict';
+
+	document.addEventListener('DOMContentLoaded', function () {
+		var fleet = document.querySelector('.rbfw-fleet');
+		if (!fleet) { return; }
+
+		var grid     = document.getElementById('rbfwGrid');
+		var table    = document.getElementById('rbfwTable');
+		var gridBtn  = document.getElementById('rbfwGridBtn');
+		var listBtn  = document.getElementById('rbfwListBtn');
+		var searchEl = document.getElementById('rbfwSearchInput');
+		var searchBox = searchEl ? searchEl.closest('.rbfw-search-box') : null;
+		var clearBtn = document.getElementById('rbfwSearchClear');
+		var typeEl   = document.getElementById('rbfwTypeFilter');
+		var emptyMsg = document.getElementById('rbfwEmptyMsg');
+		var pageInfo = document.getElementById('rbfwPageInfo');
+		var pageBtns = document.getElementById('rbfwPageBtns');
+		var tabs     = Array.prototype.slice.call(document.querySelectorAll('.rbfw-filter-pill'));
+
+		if (!grid) { return; }
+
+		var PER_PAGE = 12;
+		var STORE_KEY = 'rbfwRentalListView';
+		var cards = Array.prototype.slice.call(grid.querySelectorAll('.rbfw-card'));
+		var rows  = table ? Array.prototype.slice.call(table.querySelectorAll('tr.rbfw-row')) : [];
+
+		var state = { view: 'grid', search: '', type: '', status: '', page: 1 };
+
+		/* ---- View toggle (persisted) ---------------------------------- */
+		function applyView() {
+			var isGrid = state.view === 'grid';
+			grid.style.display = isGrid ? 'grid' : 'none';
+			if (table) { table.style.display = isGrid ? 'none' : 'table'; }
+			gridBtn.classList.toggle('active', isGrid);
+			listBtn.classList.toggle('active', !isGrid);
+		}
+		function setView(view) {
+			state.view = view;
+			try { window.localStorage.setItem(STORE_KEY, view); } catch (e) {}
+			applyView();
+			render();
+		}
+		try {
+			var saved = window.localStorage.getItem(STORE_KEY);
+			if (saved === 'list' || saved === 'grid') { state.view = saved; }
+		} catch (e) {}
+		gridBtn.addEventListener('click', function () { setView('grid'); });
+		listBtn.addEventListener('click', function () { setView('list'); });
+
+		/* ---- Matching --------------------------------------------------- */
+		function matches(el) {
+			var name = (el.getAttribute('data-name') || '');
+			var type = (el.getAttribute('data-type') || '');
+			var status = (el.getAttribute('data-status') || '');
+			if (state.search && name.indexOf(state.search) === -1) { return false; }
+			if (state.type && type !== state.type) { return false; }
+			if (state.status && status !== state.status) { return false; }
+			return true;
+		}
+
+		/* ---- Render with pagination ------------------------------------ */
+		function render() {
+			var items = state.view === 'list' ? rows : cards;
+			var matched = items.filter(matches);
+			var total = matched.length;
+			var pages = Math.max(1, Math.ceil(total / PER_PAGE));
+			if (state.page > pages) { state.page = pages; }
+			var start = (state.page - 1) * PER_PAGE;
+			var end = start + PER_PAGE;
+
+			items.forEach(function (el) { el.style.display = 'none'; });
+			matched.forEach(function (el, i) { if (i >= start && i < end) { el.style.display = ''; } });
+
+			if (emptyMsg) { emptyMsg.style.display = total === 0 ? 'block' : 'none'; }
+			renderPageInfo(total, start, end);
+			renderPageButtons(pages);
+		}
+		function renderPageInfo(total, start, end) {
+			if (!pageInfo) { return; }
+			if (total === 0) { pageInfo.textContent = '0 items'; return; }
+			pageInfo.textContent = 'Showing ' + (start + 1) + '-' + Math.min(end, total) + ' of ' + total + ' items';
+		}
+		function makeBtn(label, page, opts) {
+			opts = opts || {};
+			var btn = document.createElement('button');
+			btn.className = 'rbfw-page-btn' + (opts.active ? ' active' : '');
+			btn.innerHTML = label;
+			if (opts.disabled) { btn.disabled = true; }
+			else {
+				btn.addEventListener('click', function () {
+					state.page = page; render();
+					fleet.scrollIntoView({ behavior: 'smooth', block: 'start' });
+				});
+			}
+			return btn;
+		}
+		function renderPageButtons(pages) {
+			if (!pageBtns) { return; }
+			pageBtns.innerHTML = '';
+			if (pages <= 1) { return; }
+			pageBtns.appendChild(makeBtn('&#8249;', state.page - 1, { disabled: state.page === 1 }));
+			for (var p = 1; p <= pages; p++) {
+				pageBtns.appendChild(makeBtn(String(p), p, { active: p === state.page }));
+			}
+			pageBtns.appendChild(makeBtn('&#8250;', state.page + 1, { disabled: state.page === pages }));
+		}
+
+		function resetAndRender() { state.page = 1; render(); }
+
+		/* ---- Live search ------------------------------------------------ */
+		if (searchEl) {
+			var onSearch = function () {
+				state.search = searchEl.value.toLowerCase().trim();
+				if (searchBox) { searchBox.classList.toggle('has-value', searchEl.value.length > 0); }
+				resetAndRender();
+			};
+			searchEl.addEventListener('input', onSearch);
+			searchEl.addEventListener('search', onSearch);
+			if (searchBox) {
+				searchEl.addEventListener('focus', function () { searchBox.classList.add('is-focused'); });
+				searchEl.addEventListener('blur', function () { searchBox.classList.remove('is-focused'); });
+			}
+			if (clearBtn) {
+				clearBtn.addEventListener('click', function () { searchEl.value = ''; searchEl.focus(); onSearch(); });
+			}
+		}
+
+		/* ---- Custom styled dropdown (type filter) ---------------------- */
+		function buildDropdown(select) {
+			var options = Array.prototype.slice.call(select.options);
+			var wrap = document.createElement('div');
+			wrap.className = 'rbfw-dropdown';
+			var toggle = document.createElement('button');
+			toggle.type = 'button';
+			toggle.className = 'rbfw-dropdown-toggle';
+			toggle.setAttribute('aria-haspopup', 'listbox');
+			var label = document.createElement('span');
+			label.textContent = options[select.selectedIndex] ? options[select.selectedIndex].text : '';
+			var caret = document.createElement('span');
+			caret.className = 'rbfw-caret';
+			caret.innerHTML = '<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"/></svg>';
+			toggle.appendChild(label);
+			toggle.appendChild(caret);
+			var menu = document.createElement('div');
+			menu.className = 'rbfw-dropdown-menu';
+			menu.setAttribute('role', 'listbox');
+			var check = '<span class="rbfw-check"><svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.6" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></span>';
+			options.forEach(function (opt) {
+				var item = document.createElement('div');
+				item.className = 'rbfw-dropdown-option' + (opt.value === select.value ? ' selected' : '');
+				item.setAttribute('role', 'option');
+				item.innerHTML = '<span>' + opt.text + '</span>' + check;
+				item.addEventListener('click', function () {
+					select.value = opt.value;
+					label.textContent = opt.text;
+					menu.querySelectorAll('.rbfw-dropdown-option').forEach(function (o) { o.classList.remove('selected'); });
+					item.classList.add('selected');
+					wrap.classList.remove('open');
+					state.type = opt.value;
+					resetAndRender();
+				});
+				menu.appendChild(item);
+			});
+			toggle.addEventListener('click', function (e) { e.stopPropagation(); wrap.classList.toggle('open'); });
+			document.addEventListener('click', function (e) { if (!wrap.contains(e.target)) { wrap.classList.remove('open'); } });
+			document.addEventListener('keydown', function (e) { if (e.key === 'Escape') { wrap.classList.remove('open'); } });
+			wrap.appendChild(toggle);
+			wrap.appendChild(menu);
+			select.parentNode.insertBefore(wrap, select.nextSibling);
+		}
+		if (typeEl) { buildDropdown(typeEl); }
+
+		/* ---- Status tabs ------------------------------------------------ */
+		tabs.forEach(function (tab) {
+			tab.addEventListener('click', function () {
+				tabs.forEach(function (t) { t.classList.remove('active'); });
+				this.classList.add('active');
+				state.status = this.getAttribute('data-status') || '';
+				resetAndRender();
+			});
+		});
+
+		applyView();
+		render();
+	});
+})();


### PR DESCRIPTION


Introduce a modern, fully responsive admin screen for the rental items list (rbfw_item), gated behind a new global setting so it can be toggled on/off without affecting the classic WordPress list. Mirrors the design used for the bus fleet list.

New global setting
- "New Rental List Design" (Enable/Disable, default Enable) appended to the General Settings tab via the `rbfw_settings_field` filter.
- When enabled, edit.php?post_type=rbfw_item redirects to the new screen.
- When disabled, the classic WP list table is shown (no redirect), so the toggle works cleanly in both directions.

New design screen (admin/RBFW_Rental_List.php)
- Rendered on a hidden submenu page with full admin chrome; parent_file/ submenu_file filters keep the Rental menu highlighted and admin_title sets the browser tab title ("<Label> Items", or "Trash - <Label> Items").
- Stat cards: Total Items / Published / Draft / Categories.
- Card grid + table views populated from real post data: title, price type (rbfw_item_type -> rent-type label), rent type (rbfw_categories), price (daily/hourly rate formatted via wc_price), featured image (gradient fallback), author initials and status badge.
- Edit and Move-to-Trash actions per item (nonce-protected, confirm), revealed on card hover/focus.
- "Classic view" link (rbfw_view=classic) bypasses the redirect.

Trash management in the new design
- Trash tab shows trashed items inside the same styled layout instead of bouncing to the old list, with per-item Restore and Delete Permanently actions (nonce-protected). Counts always reflect the active items.

Separate assets (loaded only on this screen)
- assets/admin/rbfw_rental_list.css: scoped under .rbfw-fleet, responsive (4->2->1 stat columns, single-column grid, table collapses to stacked cards on mobile).
- assets/admin/rbfw_rental_list.js: persisted grid/list toggle, live search with clear button, custom styled rent-type dropdown, status tabs and client-side pagination (12/page).

The existing duplicate-post action in RBFW_Rental_List is preserved.