### PR TITLE
Resort booking widget: per-night + stay-total price, date-field calen…

### DIFF
--- a/css/rbfw_style.css
+++ b/css/rbfw_style.css
@@ -11473,9 +11473,27 @@ i.fas.fa-minus {
     margin-bottom: 5px !important;
 }
 
-/* Hide the per-field calendar icon spans */
+/* Per-field calendar icon — shown at the right of each date field.
+   Overrides the base `.rbfw-datetime .calendar` rule (left:2px; padding:12px)
+   which otherwise pins it to the top-left over the PICKUP/RETURN label. */
 .mp_default_theme .rbfw-checkin-checkout-card .rbfw-datetime span.calendar,
 .rbfw_muff_registration_wrapper .rbfw-checkin-checkout-card .rbfw-datetime span.calendar {
+    display: flex !important;
+    align-items: center !important;
+    position: absolute !important;
+    top: 50% !important;
+    left: auto !important;
+    right: 12px !important;
+    transform: translateY(-50%) !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    color: #2563eb !important;
+    font-size: 15px !important;
+    pointer-events: none !important;
+}
+/* Once a date is chosen the clear (×) button takes its place, so hide the icon */
+.mp_default_theme .rbfw-checkin-checkout-card .rbfw-datetime .date:has(.rbfw-date-clear-visible) span.calendar,
+.rbfw_muff_registration_wrapper .rbfw-checkin-checkout-card .rbfw-datetime .date:has(.rbfw-date-clear-visible) span.calendar {
     display: none !important;
 }
 
