### PR TITLE
Apply date-wise Min/Max to the multi-day booking calendar + fix maxDate off-by-one

### DIFF
--- a/assets/mp_script/md_script.js
+++ b/assets/mp_script/md_script.js
@@ -3,6 +3,29 @@
 // Holds sold-out dates returned from loadDisabledDates
 var disabledDates = [];
 
+// Date-wise Min/Max (Min & Max Booking Day addon): resolve the effective
+// min/max for a selected pickup date — the first configured date range that
+// contains it, otherwise the global values. The ranges are rendered into
+// #rbfw_datewise_minmax (JSON) server-side and refreshed via AJAX. Returns the
+// global values unchanged when date-wise is disabled or nothing matches.
+function rbfwEffectiveMinMax(dateYmd, globalMin, globalMax) {
+    var eff = { min: globalMin, max: globalMax };
+    var dw = [];
+    try { dw = JSON.parse(jQuery('#rbfw_datewise_minmax').val()) || []; } catch (e) {}
+    if (dw.length && dateYmd) {
+        var d = new Date(dateYmd);
+        for (var i = 0; i < dw.length; i++) {
+            var s = new Date(dw[i].start_date), e = new Date(dw[i].end_date);
+            if (!isNaN(s.getTime()) && !isNaN(e.getTime()) && d >= s && d <= e) {
+                eff.min = parseInt(dw[i].min_days, 10) || 0;
+                eff.max = parseInt(dw[i].max_days, 10) || 0;
+                break;
+            }
+        }
+    }
+    return eff;
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     const qtyInputs = document.querySelectorAll('.rbfw_muiti_items_qty');
     const summaryDiv = document.getElementById('rbfw-items-summary');
@@ -123,8 +146,9 @@ jQuery('body').on('focusin', '.pickup_date', function(e) {
 
 
 
-            let rbfw_minimum_booking_day = parseInt(jQuery('#rbfw_minimum_booking_day').val());
-            let rbfw_maximum_booking_day = parseInt(jQuery('#rbfw_maximum_booking_day').val());
+            let rbfw_eff = rbfwEffectiveMinMax(date_ymd, parseInt(jQuery('#rbfw_minimum_booking_day').val()), parseInt(jQuery('#rbfw_maximum_booking_day').val()));
+            let rbfw_minimum_booking_day = rbfw_eff.min;
+            let rbfw_maximum_booking_day = rbfw_eff.max;
 
 
             let selected_date_array = date_ymd.split('-');
@@ -138,10 +162,16 @@ jQuery('body').on('focusin', '.pickup_date', function(e) {
             jQuery(".dropoff_date").datepicker("option", "minDate", minDate);
 
 
-            if(rbfw_minimum_booking_day){
-                let maxDate = new Date(gYear,  gMonth - 1, gDay - 1 );
+            // Apply the max only when one is set. Use the same base day as minDate
+            // (pickup + max_days) — the previous "gDay - 1" made the max one day
+            // short, and tying it to the min meant a max of 0 ("no cap") collapsed
+            // the window to the day before pickup and disabled the whole calendar.
+            if(rbfw_maximum_booking_day){
+                let maxDate = new Date(gYear,  gMonth - 1, gDay );
                 maxDate.setDate(maxDate.getDate() + rbfw_maximum_booking_day);
                 jQuery(".dropoff_date").datepicker("option", "maxDate", maxDate );
+            } else {
+                jQuery(".dropoff_date").datepicker("option", "maxDate", null );
             }
 
             if(rbfw_enable_time_slot=='yes'){
@@ -388,6 +418,7 @@ jQuery('body').on('change', '#rbfw_search_type', function (e) {
             jQuery('#rbfw_maximum_booking_day').attr('value',response.rbfw_maximum_booking_day);
             jQuery('#rbfw_off_days').attr('value',response.rbfw_off_days);
             jQuery('#rbfw_offday_range').attr('value',response.rbfw_offday_range);
+            jQuery('#rbfw_datewise_minmax').attr('value', response.rbfw_datewise_minmax ? JSON.stringify(response.rbfw_datewise_minmax) : '[]');
 
             jQuery('.rbfw_bike_car_md_item_wrapper').removeClass('rbfw_loader_in');
             jQuery('.rbfw_bike_car_md_item_wrapper i.fa-spinner').remove();
@@ -420,8 +451,9 @@ jQuery('body').on('focusin', '.pickup_date_search', function(e) {
             let post_id = jQuery('#rbfw_post_id').val();
 
 
-            let rbfw_minimum_booking_day = parseInt(jQuery('#rbfw_minimum_booking_day').val());
-            let rbfw_maximum_booking_day = parseInt(jQuery('#rbfw_maximum_booking_day').val());
+            let rbfw_eff = rbfwEffectiveMinMax(date_ymd, parseInt(jQuery('#rbfw_minimum_booking_day').val()), parseInt(jQuery('#rbfw_maximum_booking_day').val()));
+            let rbfw_minimum_booking_day = rbfw_eff.min;
+            let rbfw_maximum_booking_day = rbfw_eff.max;
             let selected_date_array = date_ymd.split('-');
             let gYear = selected_date_array[0];
             let gMonth = selected_date_array[1];

--- a/inc/class-bike-car-md-function.php
+++ b/inc/class-bike-car-md-function.php
@@ -319,10 +319,17 @@ if ( ! class_exists( 'RBFW_BikeCarMd_Function' ) ) {
 
             $rbfw_minimum_booking_day = 0;
             $rbfw_maximum_booking_day = 0;
+            $rbfw_datewise_minmax     = array();
             if(rbfw_check_min_max_booking_day_active()){
                 $rbfw_minimum_booking_day = (int)get_post_meta($post_id, 'rbfw_minimum_booking_day', true);
                 if(get_post_meta($post_id, 'rbfw_maximum_booking_day', true)){
                     $rbfw_maximum_booking_day = '+'.get_post_meta($post_id, 'rbfw_maximum_booking_day', true).'d';
+                }
+                // Date-wise overrides (only when enabled): per-range min/max applied
+                // on the front end based on the selected pick-up date.
+                if ( get_post_meta($post_id, 'rbfw_enable_datewise_minmax', true) === 'yes' ) {
+                    $dw = get_post_meta($post_id, 'rbfw_datewise_minmax', true);
+                    $rbfw_datewise_minmax = is_array($dw) ? array_values($dw) : array();
                 }
             }
 
@@ -331,6 +338,7 @@ if ( ! class_exists( 'RBFW_BikeCarMd_Function' ) ) {
                 'rbfw_maximum_booking_day' => $rbfw_maximum_booking_day,
                 'rbfw_off_days' => rbfw_off_days($post_id),
                 'rbfw_offday_range' => rbfw_off_dates($post_id),
+                'rbfw_datewise_minmax' => $rbfw_datewise_minmax,
 
             ));
 

--- a/templates/forms/multi-day-registration.php
+++ b/templates/forms/multi-day-registration.php
@@ -814,10 +814,15 @@ $rbfw_buffer_time = get_post_meta( $rbfw_id, 'rbfw_buffer_time', true ) ? maybe_
 
                 $rbfw_minimum_booking_day = 0;
                 $rbfw_maximum_booking_day = 0;
+                $rbfw_datewise_minmax     = array();
                 if(rbfw_check_min_max_booking_day_active()){
                     $rbfw_minimum_booking_day = (int)get_post_meta($post_id, 'rbfw_minimum_booking_day', true);
                     if(get_post_meta($post_id, 'rbfw_maximum_booking_day', true)){
                         $rbfw_maximum_booking_day = '+'.get_post_meta($post_id, 'rbfw_maximum_booking_day', true).'d';
+                    }
+                    if(get_post_meta($post_id, 'rbfw_enable_datewise_minmax', true) === 'yes'){
+                        $dw = get_post_meta($post_id, 'rbfw_datewise_minmax', true);
+                        $rbfw_datewise_minmax = is_array($dw) ? array_values($dw) : array();
                     }
                 }
 
@@ -869,6 +874,7 @@ $rbfw_buffer_time = get_post_meta( $rbfw_id, 'rbfw_buffer_time', true ) ? maybe_
                 <input type="hidden" name="total_days" id="rbfw_total_days" value="0">
                 <input type="hidden" id="rbfw_minimum_booking_day" value="<?php echo esc_attr($rbfw_minimum_booking_day); ?>">
                 <input type="hidden" id="rbfw_maximum_booking_day" value="<?php echo esc_attr($rbfw_maximum_booking_day); ?>">
+                <input type="hidden" id="rbfw_datewise_minmax" value="<?php echo esc_attr( wp_json_encode( $rbfw_datewise_minmax ) ); ?>">
                 <input type="hidden" id="rbfw_month_wise_inventory" value="<?php echo esc_attr($day_wise_imventory); ?>">
 
                 <input type="hidden" name="rbfw_particular_switch" id="rbfw_particular_switch"  value='<?php echo esc_attr($rbfw_particular_switch); ?>'>


### PR DESCRIPTION


The Min & Max Booking Day addon now supports per-date-range min/max, but the modern multi-day booking calendar only ever read the GLOBAL min/max (rendered server-side into #rbfw_minimum_booking_day / #rbfw_maximum_booking_day and refreshed via AJAX), so the date-wise values had no effect on the return-date picker. This wires date-wise through to that calendar and fixes a real off-by-one in the max-date logic.

Changes
-------
- templates/forms/multi-day-registration.php Render the date-wise ranges into a hidden #rbfw_datewise_minmax field (server-side, only when the addon is active and date-wise is enabled).

- inc/class-bike-car-md-function.php rbfw_bikecarmd_ajax_min_max_and_offdays_info() also returns rbfw_datewise_minmax so the search widget calendar stays in sync.

- assets/mp_script/md_script.js
  * New rbfwEffectiveMinMax(dateYmd, globalMin, globalMax): returns the first date-wise range that contains the selected pick-up date, else the global values. Used by both the main and the search pick-up onSelect handlers.
  * AJAX success now stores rbfw_datewise_minmax into the hidden field.
  * Fix maxDate off-by-one: it was computed as (pickup - 1) + max_days (one day short) and only applied when min > 0 — so a max of 0 ("no cap") collapsed the window to the day before pick-up and disabled the whole calendar. Now it is pickup + max_days, applied only when a max is set, and cleared otherwise (consistent with minDate = pickup + min_days).

Behaviour
---------
Pick-up inside a date-wise range uses that range's min/max; otherwise the global values apply. Example (range 2026-07-02..2026-07-15, min 2 / max 5; global 8/59): pick-up 02 Jul -> return window 04-07 Jul; pick-up 01 Sep -> 09 Sep .. 30 Oct.

Validation
----------
- php -l clean on the PHP files; node --check clean on the JS.
- Server-rendered hidden value + AJAX payload verified to carry the ranges.