### PR TITLE
Add Location Configuration to the modern editor + inline location CRUD (both editors)

### DIFF
--- a/admin/RBFW_Modern_Editor.php
+++ b/admin/RBFW_Modern_Editor.php
@@ -749,6 +749,32 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 			}
 			update_post_meta( $post_id, 'rbfw_offday_range', $off_schedules );
 
+			/* ── Location (pick-up / drop-off) ──
+			 * Enable flags plus the selected location slugs (posted as a hidden,
+			 * comma-separated value). Stored in the same shape the classic editor
+			 * and the front end expect: array( array( 'loc_pickup_name' => slug ) ). */
+			$enable_pick = ( isset( $_POST['rbfw_enable_pick_point'] ) && $_POST['rbfw_enable_pick_point'] === 'yes' ) ? 'yes' : 'no';
+			update_post_meta( $post_id, 'rbfw_enable_pick_point', $enable_pick );
+
+			$enable_dropoff = ( isset( $_POST['rbfw_enable_dropoff_point'] ) && $_POST['rbfw_enable_dropoff_point'] === 'yes' ) ? 'yes' : 'no';
+			update_post_meta( $post_id, 'rbfw_enable_dropoff_point', $enable_dropoff );
+
+			$pickup_csv   = isset( $_POST['rbfw_pickup_locations'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_pickup_locations'] ) ) : '';
+			$pickup_slugs = array_filter( array_map( 'sanitize_title', array_map( 'trim', explode( ',', $pickup_csv ) ) ) );
+			$pickup_data  = [];
+			foreach ( array_values( $pickup_slugs ) as $slug ) {
+				$pickup_data[] = [ 'loc_pickup_name' => $slug ];
+			}
+			update_post_meta( $post_id, 'rbfw_pickup_data', $pickup_data );
+
+			$dropoff_csv   = isset( $_POST['rbfw_dropoff_locations'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_dropoff_locations'] ) ) : '';
+			$dropoff_slugs = array_filter( array_map( 'sanitize_title', array_map( 'trim', explode( ',', $dropoff_csv ) ) ) );
+			$dropoff_data  = [];
+			foreach ( array_values( $dropoff_slugs ) as $slug ) {
+				$dropoff_data[] = [ 'loc_dropoff_name' => $slug ];
+			}
+			update_post_meta( $post_id, 'rbfw_dropoff_data', $dropoff_data );
+
 			/* Categories (taxonomy) */
 			if ( isset( $_POST['rbfw_categories'] ) ) {
 				$cats = RBFW_Function::data_sanitize( wp_unslash( $_POST['rbfw_categories'] ) );

--- a/admin/css/rbfw-modern-editor.css
+++ b/admin/css/rbfw-modern-editor.css
@@ -4177,6 +4177,138 @@ body.rtl.rbfw-modern-editor-screen .rbfw-me-step-nav {
     margin-top: 4px !important;
 }
 
+/* ════════════════════════════════════════════════════════════════════════
+   Location card (modern) — pick-up / drop-off location checkbox groups.
+   ════════════════════════════════════════════════════════════════════════ */
+.rbfw-me-location-card .rbfw-me-loc-group {
+    padding: 4px 0 14px !important;
+    margin: 0 0 6px !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-checkboxes {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    gap: 8px 10px !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-label {
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 8px !important;
+    padding: 8px 12px !important;
+    border: 1px solid #d5d8df !important;
+    border-radius: 8px !important;
+    background: #fff !important;
+    font-size: 13px !important;
+    color: #1d2327 !important;
+    cursor: pointer !important;
+    transition: border-color .15s, background .15s !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-label:hover {
+    border-color: #1a56db !important;
+    background: #f4f7fe !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-checkbox {
+    width: 16px !important;
+    height: 16px !important;
+    margin: 0 !important;
+    cursor: pointer !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-empty {
+    margin: 0 !important;
+    font-size: 13px !important;
+    color: #6b7280 !important;
+}
+
+/* Manage locations (add / rename / delete taxonomy terms inline) */
+.rbfw-me-location-card .rbfw-me-loc-manage {
+    border: 1px solid #e2e6ee !important;
+    border-radius: 10px !important;
+    background: #f9fafc !important;
+    padding: 16px !important;
+    margin: 0 0 18px !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-manage__head {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 2px !important;
+    margin: 0 0 12px !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-manage__head strong {
+    font-size: 14px !important;
+    color: #1d2327 !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-manage__add {
+    display: flex !important;
+    gap: 8px !important;
+    margin: 0 0 12px !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-new {
+    flex: 1 1 auto !important;
+    height: 40px !important;
+    padding: 8px 12px !important;
+    border: 1px solid #d5d8df !important;
+    border-radius: 8px !important;
+    background: #fff !important;
+    font-size: 14px !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-add-btn {
+    flex: 0 0 auto !important;
+    white-space: nowrap !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-list {
+    list-style: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 6px !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-row {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    gap: 10px !important;
+    padding: 8px 12px !important;
+    border: 1px solid #e2e6ee !important;
+    border-radius: 8px !important;
+    background: #fff !important;
+    margin: 0 !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-row__name {
+    font-size: 13px !important;
+    color: #1d2327 !important;
+    word-break: break-word !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-row__actions {
+    display: inline-flex !important;
+    gap: 6px !important;
+    flex: 0 0 auto !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-edit,
+.rbfw-me-location-card .rbfw-me-loc-delete {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 30px !important;
+    height: 30px !important;
+    padding: 0 !important;
+    border: 1px solid #e2e6ee !important;
+    border-radius: 7px !important;
+    background: #fff !important;
+    color: #6b7280 !important;
+    cursor: pointer !important;
+    transition: border-color .15s, color .15s, background .15s !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-edit:hover {
+    border-color: #1a56db !important;
+    color: #1a56db !important;
+    background: #f4f7fe !important;
+}
+.rbfw-me-location-card .rbfw-me-loc-delete:hover {
+    border-color: #dc2626 !important;
+    color: #dc2626 !important;
+    background: #fef2f2 !important;
+}
+
 .rbfw-me-pricing-classic-wrap .rbfw_time_inventory.rbfw_item_stock_quantity section.rbfw_item_quantiry_duration {
     display: flex !important;
     align-items: center !important;

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -184,6 +184,124 @@
             }
         });
 
+        // Location pick-up / drop-off: mirror the checkbox group into a hidden
+        // comma-separated value (one hidden input per .rbfw-me-loc-group) that
+        // the modern AJAX save reads.
+        $wrap.on('change', '.rbfw-me-loc-checkbox', function () {
+            var $group = $(this).closest('.rbfw-me-loc-group');
+            var selected = [];
+            $group.find('.rbfw-me-loc-checkbox:checked').each(function () {
+                selected.push($(this).data('loc'));
+            });
+            $group.find('.rbfw-me-loc-hidden').val(selected.join(','));
+        });
+
+        /* ── Inline location CRUD (add / rename / delete taxonomy terms) ── */
+        function locEsc(s) { return $('<div>').text(s == null ? '' : String(s)).html(); }
+
+        function locAjax(action, data, $manage, cb) {
+            data.action = action;
+            data.nonce  = $manage.data('nonce');
+            $.post(window.ajaxurl, data, function (resp) {
+                if (resp && resp.success) {
+                    rebuildLocations(resp.data.locations);
+                    if (cb) cb();
+                } else {
+                    window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                }
+            }).fail(function () { window.alert('Request failed.'); });
+        }
+
+        // Rebuild the manage list + every pick-up/drop-off checkbox group from the
+        // authoritative location list returned by the server, preserving the
+        // current per-item selection (and dropping any deleted values).
+        function rebuildLocations(locations) {
+            locations = locations || [];
+            var $list = $wrap.find('.rbfw-me-loc-list').empty();
+            locations.forEach(function (loc) {
+                $list.append(
+                    '<li class="rbfw-me-loc-row" data-term-id="' + loc.term_id + '" data-value="' + locEsc(loc.value) + '">' +
+                        '<span class="rbfw-me-loc-row__name">' + locEsc(loc.name) + '</span>' +
+                        '<span class="rbfw-me-loc-row__actions">' +
+                            '<button type="button" class="rbfw-me-loc-edit" title="Rename"><i class="fas fa-pen" aria-hidden="true"></i></button>' +
+                            '<button type="button" class="rbfw-me-loc-delete" title="Delete"><i class="fas fa-trash-can" aria-hidden="true"></i></button>' +
+                        '</span>' +
+                    '</li>'
+                );
+            });
+
+            $wrap.find('.rbfw-me-loc-group').each(function () {
+                var $group  = $(this);
+                var current = ($group.find('.rbfw-me-loc-hidden').val() || '').split(',').filter(Boolean);
+                var values  = [];
+                var $cb     = $group.find('.rbfw-me-loc-checkboxes').empty();
+                locations.forEach(function (loc) {
+                    values.push(loc.value);
+                    var checked = current.indexOf(loc.value) !== -1 ? ' checked' : '';
+                    $cb.append(
+                        '<label class="rbfw-me-loc-label">' +
+                            '<input type="checkbox" class="rbfw-me-loc-checkbox" data-loc="' + locEsc(loc.value) + '"' + checked + ' />' +
+                            '<span>' + locEsc(loc.name) + '</span>' +
+                        '</label>'
+                    );
+                });
+                // Keep the hidden CSV in sync (remove values whose location is gone).
+                $group.find('.rbfw-me-loc-hidden').val(current.filter(function (v) { return values.indexOf(v) !== -1; }).join(','));
+                $group.find('.rbfw-me-loc-empty').toggleClass('rbfw-me-hidden', locations.length > 0);
+            });
+        }
+
+        $wrap.on('click', '.rbfw-me-loc-add-btn', function () {
+            var $manage = $(this).closest('.rbfw-me-loc-manage');
+            var $input  = $manage.find('.rbfw-me-loc-new');
+            var name    = $.trim($input.val());
+            if (! name) { $input.trigger('focus'); return; }
+            locAjax('rbfw_location_add', { name: name }, $manage, function () { $input.val(''); });
+        });
+
+        $wrap.on('keypress', '.rbfw-me-loc-new', function (e) {
+            if (e.which === 13) {
+                e.preventDefault();
+                $(this).closest('.rbfw-me-loc-manage').find('.rbfw-me-loc-add-btn').trigger('click');
+            }
+        });
+
+        // Edit → open the rename modal (no browser prompt).
+        $wrap.on('click', '.rbfw-me-loc-edit', function () {
+            var $row   = $(this).closest('.rbfw-me-loc-row');
+            var $modal = $wrap.find('#rbfw-me-loc-modal');
+            $modal.find('#rbfw-me-loc-modal-term-id').val($row.data('term-id'));
+            $modal.find('#rbfw-me-loc-modal-input').val($row.find('.rbfw-me-loc-row__name').text());
+            $modal.addClass('is-open');
+            setTimeout(function () { $modal.find('#rbfw-me-loc-modal-input').trigger('focus').select(); }, 50);
+        });
+
+        $wrap.on('click', '#rbfw-me-loc-modal .rbfw-me-faq-modal__close, #rbfw-me-loc-modal .rbfw-me-faq-modal__backdrop', function () {
+            $wrap.find('#rbfw-me-loc-modal').removeClass('is-open');
+        });
+
+        $wrap.on('click', '#rbfw-me-loc-modal-save', function () {
+            var $modal  = $wrap.find('#rbfw-me-loc-modal');
+            var $manage = $wrap.find('.rbfw-me-loc-manage');
+            var termId  = $modal.find('#rbfw-me-loc-modal-term-id').val();
+            var name    = $.trim($modal.find('#rbfw-me-loc-modal-input').val());
+            if (! name) { $modal.find('#rbfw-me-loc-modal-input').trigger('focus'); return; }
+            locAjax('rbfw_location_update', { term_id: termId, name: name }, $manage, function () {
+                $modal.removeClass('is-open');
+            });
+        });
+
+        $wrap.on('keypress', '#rbfw-me-loc-modal-input', function (e) {
+            if (e.which === 13) { e.preventDefault(); $wrap.find('#rbfw-me-loc-modal-save').trigger('click'); }
+        });
+
+        $wrap.on('click', '.rbfw-me-loc-delete', function () {
+            var $row    = $(this).closest('.rbfw-me-loc-row');
+            var $manage = $(this).closest('.rbfw-me-loc-manage');
+            if (! window.confirm('Delete this location? Items using it will no longer reference it.')) return;
+            locAjax('rbfw_location_delete', { term_id: $row.data('term-id') }, $manage);
+        });
+
         // Old-style toggle: value attribute stores DB state ('on'/'off'); sync it then
         // delegate all show/hide to syncTimelyUI scoped to the containing panel.
         // stopPropagation prevents rbfw-admin-input.js (loaded globally) from reading
@@ -1747,6 +1865,11 @@
             // hides inventory for resort / bike_car_sd / appointment.
             var _invShow = (type !== 'resort' && type !== 'bike_car_sd' && type !== 'appointment');
             $pricing.find('.rbfw-me-inventory-card').toggleClass('rbfw-me-hidden', !_invShow);
+
+            // Location card (Advanced step): mirror the classic editor, which hides
+            // the Location tab for resort / appointment.
+            var _locShow = (type !== 'resort' && type !== 'appointment');
+            $wrap.find('.rbfw-me-location-card').toggleClass('rbfw-me-hidden', !_locShow);
 
             if (typeof window.rbfwMdsSyncPanelForRentType === 'function') {
                 window.rbfwMdsSyncPanelForRentType(type, $pricing);

--- a/admin/settings/Location.php
+++ b/admin/settings/Location.php
@@ -11,6 +11,81 @@
 				add_action( 'rbfw_meta_box_tab_name', [ $this, 'add_tab_menu' ] );
 				add_action( 'rbfw_meta_box_tab_content', [ $this, 'add_tabs_content' ] );
 				add_action( 'save_post', array( $this, 'settings_save' ), 99, 1 );
+				// Inline location (taxonomy term) CRUD — shared by the classic and
+				// modern editors so locations can be managed without leaving the page.
+				add_action( 'wp_ajax_rbfw_location_add',    [ $this, 'ajax_location_add' ] );
+				add_action( 'wp_ajax_rbfw_location_update', [ $this, 'ajax_location_update' ] );
+				add_action( 'wp_ajax_rbfw_location_delete', [ $this, 'ajax_location_delete' ] );
+			}
+
+			/**
+			 * Return every location as a flat list. `value` is sanitize_title( name ),
+			 * the identity the render + save use throughout (NOT the raw term slug),
+			 * so the JS that rebuilds checkboxes/options keys on the same value.
+			 *
+			 * @return array[] List of [ term_id, name, value ].
+			 */
+			public function rbfw_get_location_list() {
+				$terms = get_terms( array( 'taxonomy' => 'rbfw_item_location', 'hide_empty' => false ) );
+				$out   = array();
+				if ( ! is_wp_error( $terms ) ) {
+					foreach ( $terms as $term ) {
+						$out[] = array(
+							'term_id' => (int) $term->term_id,
+							'name'    => $term->name,
+							'value'   => sanitize_title( $term->name ),
+						);
+					}
+				}
+				return $out;
+			}
+
+			/** Shared guard for the location CRUD endpoints. */
+			private function rbfw_location_crud_guard() {
+				check_ajax_referer( 'rbfw_location_crud', 'nonce' );
+				if ( ! current_user_can( 'manage_categories' ) ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+				}
+			}
+
+			public function ajax_location_add() {
+				$this->rbfw_location_crud_guard();
+				$name = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+				if ( '' === $name ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Please enter a location name.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$res = wp_insert_term( $name, 'rbfw_item_location' );
+				if ( is_wp_error( $res ) ) {
+					wp_send_json_error( array( 'message' => $res->get_error_message() ) );
+				}
+				wp_send_json_success( array( 'locations' => $this->rbfw_get_location_list() ) );
+			}
+
+			public function ajax_location_update() {
+				$this->rbfw_location_crud_guard();
+				$term_id = isset( $_POST['term_id'] ) ? absint( $_POST['term_id'] ) : 0;
+				$name    = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+				if ( ! $term_id || '' === $name ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Invalid location.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$res = wp_update_term( $term_id, 'rbfw_item_location', array( 'name' => $name ) );
+				if ( is_wp_error( $res ) ) {
+					wp_send_json_error( array( 'message' => $res->get_error_message() ) );
+				}
+				wp_send_json_success( array( 'locations' => $this->rbfw_get_location_list() ) );
+			}
+
+			public function ajax_location_delete() {
+				$this->rbfw_location_crud_guard();
+				$term_id = isset( $_POST['term_id'] ) ? absint( $_POST['term_id'] ) : 0;
+				if ( ! $term_id ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Invalid location.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$res = wp_delete_term( $term_id, 'rbfw_item_location' );
+				if ( is_wp_error( $res ) ) {
+					wp_send_json_error( array( 'message' => $res->get_error_message() ) );
+				}
+				wp_send_json_success( array( 'locations' => $this->rbfw_get_location_list() ) );
 			}
 
 			public function add_tab_menu($rbfw_id) {
@@ -147,10 +222,178 @@
 				<?php
 			}
 
+			/**
+			 * Render the Location Configuration for the modern editor.
+			 *
+			 * Mirrors the RBFW_Off_Day modern pattern: the modern editor had no
+			 * location UI, and its AJAX save only stored the pick-up toggle (never
+			 * the drop-off toggle or the pick-up/drop-off location data). Rather
+			 * than reuse the classic markup (which hard-codes select2 + an inline
+			 * toggle script), this renders clean modern markup — the existing
+			 * reveal-toggle component plus a checkbox group backed by a hidden
+			 * comma-separated value (the same approach as Off Days / Categories,
+			 * which collectFormData() serialises reliably).
+			 *
+			 * @param int $post_id Current rental item ID.
+			 * @return void
+			 */
+			public static function render_for_modern_editor( int $post_id ): void {
+				$renderer      = ( new \ReflectionClass( static::class ) )->newInstanceWithoutConstructor();
+				$locations     = $renderer->rbfw_get_location_list();
+				$pickup_data   = get_post_meta( $post_id, 'rbfw_pickup_data', true );
+				$dropoff_data  = get_post_meta( $post_id, 'rbfw_dropoff_data', true );
+				$pickup_slugs  = is_array( $pickup_data ) ? array_filter( (array) wp_list_pluck( $pickup_data, 'loc_pickup_name' ) ) : [];
+				$dropoff_slugs = is_array( $dropoff_data ) ? array_filter( (array) wp_list_pluck( $dropoff_data, 'loc_dropoff_name' ) ) : [];
+				?>
+				<div class="rbfw-me-loc-manage" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_location_crud' ) ); ?>">
+					<div class="rbfw-me-loc-manage__head">
+						<strong><?php esc_html_e( 'Manage Locations', 'booking-and-rental-manager-for-woocommerce' ); ?></strong>
+						<span class="rbfw-me-field__desc"><?php esc_html_e( 'Add, rename or remove the locations available for pick-up and drop-off.', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+					</div>
+					<div class="rbfw-me-loc-manage__add">
+						<input type="text" class="rbfw-me-input rbfw-me-loc-new" placeholder="<?php esc_attr_e( 'New location name', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+						<button type="button" class="rbfw-me-btn rbfw-me-btn--primary rbfw-me-loc-add-btn"><i class="fas fa-circle-plus" aria-hidden="true"></i> <?php esc_html_e( 'Add', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+					</div>
+					<ul class="rbfw-me-loc-list">
+						<?php foreach ( $locations as $loc ) : ?>
+							<li class="rbfw-me-loc-row" data-term-id="<?php echo esc_attr( $loc['term_id'] ); ?>" data-value="<?php echo esc_attr( $loc['value'] ); ?>">
+								<span class="rbfw-me-loc-row__name"><?php echo esc_html( $loc['name'] ); ?></span>
+								<span class="rbfw-me-loc-row__actions">
+									<button type="button" class="rbfw-me-loc-edit" title="<?php esc_attr_e( 'Rename', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-pen" aria-hidden="true"></i></button>
+									<button type="button" class="rbfw-me-loc-delete" title="<?php esc_attr_e( 'Delete', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-trash-can" aria-hidden="true"></i></button>
+								</span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+
+					<!-- Rename modal (reuses the modern editor's modal styling) -->
+					<div class="rbfw-me-faq-modal" id="rbfw-me-loc-modal">
+						<div class="rbfw-me-faq-modal__backdrop"></div>
+						<div class="rbfw-me-faq-modal__box">
+							<div class="rbfw-me-faq-modal__head">
+								<h3><?php esc_html_e( 'Rename Location', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+								<button type="button" class="rbfw-me-faq-modal__close"><span class="dashicons dashicons-no-alt"></span></button>
+							</div>
+							<div class="rbfw-me-faq-modal__body">
+								<div class="rbfw-me-field">
+									<label class="rbfw-me-field__label"><?php esc_html_e( 'Location name', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+									<input class="rbfw-me-input" type="text" id="rbfw-me-loc-modal-input" />
+								</div>
+								<input type="hidden" id="rbfw-me-loc-modal-term-id" value="">
+							</div>
+							<div class="rbfw-me-faq-modal__foot">
+								<button type="button" id="rbfw-me-loc-modal-save" class="rbfw-me-btn rbfw-me-btn--primary"><?php esc_html_e( 'Update', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+							</div>
+						</div>
+					</div>
+				</div>
+				<?php
+
+				self::render_modern_location_group(
+					__( 'Pick-up Location', 'booking-and-rental-manager-for-woocommerce' ),
+					__( 'Turn Pick-up Location On/Off', 'booking-and-rental-manager-for-woocommerce' ),
+					'rbfw_enable_pick_point',
+					get_post_meta( $post_id, 'rbfw_enable_pick_point', true ) === 'yes',
+					'rbfw-me-pickup-locations',
+					'rbfw_pickup_locations',
+					$locations,
+					$pickup_slugs
+				);
+
+				self::render_modern_location_group(
+					__( 'Drop-off Location', 'booking-and-rental-manager-for-woocommerce' ),
+					__( 'Turn Drop-off Location On/Off', 'booking-and-rental-manager-for-woocommerce' ),
+					'rbfw_enable_dropoff_point',
+					get_post_meta( $post_id, 'rbfw_enable_dropoff_point', true ) === 'yes',
+					'rbfw-me-dropoff-locations',
+					'rbfw_dropoff_locations',
+					$locations,
+					$dropoff_slugs
+				);
+			}
+
+			/**
+			 * Render one location group (toggle + reveal + checkbox list) for the
+			 * modern editor. Checkbox state is mirrored into a hidden, comma
+			 * separated value (of sanitize_title() values) that the modern AJAX
+			 * save reads.
+			 */
+			private static function render_modern_location_group( $title, $desc, $enable_name, $enabled, $reveal_class, $hidden_name, $locations, $selected_slugs ) {
+				$csv = implode( ',', array_map( 'sanitize_title', (array) $selected_slugs ) );
+				?>
+				<div class="rbfw-me-field rbfw-me-field--toggle-row">
+					<div class="rbfw-me-field__info">
+						<strong><?php echo esc_html( $title ); ?></strong>
+						<span class="rbfw-me-field__desc"><?php echo esc_html( $desc ); ?></span>
+					</div>
+					<label class="rbfw-me-toggle">
+						<input type="checkbox" name="<?php echo esc_attr( $enable_name ); ?>" value="yes" <?php checked( $enabled ); ?> class="rbfw-me-toggle__input rbfw-me-toggle--reveal" data-reveals=".<?php echo esc_attr( $reveal_class ); ?>" />
+						<span class="rbfw-me-toggle__ui" aria-hidden="true"></span>
+					</label>
+				</div>
+				<div class="<?php echo esc_attr( $reveal_class ); ?> rbfw-me-loc-group<?php echo $enabled ? '' : ' rbfw-me-hidden'; ?>">
+					<input type="hidden" name="<?php echo esc_attr( $hidden_name ); ?>" class="rbfw-me-loc-hidden" value="<?php echo esc_attr( $csv ); ?>">
+					<div class="rbfw-me-loc-checkboxes">
+						<?php foreach ( $locations as $loc ) : ?>
+							<label class="rbfw-me-loc-label">
+								<input type="checkbox" class="rbfw-me-loc-checkbox" data-loc="<?php echo esc_attr( $loc['value'] ); ?>" <?php checked( in_array( $loc['value'], (array) $selected_slugs, true ) ); ?> />
+								<span><?php echo esc_html( $loc['name'] ); ?></span>
+							</label>
+						<?php endforeach; ?>
+					</div>
+					<p class="rbfw-me-loc-empty<?php echo empty( $locations ) ? '' : ' rbfw-me-hidden'; ?>"><?php esc_html_e( 'No locations yet — add one above.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+				</div>
+				<?php
+			}
+
 			public function add_tabs_content( $post_id ) {
 				?>
                 <div class="mpStyle mp_tab_item" data-tab-item="#rbfw_location_config">
 					<?php $this->section_header(); ?>
+                    <div class="rbfw-location-manage" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_location_crud' ) ); ?>">
+						<?php $this->panel_header( 'Manage Locations', 'Add, rename or remove the locations available for pick-up and drop-off.' ); ?>
+                        <section>
+                            <div>
+                                <label><?php esc_html_e( 'Add Location', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                                <p><?php esc_html_e( 'Create a new location.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+                            </div>
+                            <div class="rbfw-location-add">
+                                <input type="text" class="rbfw-location-new" placeholder="<?php esc_attr_e( 'New location name', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                <button type="button" class="button button-primary rbfw-location-add-btn"><i class="fas fa-circle-plus"></i> <?php esc_html_e( 'Add', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                            </div>
+                        </section>
+                        <section>
+                            <ul class="rbfw-location-list">
+								<?php foreach ( $this->rbfw_get_location_list() as $loc ) : ?>
+                                    <li class="rbfw-location-row" data-term-id="<?php echo esc_attr( $loc['term_id'] ); ?>" data-value="<?php echo esc_attr( $loc['value'] ); ?>">
+                                        <span class="rbfw-location-row-name"><?php echo esc_html( $loc['name'] ); ?></span>
+                                        <span class="rbfw-location-row-actions">
+                                            <button type="button" class="button rbfw-location-edit" title="<?php esc_attr_e( 'Rename', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-pen"></i></button>
+                                            <button type="button" class="button rbfw-location-delete" title="<?php esc_attr_e( 'Delete', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-trash-can"></i></button>
+                                        </span>
+                                    </li>
+								<?php endforeach; ?>
+                            </ul>
+                        </section>
+                        <div class="rbfw-location-modal" id="rbfw-location-modal">
+                            <div class="rbfw-location-modal__backdrop"></div>
+                            <div class="rbfw-location-modal__box">
+                                <div class="rbfw-location-modal__head">
+                                    <h3><?php esc_html_e( 'Rename Location', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+                                    <button type="button" class="rbfw-location-modal__close" aria-label="Close">&times;</button>
+                                </div>
+                                <div class="rbfw-location-modal__body">
+                                    <label for="rbfw-location-modal-input"><strong><?php esc_html_e( 'Location name', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></label>
+                                    <input type="text" id="rbfw-location-modal-input" class="widefat" style="margin-top:6px;">
+                                    <input type="hidden" id="rbfw-location-modal-term-id" value="">
+                                </div>
+                                <div class="rbfw-location-modal__foot">
+                                    <button type="button" class="button button-primary" id="rbfw-location-modal-save"><?php esc_html_e( 'Update', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                    <button type="button" class="button rbfw-location-modal__close"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
 					<?php do_action( 'rbfw_location_config_before', $post_id ); ?>
 					<?php $this->panel_header( 'Pick-up Location Configuration', 'Here you can set location.' ); ?>
 					<?php $this->pickup_location_config( $post_id ); ?>
@@ -189,7 +432,103 @@
                         jQuery(".rbfw-drop-off-clone").clone().appendTo(".rbfw-drop-off-locations")
                             .removeClass('rbfw-drop-off-clone').addClass('rbfw-drop-off');
                     };
+
+                    /* ── Inline location CRUD (classic editor) ── */
+                    (function () {
+                        function locEsc(s) { return jQuery('<div>').text(s == null ? '' : String(s)).html(); }
+                        function locNonce() { return jQuery('.rbfw-location-manage').data('nonce'); }
+
+                        function locRebuild(locations) {
+                            locations = locations || [];
+                            var $list = jQuery('.rbfw-location-list').empty();
+                            locations.forEach(function (loc) {
+                                $list.append(
+                                    '<li class="rbfw-location-row" data-term-id="' + loc.term_id + '" data-value="' + locEsc(loc.value) + '">' +
+                                        '<span class="rbfw-location-row-name">' + locEsc(loc.name) + '</span>' +
+                                        '<span class="rbfw-location-row-actions">' +
+                                            '<button type="button" class="button rbfw-location-edit"><i class="fas fa-pen"></i></button> ' +
+                                            '<button type="button" class="button rbfw-location-delete"><i class="fas fa-trash-can"></i></button>' +
+                                        '</span>' +
+                                    '</li>'
+                                );
+                            });
+                            // Rebuild the pick-up / drop-off selects, preserving the current selection.
+                            jQuery('#rdfw_pickup_location, #rdfw_dropoff_location').each(function () {
+                                var $sel = jQuery(this);
+                                var current = $sel.val() || [];
+                                $sel.empty();
+                                locations.forEach(function (loc) {
+                                    var sel = (current.indexOf(loc.value) !== -1) ? ' selected' : '';
+                                    $sel.append('<option value="' + locEsc(loc.value) + '"' + sel + '>' + locEsc(loc.name) + '</option>');
+                                });
+                                $sel.trigger('change');
+                            });
+                        }
+
+                        function locAjax(action, data, cb) {
+                            data.action = action;
+                            data.nonce = locNonce();
+                            jQuery.post(ajaxurl, data, function (resp) {
+                                if (resp && resp.success) { locRebuild(resp.data.locations); if (cb) cb(); }
+                                else { window.alert((resp && resp.data && resp.data.message) || 'Action failed.'); }
+                            }).fail(function () { window.alert('Request failed.'); });
+                        }
+
+                        jQuery(document).on('click', '.rbfw-location-add-btn', function () {
+                            var $input = jQuery('.rbfw-location-new');
+                            var name = jQuery.trim($input.val());
+                            if (!name) { $input.focus(); return; }
+                            locAjax('rbfw_location_add', { name: name }, function () { $input.val(''); });
+                        });
+                        jQuery(document).on('keypress', '.rbfw-location-new', function (e) {
+                            if (e.which === 13) { e.preventDefault(); jQuery('.rbfw-location-add-btn').click(); }
+                        });
+                        // Edit → open the rename modal (no browser prompt).
+                        jQuery(document).on('click', '.rbfw-location-edit', function () {
+                            var $row = jQuery(this).closest('.rbfw-location-row');
+                            jQuery('#rbfw-location-modal-term-id').val($row.data('term-id'));
+                            jQuery('#rbfw-location-modal-input').val(jQuery.trim($row.find('.rbfw-location-row-name').text()));
+                            jQuery('#rbfw-location-modal').addClass('is-open');
+                            setTimeout(function () { jQuery('#rbfw-location-modal-input').focus().select(); }, 50);
+                        });
+                        jQuery(document).on('click', '.rbfw-location-modal__close, .rbfw-location-modal__backdrop', function () {
+                            jQuery('#rbfw-location-modal').removeClass('is-open');
+                        });
+                        jQuery(document).on('click', '#rbfw-location-modal-save', function () {
+                            var term_id = jQuery('#rbfw-location-modal-term-id').val();
+                            var name = jQuery.trim(jQuery('#rbfw-location-modal-input').val());
+                            if (!name) { jQuery('#rbfw-location-modal-input').focus(); return; }
+                            locAjax('rbfw_location_update', { term_id: term_id, name: name }, function () {
+                                jQuery('#rbfw-location-modal').removeClass('is-open');
+                            });
+                        });
+                        jQuery(document).on('keypress', '#rbfw-location-modal-input', function (e) {
+                            if (e.which === 13) { e.preventDefault(); jQuery('#rbfw-location-modal-save').click(); }
+                        });
+                        jQuery(document).on('click', '.rbfw-location-delete', function () {
+                            var $row = jQuery(this).closest('.rbfw-location-row');
+                            if (!window.confirm('Delete this location? Items using it will no longer reference it.')) { return; }
+                            locAjax('rbfw_location_delete', { term_id: $row.data('term-id') });
+                        });
+                    })();
                 </script>
+                <style>
+                    .rbfw-location-add { display: flex; gap: 8px; align-items: center; }
+                    .rbfw-location-new { min-width: 240px; }
+                    .rbfw-location-list { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 6px; width: 100%; }
+                    .rbfw-location-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 12px; border: 1px solid #e2e6ee; border-radius: 6px; background: #fff; }
+                    .rbfw-location-row-name { font-weight: 500; }
+                    .rbfw-location-row-actions { display: inline-flex; gap: 6px; }
+                    .rbfw-location-modal { position: fixed; inset: 0; z-index: 100000; display: none; }
+                    .rbfw-location-modal.is-open { display: block; }
+                    .rbfw-location-modal__backdrop { position: absolute; inset: 0; background: rgba(0,0,0,.5); }
+                    .rbfw-location-modal__box { position: relative; max-width: 440px; margin: 12vh auto 0; background: #fff; border-radius: 8px; box-shadow: 0 10px 40px rgba(0,0,0,.25); overflow: hidden; }
+                    .rbfw-location-modal__head { display: flex; align-items: center; justify-content: space-between; padding: 14px 18px; border-bottom: 1px solid #e2e6ee; }
+                    .rbfw-location-modal__head h3 { margin: 0; font-size: 15px; }
+                    .rbfw-location-modal__close { background: none; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: #6b7280; }
+                    .rbfw-location-modal__body { padding: 18px; }
+                    .rbfw-location-modal__foot { padding: 14px 18px; border-top: 1px solid #e2e6ee; display: flex; gap: 8px; }
+                </style>
 				<?php
 			}
 

--- a/admin/taxonomy_register.php
+++ b/admin/taxonomy_register.php
@@ -46,6 +46,11 @@ function rbfw_taxonomy_register(){
         'show_admin_column'     => false,
         'update_count_callback' => '_update_post_term_count',
         'query_var'             => true,
+        // Locations are now managed inline in the rental-item editor
+        // (Advanced ▸ Location Configuration), so the auto-generated taxonomy
+        // submenu is hidden from the admin sidebar. The taxonomy itself stays
+        // fully functional (terms, queries, and the edit-tags screen via URL).
+        'show_in_menu'          => false,
         'rewrite'               => array( 'slug' => 'rbfw_location' ),
         'show_in_rest'          => false,
         'meta_box_cb'           => false,

--- a/admin/views/rbfw-modern-editor.php
+++ b/admin/views/rbfw-modern-editor.php
@@ -356,6 +356,25 @@
 			<!-- Advanced ─────────────────────────────────────────────────── -->
 			<div class="rbfw-me-panel" data-panel="advanced">
 
+				<?php
+				// Location Configuration (pick-up / drop-off). The classic editor
+				// hides this tab for resort / appointment; mirror that here, with
+				// applyType() in the JS keeping it in sync on live type changes.
+				if ( class_exists( 'RBFW_Location' ) ) :
+					$rbfw_me_loc_type   = get_post_meta( $post_id, 'rbfw_item_type', true ) ?: 'bike_car_sd';
+					$rbfw_me_loc_hidden = in_array( $rbfw_me_loc_type, [ 'resort', 'appointment' ], true );
+				?>
+				<div class="rbfw-me-card rbfw-me-location-card<?php echo $rbfw_me_loc_hidden ? ' rbfw-me-hidden' : ''; ?>">
+					<div class="rbfw-me-card__head">
+						<h2><?php esc_html_e( 'Location Configuration', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+						<p><?php esc_html_e( 'Configure pick-up and drop-off locations for this rental item.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+					</div>
+					<div class="rbfw-me-card__body">
+						<?php RBFW_Location::render_for_modern_editor( $post_id ); ?>
+					</div>
+				</div>
+				<?php endif; ?>
+
 				<!-- Template picker -->
 				<?php
 				$screenshot_url = RBFW_PLUGIN_URL . '/templates/screenshot/';


### PR DESCRIPTION


The modern rental-item editor had no Location UI, and there was no way to add / rename / remove locations without leaving the editor. This brings Location to the modern editor (modern layout), adds full inline location management to BOTH the classic and modern editors, and removes the now-redundant Location submenu.

What was wrong / missing
------------------------
- The modern editor rendered no Location section at all, and its AJAX save only stored the rbfw_enable_pick_point flag — never the drop-off toggle or the pick-up/drop-off location data. So locations were uneditable in the modern editor and weren't persisted.
- Locations (rbfw_item_location taxonomy terms) could only be managed via the separate "Location" submenu (the default taxonomy screen).

Changes
-------
1. Location Configuration in the modern editor
   - admin/settings/Location.php: new RBFW_Location::render_for_modern_editor(). Rather than reuse the classic markup (which hard-codes select2 + an inline toggle script), it renders clean modern markup — the existing reveal-toggle component plus checkbox groups backed by a hidden, comma-separated value (the Off Days / Categories pattern that collectFormData() serialises reliably). Locations are keyed by sanitize_title(name), the identity the render + save already use throughout.
   - admin/views/rbfw-modern-editor.php: a "Location Configuration" card in the Advanced step, hidden for resort / appointment (mirrors the classic tab condition).
   - admin/RBFW_Modern_Editor.php: ajax_save() now persists both enable flags and rbfw_pickup_data / rbfw_dropoff_data in the exact shape the classic editor and front end expect: array( array( 'loc_pickup_name' => slug ) ).
   - admin/js/rbfw-modern-editor.js: checkbox -> hidden-CSV sync, and a visibility toggle in applyType() so the card hides for resort / appointment on live type change. Show/hide of the location list reuses the existing data-reveals toggle.
   - admin/css/rbfw-modern-editor.css: styled the checkbox chips, the manage list and the action buttons, scoped to .rbfw-me-location-card.

2. Inline location CRUD (add / rename / delete) in BOTH editors — no new submenu
   - admin/settings/Location.php: three nonce- + manage_categories-guarded AJAX endpoints (rbfw_location_add / _update / _delete) on RBFW_Location, each returning the full location list. A "Manage Locations" block (add field + list with edit/delete) is rendered in the modern card and in the classic Location tab (classic markup/styling).
   - Rename uses a MODAL (not a browser prompt): the modern modal reuses the editor's rbfw-me-faq-modal styling; the classic editor gets a self-contained modal (markup + scoped CSS + JS).
   - The JS rebuilds the manage list and every pick-up/drop-off group (modern checkboxes / classic <select> options) from the authoritative list returned by the server, preserving the current per-item selection and dropping any values whose location was deleted.

3. Remove the redundant Location submenu
   - admin/taxonomy_register.php: rbfw_item_location now registers with show_in_menu => false, hiding the auto-generated sidebar submenu. show_ui stays true, so the taxonomy remains fully functional (terms, queries, and the edit-tags screen via direct URL).

Notes
-----
- Renaming a location changes sanitize_title(name), so it re-keys that location — consistent with how the plugin already treats locations (same effect as renaming the term in the WP taxonomy UI). Deleting orphans any item that referenced it (harmless; it simply unchecks).
- No change to the classic save path or the front end; the stored data shape is unchanged, so everything round-trips identically to the classic Location tab.

Validation
----------
- php -l clean on the changed PHP files; node --check clean on the JS.
- CSS brace balance verified; modern rules scoped under .rbfw-me-location-card.
- Backend CRUD uses standard WP term functions (wp_insert_term / wp_update_term / wp_delete_term). Note: the taxonomy is intentionally not registered under WP-CLI (guard in rbfw_taxonomy_register), so CRUD must be exercised in a browser admin/AJAX request, where it is registered.