### PR TITLE
Add Inventory section to the modern rental-item editor (fix missing UI + data loss)

### DIFF
--- a/admin/css/rbfw-modern-editor.css
+++ b/admin/css/rbfw-modern-editor.css
@@ -3974,6 +3974,209 @@ body.rtl.rbfw-modern-editor-screen .rbfw-me-step-nav {
     margin-bottom: 12px !important;
 }
 
+/* ════════════════════════════════════════════════════════════════════════
+   Inventory card (reused classic markup) — match the modern editor's field
+   spacing. The generic `.rbfw-me-pricing-classic-wrap section:not(…)` rule
+   forces padding:0 with high specificity, so the padding override below
+   replicates that :not() chain (plus the .rbfw-me-inventory-card scope) to
+   win, while the layout/control rules stay scoped to this card only.
+   ════════════════════════════════════════════════════════════════════════ */
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section:not(.bg-light):not(.rent-type-area):not(.category-wise-service):not(.service_category_title):not(.particulare-date-time-slot):not(.manage_inventory_as_timely):not(.rbfw_item_quantiry_duration):not(.appointment-onday) {
+    padding: 16px 20px !important;
+    margin: 0 !important;
+}
+/* Toggle / stock rows: title + helper on the left, control on the right */
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section:not(.rbfw_variations_table_wrap) {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    gap: 20px !important;
+}
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section > div:first-child {
+    flex: 1 1 auto !important;
+    min-width: 0 !important;
+}
+/* Stock quantity — modern input, right aligned */
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap .item_stock_quantity {
+    flex: 0 0 auto !important;
+    margin: 0 !important;
+}
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap .item_stock_quantity input {
+    width: 160px !important;
+    max-width: 100% !important;
+    height: 40px !important;
+    padding: 8px 12px !important;
+    border: 1px solid #d5d8df !important;
+    border-radius: 8px !important;
+    background: #fff !important;
+    font-size: 14px !important;
+    color: #1d2327 !important;
+    box-shadow: none !important;
+    margin: 0 !important;
+}
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap .item_stock_quantity input:focus {
+    border-color: #1a56db !important;
+    box-shadow: 0 0 0 3px rgba(26,86,219,.12) !important;
+    outline: none !important;
+}
+/* Variation rows table spans full width below the toggles */
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_variations_table_wrap.show {
+    display: block !important;
+}
+.rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_variations_table_wrap.hide {
+    display: none !important;
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   Variations builder (inside the inventory card) — modern, card-per-variation
+   layout with styled inputs, value table and action buttons.
+   ════════════════════════════════════════════════════════════════════════ */
+.rbfw-me-inventory-card .rbfw_variations_table {
+    width: 100% !important;
+    margin: 0 0 14px !important;
+}
+/* Each variation = a bordered sub-card */
+.rbfw-me-inventory-card .rbfw_variations_table_row {
+    position: relative !important;
+    border: 1px solid #e2e6ee !important;
+    border-radius: 10px !important;
+    background: #fff !important;
+    padding: 16px !important;
+    margin: 0 0 14px !important;
+}
+/* Field Label header */
+.rbfw-me-inventory-card .rbfw_variations_table_row > header {
+    display: block !important;
+    margin: 0 0 14px !important;
+    padding-right: 48px !important; /* room for the remove-variation button */
+}
+.rbfw-me-inventory-card .rbfw_variations_table_row > header > label {
+    display: block !important;
+    font-size: 13px !important;
+    font-weight: 600 !important;
+    color: #1d2327 !important;
+    margin: 0 0 6px !important;
+}
+.rbfw-me-inventory-card .rbfw_variations_table_row > header > div > input[type="text"] {
+    width: 100% !important;
+    height: 40px !important;
+    padding: 8px 12px !important;
+    border: 1px solid #d5d8df !important;
+    border-radius: 8px !important;
+    background: #fff !important;
+    font-size: 14px !important;
+    box-shadow: none !important;
+    margin: 0 !important;
+}
+/* Value table */
+.rbfw-me-inventory-card .rbfw_variations_value_table {
+    width: 100% !important;
+    border-collapse: separate !important;
+    border-spacing: 0 !important;
+    margin: 0 !important;
+    background: transparent !important;
+}
+.rbfw-me-inventory-card .rbfw_variations_value_table thead th {
+    text-align: left !important;
+    font-size: 12px !important;
+    font-weight: 600 !important;
+    color: #6b7280 !important;
+    padding: 6px 10px !important;
+    border: none !important;
+    background: transparent !important;
+}
+.rbfw-me-inventory-card .rbfw_variations_value_table tbody td {
+    padding: 6px 10px !important;
+    border: none !important;
+    vertical-align: middle !important;
+    background: transparent !important;
+}
+.rbfw-me-inventory-card .rbfw_variations_value_table td input[type="text"],
+.rbfw-me-inventory-card .rbfw_variations_value_table td input[type="number"] {
+    width: 100% !important;
+    height: 38px !important;
+    padding: 8px 12px !important;
+    border: 1px solid #d5d8df !important;
+    border-radius: 8px !important;
+    background: #fff !important;
+    font-size: 14px !important;
+    box-shadow: none !important;
+    margin: 0 !important;
+}
+.rbfw-me-inventory-card .rbfw_variations_value_table td input:focus,
+.rbfw-me-inventory-card .rbfw_variations_table_row > header input:focus {
+    border-color: #1a56db !important;
+    box-shadow: 0 0 0 3px rgba(26,86,219,.12) !important;
+    outline: none !important;
+}
+/* "Is Default" column — centre the checkbox */
+.rbfw-me-inventory-card .rbfw_variations_value_table th:nth-child(3),
+.rbfw-me-inventory-card .rbfw_variations_value_table td:nth-child(3) {
+    text-align: center !important;
+    width: 90px !important;
+}
+.rbfw-me-inventory-card .rbfw_variation_selected_value {
+    width: 18px !important;
+    height: 18px !important;
+    margin: 0 !important;
+    cursor: pointer !important;
+}
+.rbfw-me-inventory-card .rbfw_variations_value_table th:nth-child(4),
+.rbfw-me-inventory-card .rbfw_variations_value_table td:nth-child(4) {
+    width: 90px !important;
+}
+/* Action icon buttons (trash / move) */
+.rbfw-me-inventory-card .mp_event_remove_move {
+    display: inline-flex !important;
+    gap: 6px !important;
+    align-items: center !important;
+}
+.rbfw-me-inventory-card .mp_event_remove_move .button,
+.rbfw-me-inventory-card .remove-rbfw_variations_table_row {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 34px !important;
+    height: 34px !important;
+    min-height: 0 !important;
+    padding: 0 !important;
+    border: 1px solid #e2e6ee !important;
+    border-radius: 8px !important;
+    background: #fff !important;
+    color: #6b7280 !important;
+    cursor: pointer !important;
+    transition: border-color .15s, color .15s, background .15s !important;
+}
+.rbfw-me-inventory-card .mp_event_remove_move .button:hover {
+    border-color: #1a56db !important;
+    color: #1a56db !important;
+    background: #f4f7fe !important;
+}
+.rbfw-me-inventory-card .remove-rbfw_variations_value_table_row:hover,
+.rbfw-me-inventory-card .remove-rbfw_variations_table_row:hover {
+    border-color: #dc2626 !important;
+    color: #dc2626 !important;
+    background: #fef2f2 !important;
+}
+/* Remove-whole-variation button — pin to the card's top-right corner */
+.rbfw-me-inventory-card .rbfw_variations_table_row > .mp_event_remove_move {
+    position: absolute !important;
+    top: 14px !important;
+    right: 14px !important;
+}
+/* Divider + add buttons spacing */
+.rbfw-me-inventory-card .variations-inner-table hr {
+    border: none !important;
+    border-top: 1px solid #f0f0f1 !important;
+    margin: 12px 0 !important;
+}
+.rbfw-me-inventory-card .add-new-variation-value {
+    margin-top: 4px !important;
+}
+.rbfw-me-inventory-card #add-new-variation {
+    margin-top: 4px !important;
+}
+
 .rbfw-me-pricing-classic-wrap .rbfw_time_inventory.rbfw_item_stock_quantity section.rbfw_item_quantiry_duration {
     display: flex !important;
     align-items: center !important;

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -1743,6 +1743,11 @@
                 $pricing.find('.mds_price_md').show();
             }
 
