### PR TITLE
Fix 504 timeout when filtering the Rent List by multiple categories

### DIFF
--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -3396,6 +3396,54 @@ function rbfw_build_category_meta_clause( $category_name ) {
 	);
 }
 
+/**
+ * Build a SINGLE flat meta_query OR group matching any of the supplied
+ * category names against the rbfw_categories meta.
+ *
+ * PERF / 504 FIX: rbfw_build_category_meta_clause() returns a nested OR group
+ * per category. WP_Meta_Query only reuses a wp_postmeta JOIN between clauses
+ * that share the SAME immediate parent, so adding one nested group per selected
+ * category forced a separate self-JOIN on wp_postmeta for every category. With
+ * several categories selected (and leading-wildcard LIKEs that cannot use an
+ * index) the resulting multi-JOIN query was slow enough to exceed the
+ * nginx/php-fpm timeout, surfacing as a "504 Gateway Time-out" in the Elementor
+ * editor and on the front end.
+ *
+ * Flattening every leaf condition into one OR group that all share the
+ * rbfw_categories key lets WP_Meta_Query collapse them onto a single JOIN,
+ * regardless of how many categories are selected, while preserving the exact
+ * same matching (an item is shown when it belongs to ANY selected category).
+ *
+ * @param array|string $category_names One or more category display names.
+ * @return array Flat meta_query OR group, or array() when nothing is usable.
+ */
+function rbfw_build_categories_meta_clause( $category_names ) {
+	if ( ! is_array( $category_names ) ) {
+		$category_names = ( '' === $category_names || null === $category_names ) ? array() : array( $category_names );
+	}
+
+	$group = array( 'relation' => 'OR' );
+
+	foreach ( $category_names as $category_name ) {
+		$clause = rbfw_build_category_meta_clause( $category_name );
+		if ( empty( $clause ) ) {
+			continue;
+		}
+		// Merge the per-category leaf conditions up into the single flat OR
+		// group (dropping the nested 'relation' key) so every leaf shares one
+		// JOIN alias instead of forcing a JOIN per category.
+		foreach ( $clause as $clause_key => $leaf ) {
+			if ( 'relation' === $clause_key || ! is_array( $leaf ) ) {
+				continue;
+			}
+			$group[] = $leaf;
+		}
+	}
+
+	// Only return a usable group when at least one leaf was added.
+	return ( count( $group ) > 1 ) ? $group : array();
+}
+
 
 
 

--- a/inc/rbfw_shortcodes.php
+++ b/inc/rbfw_shortcodes.php
@@ -309,6 +309,7 @@ function rbfw_rent_list_shortcode_func($atts = null) {
 
         if(!empty($category)) {
             $category = array_filter( array_map( 'trim', explode( ',', $category ) ) );
+            $category_names = array();
             foreach ($category as $cat) {
                 $term = get_term( absint( $cat ) );
 
@@ -316,15 +317,18 @@ function rbfw_rent_list_shortcode_func($atts = null) {
                     continue;
                 }
 
-                $category_name = $term->name;
+                $category_name            = $term->name;
                 $base_filter_categories[] = $category_name;
-                // Match every storage format of rbfw_categories (serialized
-                // array / single string / comma separated) so the initial list
-                // is not empty when the meta is not a serialized array.
-                $category_clause = rbfw_build_category_meta_clause( $category_name );
-                if ( ! empty( $category_clause ) ) {
-                    $args['meta_query'][] = $category_clause;
-                }
+                $category_names[]         = $category_name;
+            }
+            // Match every storage format of rbfw_categories (serialized array /
+            // single string / comma separated) in ONE flat OR group so several
+            // selected categories share a single wp_postmeta JOIN instead of
+            // forcing one JOIN per category, which timed out (504 Gateway
+            // Time-out). See rbfw_build_categories_meta_clause().
+            $category_clause = rbfw_build_categories_meta_clause( $category_names );
+            if ( ! empty( $category_clause ) ) {
+                $args['meta_query'][] = $category_clause;
             }
         }
     }

--- a/lib/classes/class-search-page.php
+++ b/lib/classes/class-search-page.php
@@ -348,16 +348,16 @@
 				if ( ! is_array( $categories ) || count( $categories ) === 0 ) {
 					return '';
 				}
