### PR TITLE
fix: front-end booking issues (time order, add-ons notice, calendar nav, extra-service UI)

### DIFF
--- a/admin/settings/Extra_Service.php
+++ b/admin/settings/Extra_Service.php
@@ -404,7 +404,7 @@
 									<table class='rbfw_pricing_table form-table w-100' id="repeatable-fieldset-one">
 										<thead>
 										<tr>
-											<th><?php // esc_html_e( 'Image', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+											<th><?php esc_html_e( 'Image', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
 											<th><?php esc_html_e( 'Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
 											<th><?php esc_html_e( 'Description', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
 											<th><?php echo wp_kses_post( 'Price <b class="required">*</b>' ); ?></th>
@@ -439,7 +439,7 @@
 																	<?php  endif; ?>
 																</div>
 																<div class="service_image_add_remove">
-																	<a class="rbfw_service_image_btn button"><i class="fas fa-circle-plus"></i></a><a class="rbfw_remove_service_image_btn btn"><i class="fas fa-circle-minus"></i></a>
+																	<a class="rbfw_service_image_btn button" title="<?php esc_attr_e( 'Upload image', 'booking-and-rental-manager-for-woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Upload image', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-image"></i></a><a class="rbfw_remove_service_image_btn btn" title="<?php esc_attr_e( 'Remove image', 'booking-and-rental-manager-for-woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Remove image', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-trash-can"></i></a>
 																	<input type="hidden" name="service_img[]" value="<?php echo esc_attr( $service_img ); ?>" class="rbfw_service_image"/>
 																</div>
 															</div>
@@ -465,7 +465,7 @@
 												<div class="rbfw_service_image_wrap text-center">
 													<div class="rbfw_service_image_preview"></div>
 													<div class="service_image_add_remove">
-														<a class="rbfw_service_image_btn button"><i class="fas fa-circle-plus"></i></a><a class="rbfw_remove_service_image_btn button"><i class="fas fa-circle-minus"></i></a>
+														<a class="rbfw_service_image_btn button" title="<?php esc_attr_e( 'Upload image', 'booking-and-rental-manager-for-woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Upload image', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-image"></i></a><a class="rbfw_remove_service_image_btn button" title="<?php esc_attr_e( 'Remove image', 'booking-and-rental-manager-for-woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Remove image', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-trash-can"></i></a>
 														<input type="hidden" name="service_img[]" value="" class="rbfw_service_image"/>
 													</div>
 												</div>

--- a/assets/mp_script/rbfw_script.js
+++ b/assets/mp_script/rbfw_script.js
@@ -195,6 +195,26 @@ function rbfw_off_day_dates(date,type='',today_enable='no',dropoff=null){
 }
 
 
+// Convert a time string ("10:00 am", "2:30 PM" or 24h "14:30") to minutes-of-day
+// so time options can be ordered clock-wise instead of by stored/string order.
+function rbfwTimeToMinutes(t) {
+    if (t === undefined || t === null) return 0;
+    var s = String(t).trim();
+    var ampm = s.match(/(am|pm)\s*$/i);
+    var clean = s.replace(/\s*(am|pm)\s*$/i, '').trim();
+    var parts = clean.split(':');
+    var h = parseInt(parts[0], 10);
+    var m = parseInt(parts[1], 10);
+    if (isNaN(h)) h = 0;
+    if (isNaN(m)) m = 0;
+    if (ampm) {
+        var mod = ampm[1].toLowerCase();
+        if (mod === 'pm' && h !== 12) h += 12;
+        if (mod === 'am' && h === 12) h = 0;
+    }
+    return h * 60 + m;
+}
+
 function getAvailableTimes(schedule, givenDate,rdfw_available_time,pickup_time_particular,is_calendar=null) {
 
     var rbfw_buffer_time = parseInt(jQuery("#rbfw_buffer_time").val());
@@ -227,6 +247,10 @@ function getAvailableTimes(schedule, givenDate,rdfw_available_time,pickup_time_p
     } catch (e) {
         rdfw_available_timeJson = [];
     }
+    // Order the general available times clock-wise.
+    rdfw_available_timeJson.sort(function (a, b) {
+        return rbfwTimeToMinutes(a && a.time) - rbfwTimeToMinutes(b && b.time);
+    });
     let  sapecific_date_time = false;
     let  time_enable = false;
     let past_time = ''
@@ -266,6 +290,10 @@ function getAvailableTimes(schedule, givenDate,rdfw_available_time,pickup_time_p
                 specific_available_time = [];
             }
 
+            // Order the date-specific available times clock-wise.
+            specific_available_time.sort(function (a, b) {
+                return rbfwTimeToMinutes(a && a.time) - rbfwTimeToMinutes(b && b.time);
+            });
 
             specific_available_time.forEach(timeObj => {
                 if (timeObj.status === "enabled") {

--- a/css/rbfw_style.css
+++ b/css/rbfw_style.css
@@ -5448,6 +5448,30 @@ color: #666;
     padding: 20px;
 }
 
+/* Calendar prev/next arrows must not inherit the day-cell's 20px padded highlight
+   (that made the hovered arrow balloon into a huge brand-coloured circle). Keep a
+   neat, fixed-size circular button on hover. */
+.single-rbfw_item .ui-datepicker .ui-datepicker-prev,
+.single-rbfw_item .ui-datepicker .ui-datepicker-next{
+    transition: background-color .2s ease, color .2s ease;
+}
+.single-rbfw_item .ui-datepicker .ui-datepicker-prev.ui-state-hover:hover,
+.single-rbfw_item .ui-datepicker .ui-datepicker-next.ui-state-hover:hover,
+.single-rbfw_item .ui-datepicker .ui-datepicker-prev:hover,
+.single-rbfw_item .ui-datepicker .ui-datepicker-next:hover{
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: 50%;
+    background: var(--rbfw_color_primary);
+    border: 1px solid var(--rbfw_color_primary);
+    color: #fff;
+}
+.single-rbfw_item .ui-datepicker .ui-datepicker-prev:hover::before,
+.single-rbfw_item .ui-datepicker .ui-datepicker-next:hover::before{
+    color: #fff;
+}
+
 .single-rbfw_item .rbfw_bikecarsd_book_now_btn_wrap button.mp_rbfw_book_now_submit.rbfw_disabled_button{
     background: var(--rbfw_color_primary);
     opacity: .35;

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -2470,13 +2470,15 @@ function rbfw_timely_available_quantity_updated( $post_id, $start_date, $start_t
 
 
                     }
-	
+
+					uksort( $the_array, function ( $a, $b ) { return strtotime( $a ) <=> strtotime( $b ); } );
+
 					return array( $the_array, $selector );
 				}
 			}
 
 		}
-		
+
 
         $rdfw_available_time = get_post_meta( $rbfw_id, 'rdfw_available_time', true ) ? maybe_unserialize( get_post_meta( $rbfw_id, 'rdfw_available_time', true ) ) : [];
 
@@ -2500,6 +2502,8 @@ function rbfw_timely_available_quantity_updated( $post_id, $start_date, $start_t
                 $the_array[ $start_time ] = array( $time_status, gmdate( get_option( 'time_format' ), strtotime( $start_time ) ) );
             }
         }
+
+		uksort( $the_array, function ( $a, $b ) { return strtotime( $a ) <=> strtotime( $b ); } );
 
 		return array( $the_array, $selector );
 	}

--- a/templates/forms/single-day-registration.php
+++ b/templates/forms/single-day-registration.php
@@ -271,6 +271,9 @@
                                     foreach ($rbfw_extra_service_data as $value) {
                                         $img_url = !empty($value['service_img']) ? wp_get_attachment_url($value['service_img']) : '';
                                         $uniq_id = wp_rand();
+                                        // Available qty defaults to the configured stock (no date is selected at
+                                        // initial render); avoids an undefined-variable warning in the notice below.
+                                        $max_es_available_qty = isset($value['service_qty']) ? $value['service_qty'] : 0;
                                         if ($img_url) {
                                             $img = '<a href="#rbfw_service_img_<?php echo $uniq_id ?>" rel="mage_modal:open"><img src="' . esc_url($img_url) . '"/></a>';
                                             $img .= '<div id="rbfw_service_img_' . $uniq_id . '" class="mage_modal"><img src="<?php echo esc_url($img_url) ?>"/></div>';


### PR DESCRIPTION


- Pickup Time now sorts clock-wise: add rbfwTimeToMinutes() + sort the date- specific and general time lists in getAvailableTimes() (handles 12h/24h); defensive uksort() in rbfw_get_available_times_particulars().
- Single-day add-ons: define $max_es_available_qty (configured stock) before the 'Available:' notice to remove an Undefined variable warning and blank value.
- Calendar prev/next: nav arrows no longer inherit the day-cell hover's 20px padding, which ballooned the hovered arrow into a huge brand-coloured circle; give them a neat fixed-size circular hover instead.
- Extra-service rows: add an 'Image' column header and use clear upload/remove icons with tooltips so the per-row image controls are understandable.