@@ -11484,7 +11502,7 @@ i.fas.fa-minus {
 .rbfw_muff_registration_wrapper .rbfw-checkin-checkout-card .rbfw-datetime input.rbfw-input {
     border: none !important;
     background: transparent !important;
-    padding: 0 !important;
+    padding: 0 24px 0 0 !important;
     height: auto !important;
     font-size: 15px !important;
     font-weight: 700 !important;

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -43,7 +43,7 @@ if (! class_exists('RBFW_Dependencies')) {
 			// loading popup css
 			wp_enqueue_style('jquery.modal.min', plugin_dir_url(__DIR__) . 'admin/css/jquery.modal.min.css');
 			// loading popup js
-			wp_enqueue_style('rbfw-style', plugin_dir_url(__DIR__) . 'css/rbfw_style.css', array());
+			wp_enqueue_style('rbfw-style', plugin_dir_url(__DIR__) . 'css/rbfw_style.css', array(), filemtime( RBFW_PLUGIN_DIR . '/css/rbfw_style.css' ));
 			wp_enqueue_style('rbfw-rent-items', plugin_dir_url(__DIR__) . 'css/rbfw_rent_items.css', array());
 			wp_enqueue_script('jquery.modal.min', plugin_dir_url(__DIR__) . 'admin/js/jquery.modal.min.js', array('jquery'), '0.9.1', false);
 			wp_enqueue_script('rbfw_script', RBFW_PLUGIN_URL . '/assets/mp_script/rbfw_script.js', array(), time(), true);
@@ -187,7 +187,7 @@ if (! class_exists('RBFW_Dependencies')) {
 			// loading popup css
 			wp_enqueue_style('jquery.modal.min', plugin_dir_url(__DIR__) . 'admin/css/jquery.modal.min.css');
 			// loading popup js
-			wp_enqueue_style('rbfw-style', plugin_dir_url(__DIR__) . 'css/rbfw_style.css', array());
+			wp_enqueue_style('rbfw-style', plugin_dir_url(__DIR__) . 'css/rbfw_style.css', array(), filemtime( RBFW_PLUGIN_DIR . '/css/rbfw_style.css' ));
 			wp_enqueue_style('rbfw-rent-items', plugin_dir_url(__DIR__) . 'css/rbfw_rent_items.css', array());
 			wp_enqueue_script('jquery.modal.min', plugin_dir_url(__DIR__) . 'admin/js/jquery.modal.min.js', array('jquery'), '0.9.1', false);
 			// mage icon

--- a/templates/template_segment/resort_info.php
+++ b/templates/template_segment/resort_info.php
@@ -33,6 +33,12 @@ if(isset($post_id) && isset($active_tab)){
     $available_qty_info_switch = get_post_meta($post_id, 'rbfw_available_qty_info_switch', true) ? get_post_meta($post_id, 'rbfw_available_qty_info_switch', true) : 'no';
 
     ?>
+    <style>
+        .rbfw_resort_rt_price_table .rbfw-room-price { display: flex; flex-direction: column; gap: 2px; line-height: 1.25; }
+        .rbfw_resort_rt_price_table .rbfw-room-price__rate { white-space: nowrap; font-weight: 600; }
+        .rbfw_resort_rt_price_table .rbfw-room-price__unit { font-weight: 400; font-size: 11px; color: #8a94a6; margin-left: 1px; }
+        .rbfw_resort_rt_price_table .rbfw-room-price__stay { white-space: nowrap; font-size: 11px; color: #121511; border: #ff00002e solid 1px; border-radius: 10px; padding: 3px; background-color: #ff00001c; }
+    </style>
 
     <div class="rbfw-single-right-heading" style="margin-top: 10px;margin-bottom:0;">
         <i class="fas fa-clock rbfw-srh-icon"></i>
@@ -61,6 +67,16 @@ if(isset($post_id) && isset($active_tab)){
 
             <?php
             $i = 0;
+
+            // Per-night / per-day unit labels so the room price clearly relates
+            // to the selected day-night stay length (e.g. "$400 / night" and the
+            // "$1,200 / 3 nights" stay total), helping the customer understand it.
+            $rbfw_room_unit        = ( $active_tab === 'daylong' )
+                ? __( 'day', 'booking-and-rental-manager-for-woocommerce' )
+                : __( 'night', 'booking-and-rental-manager-for-woocommerce' );
+            $rbfw_room_unit_plural = ( $active_tab === 'daylong' )
+                ? _n( 'day', 'days', (int) $total_days, 'booking-and-rental-manager-for-woocommerce' )
+                : _n( 'night', 'nights', (int) $total_days, 'booking-and-rental-manager-for-woocommerce' );
 
             foreach ($rbfw_resort_room_data as $key => $value) {
                 $img_url    = wp_get_attachment_url($value['rbfw_room_image']);
@@ -179,7 +195,12 @@ if(isset($post_id) && isset($active_tab)){
 
                         <?php }else{ ?>
                             <td>
-                                <?php echo wp_kses(wc_price($price) , rbfw_allowed_html()); ?>
+                                <div class="rbfw-room-price">
+                                    <span class="rbfw-room-price__rate"><?php echo wp_kses( wc_price( $price ), rbfw_allowed_html() ); ?><span class="rbfw-room-price__unit">/<?php echo esc_html( $rbfw_room_unit ); ?></span></span>
+                                    <?php if ( (int) $total_days > 0 ) : ?>
+                                        <span class="rbfw-room-price__stay"><?php echo wp_kses( wc_price( (float) $price * (int) $total_days ), rbfw_allowed_html() ); ?> · <?php echo esc_html( $total_days . ' ' . $rbfw_room_unit_plural ); ?></span>
+                                    <?php endif; ?>
+                                </div>
                                 <input type="hidden" name="rbfw_room_info[<?php echo esc_attr($i); ?>][room_price]" value="<?php echo esc_attr($price); ?>"/>
                             </td>
                         <?php } ?>
@@ -187,7 +208,12 @@ if(isset($post_id) && isset($active_tab)){
 
                     <?php }else{ ?>
                         <td>
-                            <?php echo wp_kses(wc_price($price) , rbfw_allowed_html()); ?>
+                            <div class="rbfw-room-price">
+                                <span class="rbfw-room-price__rate"><?php echo wp_kses( wc_price( $price ), rbfw_allowed_html() ); ?><span class="rbfw-room-price__unit">/<?php echo esc_html( $rbfw_room_unit ); ?></span></span>
+                                <?php if ( (int) $total_days > 0 ) : ?>
+                                    <span class="rbfw-room-price__stay"><?php echo wp_kses( wc_price( (float) $price * (int) $total_days ), rbfw_allowed_html() ); ?> · <?php echo esc_html( $total_days . ' ' . $rbfw_room_unit_plural ); ?></span>
+                                <?php endif; ?>
+                            </div>
                             <input type="hidden" name="rbfw_room_info[<?php echo esc_attr($i); ?>][room_price]" value="<?php echo esc_attr($price); ?>"/>
                         </td>
                     <?php } ?>


### PR DESCRIPTION
…dar icon, CSS cache-buster

Three frontend/resort polish changes for the resort booking widget.

1. Room price shows per-night rate + stay total (templates/template_segment/resort_info.php) The room price was a bare amount (e.g. "$400"), which didn't read as a per-night rate and looked disconnected from the Duration Cost. It now shows the rate as "$400 / night" plus a small caption with the stay total ("$1,200 · 3 nights"), so customers understand the price relates to the selected day-night stay. Unit text follows the active tab (night vs day) and is singular/plural-correct and translatable. Laid out in a compact, no-wrap two-line stack so it stays readable in the narrow PRICE column.

2. Show the calendar icon in the PICKUP / RETURN date fields (css/rbfw_style.css) The per-field calendar icon span was deliberately hidden in the muffin/default resort widget. It is now shown at the right of each date field, vertically centred, and hidden again once a date is picked (the clear "x" takes its place via :has(.rbfw-date-clear-visible)). This also overrides the base `.rbfw-datetime .calendar` rule (left:2px; padding:12px) that otherwise pinned the icon to the top-left over the PICKUP/RETURN label.

3. Cache-bust the main stylesheet (inc/RBFW_Dependencies.php) rbfw_style.css was enqueued without a version, so CSS edits required a hard reload. Added filemtime() as the version on both enqueue calls so stylesheet changes are picked up automatically (matching how md_script.js is already versioned).

Validation
----------
- php -l clean on the changed PHP; CSS brace balance verified.