-				$group = array( 'relation' => 'OR' );
-				foreach ( $categories as $category_name ) {
-					$clause = rbfw_build_category_meta_clause( $category_name );
-					if ( ! empty( $clause ) ) {
-						$group[] = $clause;
-					}
-				}
+				// Flatten every selected category into ONE OR group so the query
+				// uses a single wp_postmeta JOIN regardless of how many
+				// categories are chosen. Building a nested group per category
+				// (the previous approach) forced a separate self-JOIN each, and
+				// the base + active category filters together were slow enough
+				// to hit the nginx/php-fpm timeout (504 Gateway Time-out).
+				$group = rbfw_build_categories_meta_clause( $categories );
 
 				// Only return a usable group when at least one clause was added.
-				return ( count( $group ) > 1 ) ? $group : '';
+				return ! empty( $group ) ? $group : '';
 			}
 
 			public function display_filter_rent_items( $post_id, $post_title, $the_content, $style, $d ) {

--- a/rent-manager.php
+++ b/rent-manager.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Booking and Rental Manager for Bike | Car | Resort | Appointment | Dress | Equipment
 	 * Plugin URI: https://mage-people.com
 	 * Description: A complete booking & rental solution for WordPress.
-	 * Version: 2.7.1
+	 * Version: 2.7.2
 	 * Author: MagePeople Team
 	 * Author URI: https://www.mage-people.com/
 	 * Text Domain: booking-and-rental-manager-for-woocommerce


### PR DESCRIPTION
Selecting several categories in the "Rent List" Elementor widget (and in the AJAX sidebar filter) caused a "504 Gateway Time-out" from nginx. The page only recovered once the slow query finished; it was a query-time explosion, not a crash or infinite loop.

Root cause
----------
Each selected category appended its OWN nested OR group to the WP_Query meta_query (via rbfw_build_category_meta_clause(), which returns 5 leading-wildcard LIKE/= patterns for the rbfw_categories meta). WP_Meta_Query only reuses a wp_postmeta JOIN between clauses that share the SAME immediate parent, so every nested group forced a separate self-JOIN on wp_postmeta.

N selected categories therefore produced N self-JOINs on wp_postmeta, each with non-indexable LIKE '%...%' conditions, combined with posts_per_page = -1. On the AJAX search page this compounded further because the base-category filter and the active-category filter each contributed their own per-category JOINs. On a live database the resulting multi-JOIN query exceeded the php-fpm/nginx timeout -> 504.

Fix
---
Flatten every category's leaf conditions into a SINGLE OR group that all share the rbfw_categories key. Because the leaves are now direct siblings with the same key and compatible compares (LIKE/=), WP_Meta_Query collapses them onto ONE JOIN regardless of how many categories are selected. Matching is unchanged: an item is shown when it belongs to ANY selected category, and all historical storage formats of rbfw_categories (serialized array / single string / comma separated) are still matched.

JOINs for the category filter go from O(categories) to O(1).

Changes
-------
- inc/rbfw_functions.php Add rbfw_build_categories_meta_clause() — builds one flat OR group from one or more category names by merging the per-category leaves (dropping the nested 'relation' key) into a single group.

- inc/rbfw_shortcodes.php rbfw_rent_list_shortcode_func(): collect the resolved category names first, then add ONE flat clause via rbfw_build_categories_meta_clause() instead of appending a nested group per category in the loop.

- lib/classes/class-search-page.php rbfw_build_categories_meta_query(): delegate to the shared flat builder so the AJAX sidebar filter benefits from the same single-JOIN collapse.

- rent-manager.php Bump plugin version 2.7.1 -> 2.7.2 for this release.

Notes
-----
The deliberate meta-LIKE matching is preserved (not switched to tax_query) to avoid regressing older items that have the rbfw_categories meta but lack clean rbfw_item_caregory taxonomy assignments. A future tax_query migration could be faster still once term assignments are confirmed consistent.

Validation
----------
- php -l clean on all changed files.
- Structural check: 4 categories drop from 4 nested groups (~4 JOINs) to one flat OR group of 20 sibling leaves (1 JOIN); relation preserved as OR.
- No change to input handling/escaping (values still resolved via get_term() and sanitize_text_field(), bound by WP_Query/$wpdb).