+            // Inventory card (stock + variations): mirror the classic editor, which
+            // hides inventory for resort / bike_car_sd / appointment.
+            var _invShow = (type !== 'resort' && type !== 'bike_car_sd' && type !== 'appointment');
+            $pricing.find('.rbfw-me-inventory-card').toggleClass('rbfw-me-hidden', !_invShow);
+
             if (typeof window.rbfwMdsSyncPanelForRentType === 'function') {
                 window.rbfwMdsSyncPanelForRentType(type, $pricing);
             }

--- a/admin/settings/Inventory.php
+++ b/admin/settings/Inventory.php
@@ -270,6 +270,30 @@
 				<?php
 			}
 
+			/**
+			 * Render the Inventory section for the modern editor.
+			 *
+			 * Mirrors the RBFW_Pricing / RBFW_Off_Day reuse pattern: the modern
+			 * editor lacked any inventory UI, so its AJAX save read empty values
+			 * and silently reset stock to 1000, disabled variations and wiped the
+			 * variation rows on every save. Reusing the existing classic render
+			 * methods (via a constructor-less instance, so no hooks re-register)
+			 * surfaces the exact same fields/markup the save handler expects, and
+			 * the already-loaded mkb-admin.js drives the variations repeater and
+			 * the enable/return-date toggles unchanged.
+			 *
+			 * @param int $post_id Current rental item ID.
+			 * @return void
+			 */
+			public static function render_for_modern_editor( int $post_id ): void {
+				$renderer = ( new \ReflectionClass( static::class ) )->newInstanceWithoutConstructor();
+				$renderer->stock_settings( $post_id );
+				$renderer->stock_manage_return_date( $post_id );
+				$renderer->quantity_box_toggle( $post_id );
+				$renderer->variation_table_switch_on_off( $post_id );
+				$renderer->variation_settings( $post_id );
+			}
+
 			public function add_tabs_content( $post_id ) {
 				$rbfw_item_type = get_post_meta( $post_id, 'rbfw_item_type', true ) ? get_post_meta( $post_id, 'rbfw_item_type', true ) : '';
 				?>

--- a/admin/views/rbfw-modern-editor.php
+++ b/admin/views/rbfw-modern-editor.php
@@ -317,6 +317,25 @@
 				</div>
 				<?php endif; ?>
 
+				<?php
+				// Inventory (stock quantity + variations). The classic editor hides this
+				// for resort / bike_car_sd / appointment; mirror that here, with applyType()
+				// in the JS keeping it in sync when the rental type is changed live.
+				if ( class_exists( 'RBFW_Inventory' ) ) :
+					$rbfw_me_inv_type   = get_post_meta( $post_id, 'rbfw_item_type', true ) ?: 'bike_car_sd';
+					$rbfw_me_inv_hidden = in_array( $rbfw_me_inv_type, [ 'resort', 'bike_car_sd', 'appointment' ], true );
+				?>
+				<div class="rbfw-me-card rbfw-me-inventory-card<?php echo $rbfw_me_inv_hidden ? ' rbfw-me-hidden' : ''; ?>">
+					<div class="rbfw-me-card__head">
+						<h2><?php esc_html_e( 'Inventory', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+						<p><?php esc_html_e( 'Manage stock quantity, return-date availability and item variations.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+					</div>
+					<div class="rbfw-me-card__body rbfw-me-pricing-classic-wrap">
+						<?php RBFW_Inventory::render_for_modern_editor( $post_id ); ?>
+					</div>
+				</div>
+				<?php endif; ?>
+
 				<div class="rbfw-me-card">
 					<div class="rbfw-me-card__head">
 						<h2><?php esc_html_e( 'Fee Management', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>


### PR DESCRIPTION


The classic editor shows an Inventory tab (stock quantity, inventory-by-return-date, multiple-item toggle, item variations), but the modern editor rendered no inventory UI at all.

Root cause / impact
-------------------
The modern editor's AJAX save already reads the inventory fields (RBFW_Modern_Editor::ajax_save reads rbfw_item_stock_quantity, stock_manage_on_return_date, rbfw_enable_variations, rbfw_variations_data), but the view never rendered those inputs. Because collectFormData() only serialises inputs present in the form, the values were never posted, so EVERY modern-editor save:
  - reset rbfw_item_stock_quantity to 1000,
  - forced rbfw_enable_variations to 'no',
  - cleared rbfw_variations_data. So this was not just a missing UI — it silently wiped inventory data on every save.

Fix
---
Reuse the existing classic RBFW_Inventory render via the established render_for_modern_editor() pattern (same approach as RBFW_Pricing / RBFW_Off_Day / RBFW_Fee_Management), surfacing the exact fields the save handler expects. The already-loaded mkb-admin.js (a declared dependency of the modern editor script) drives the variations repeater and the enable/return-date toggles unchanged, so no behaviour is duplicated or re-implemented.

Changes
-------
- admin/settings/Inventory.php Add `public static function render_for_modern_editor( int $post_id )` that renders the inventory fields by calling the existing instance methods on a constructor-less reflection instance (so the class hooks are not re-registered).

- admin/views/rbfw-modern-editor.php Render an "Inventory" card in the Pricing step (wrapped in .rbfw-me-pricing-classic-wrap for modern restyling). Mirrors the classic visibility rule: hidden for resort / bike_car_sd / appointment.

- admin/js/rbfw-modern-editor.js In applyType(), toggle the inventory card when the rental type is changed live, so it stays in sync with the classic show/hide behaviour.

- admin/css/rbfw-modern-editor.css Style the reused classic markup to match the modern editor (scoped entirely to .rbfw-me-inventory-card so the Pricing panel is untouched):
    * Re-pad each row and lay it out info-left / control-right (overrides the generic `.rbfw-me-pricing-classic-wrap section:not(...)` padding:0 rule by replicating its :not() chain plus the inventory scope to win on specificity).
    * Modern stock-quantity input.
    * Variations builder: a bordered sub-card per variation, styled Field Label + value-table inputs, centred "Is Default" checkbox, uniform 34px trash/move action buttons, and the remove-variation button pinned to the card corner.

Notes
-----
- No change to the save logic or to the classic editor; field names and matching semantics are unchanged, so data round-trips identically to the classic tab.
- Inventory was placed as a card in the Pricing step (not a new wizard tab) to keep the change surgical (no tab-array / step-navigation changes).

Validation
----------
- php -l clean on the changed PHP files; node --check clean on the JS.
- CSS brace balance verified; all new rules scoped under .rbfw-me-inventory-card.
- No field-name collision with the Pricing timely-stock field (rbfw_item_stock_quantity_timely vs rbfw_item_stock_quantity).