### PR TITLE
Modernize rental admin (Order List, Inventory, Time Slots) + order ma…

### DIFF
--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -677,17 +677,30 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $rbfw_service_infos_post = isset( $sd_input_data_sabitized['rbfw_service_price_data'] ) ? $sd_input_data_sabitized['rbfw_service_price_data'] : [];
                 $rbfw_service_infos = [];
 
-                if ( ! empty( $rbfw_service_infos_post ) ) {
+                if ( ! empty( $rbfw_service_infos_post ) && is_array( $rbfw_service_infos_post ) ) {
                     foreach ( $rbfw_service_infos_post as $key_cat => $value ) {
-                        $rbfw_service_infos[ $value['cat_title'] ] = [];
+                        if ( ! is_array( $value ) ) {
+                            continue;
+                        }
+                        $cat_title                       = isset( $value['cat_title'] ) ? $value['cat_title'] : '';
+                        $rbfw_service_infos[ $cat_title ] = [];
                         foreach ( $value as $key_ser => $item ) {
-                            if ( isset( $item['main_cat_name'] ) && $item['main_cat_name'] ) {
-                                $rbfw_service_infos[ $value['cat_title'] ][] = $item;
-                                if ( $item['service_price_type'] == 'day_wise' ) {
-                                    $rbfw_service_price = $rbfw_service_price + $item['price'] * $item['quantity'] * $total_days;
-                                } else {
-                                    $rbfw_service_price = $rbfw_service_price + $item['price'] * $item['quantity'];
-                                }
+                            // The category-level "cat_title" entry is a string; only service rows are arrays
+                            // carrying the [name] field posted by forms/multi-day-registration.php.
+                            if ( 'cat_title' === $key_ser || ! is_array( $item ) || empty( $item['name'] ) ) {
+                                continue;
+                            }
+                            $service_qty = isset( $item['quantity'] ) ? (float) $item['quantity'] : 0;
+                            if ( $service_qty <= 0 ) {
+                                continue; // service not selected
+                            }
+                            $service_unit_price = isset( $item['price'] ) ? (float) $item['price'] : 0;
+                            $service_type       = isset( $item['service_price_type'] ) ? $item['service_price_type'] : '';
+                            $rbfw_service_infos[ $cat_title ][] = $item;
+                            if ( 'day_wise' === $service_type ) {
+                                $rbfw_service_price += $service_unit_price * $service_qty * $total_days;
+                            } else {
+                                $rbfw_service_price += $service_unit_price * $service_qty;
                             }
                         }
                     }

--- a/admin/css/rbfw_inventory.css
+++ b/admin/css/rbfw_inventory.css
@@ -1,0 +1,616 @@
+/* =========================================================================
+   RBFW Inventory page – modern redesign
+   All rules are scoped under .rbfw_inv (page) and #rbfw_stock_view_result_wrap
+   (detail modal) so nothing here can leak into the rest of wp-admin.
+   ========================================================================= */
+
+.rbfw_inv {
+    --rbfw-bg:        #F4F6FA;
+    --rbfw-surface:   #FFFFFF;
+    --rbfw-border:    #E4E9F2;
+    --rbfw-text-1:    #1A1F36;
+    --rbfw-text-2:    #4A5568;
+    --rbfw-text-3:    #8896B0;
+    --rbfw-accent:    #4F6EF7;
+    --rbfw-accent-lt: #EEF1FE;
+    --rbfw-green:     #10B981;
+    --rbfw-green-lt:  #D1FAE5;
+    --rbfw-amber:     #F59E0B;
+    --rbfw-amber-lt:  #FEF3C7;
+    --rbfw-shadow-sm: 0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+    --rbfw-radius:    12px;
+    --rbfw-radius-sm: 8px;
+
+    max-width: 1340px;
+    margin: 16px 20px 48px 0;
+    color: var(--rbfw-text-1);
+    font-size: 14px;
+    line-height: 1.5;
+}
+.rbfw_inv,
+.rbfw_inv *,
+.rbfw_inv *::before,
+.rbfw_inv *::after {
+    box-sizing: border-box;
+    font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Inline SVG icons – size with 1em (inherits parent font-size), colour via currentColor */
+.rbfw_inv svg.rbfw_inv_ic,
+.rbfw_inv_modal svg.rbfw_inv_ic,
+#rbfw_stock_view_result_wrap svg.rbfw_inv_ic {
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    vertical-align: -0.125em;
+    stroke: currentColor;
+    fill: none;
+    flex: 0 0 auto;
+}
+
+/* ── Header ── */
+.rbfw_inv_header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+.rbfw_inv_title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.rbfw_inv_title > svg.rbfw_inv_ic {
+    font-size: 22px;
+    color: var(--rbfw-accent);
+    line-height: 1;
+}
+.rbfw_inv .rbfw_inv_title h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -.3px;
+    color: var(--rbfw-text-1);
+    margin: 0;
+    padding: 0;
+}
+.rbfw_inv_badge {
+    background: var(--rbfw-accent-lt);
+    color: var(--rbfw-accent);
+    font-size: 12px;
+    font-weight: 600;
+    padding: 3px 10px;
+    border-radius: 20px;
+}
+
+/* ── Stat cards ── */
+.rbfw_inv_stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 14px;
+    margin-bottom: 24px;
+}
+.rbfw_inv_stat_card {
+    background: var(--rbfw-surface);
+    border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius);
+    padding: 18px 20px;
+    box-shadow: var(--rbfw-shadow-sm);
+}
+.rbfw_inv_stat_label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .6px;
+    color: var(--rbfw-text-3);
+    margin-bottom: 6px;
+}
+.rbfw_inv_stat_value {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--rbfw-text-1);
+}
+.rbfw_inv_stat_sub {
+    font-size: 12px;
+    color: var(--rbfw-text-3);
+    margin-top: 2px;
+}
+.rbfw_inv_stat_card.rbfw_inv_green .rbfw_inv_stat_value { color: var(--rbfw-green); }
+.rbfw_inv_stat_card.rbfw_inv_blue  .rbfw_inv_stat_value { color: var(--rbfw-accent); }
+
+/* ── Filter bar ── */
+.rbfw_inv .rbfw_inv_filters {
+    background: var(--rbfw-surface);
+    border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius);
+    padding: 16px 20px;
+    display: flex;
+    align-items: flex-end;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+    box-shadow: var(--rbfw-shadow-sm);
+}
+.rbfw_inv .rbfw_inv_filter_group {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin: 0;
+}
+.rbfw_inv .rbfw_inv_filter_group label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: .4px;
+    text-transform: uppercase;
+    color: var(--rbfw-text-3);
+    min-height: 0;
+    line-height: 1.4;
+}
+.rbfw_inv .rbfw_inv_filter_group input {
+    height: 38px;
+    border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius-sm);
+    padding: 0 12px;
+    font-size: 13px;
+    color: var(--rbfw-text-1);
+    background: var(--rbfw-bg);
+    outline: none;
+    box-shadow: none;
+    transition: border-color .2s, box-shadow .2s;
+    min-width: 150px;
+    margin: 0;
+    line-height: 36px;
+}
+.rbfw_inv .rbfw_inv_filter_group input:focus {
+    border-color: var(--rbfw-accent);
+    box-shadow: 0 0 0 3px rgba(79,110,247,.12);
+}
+.rbfw_inv_filter_actions {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+/* Buttons */
+.rbfw_inv .rbfw_inv_btn {
+    height: 38px;
+    padding: 0 18px;
+    border: none;
+    border-radius: var(--rbfw-radius-sm);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: opacity .18s, transform .12s, background .18s;
+    box-shadow: none;
+    text-decoration: none;
+    line-height: 1;
+}
+.rbfw_inv .rbfw_inv_btn:active { transform: scale(.97); }
+.rbfw_inv .rbfw_inv_btn svg.rbfw_inv_ic { font-size: 15px; }
+.rbfw_inv .rbfw_inv_btn_primary { background: var(--rbfw-accent); color: #fff; }
+.rbfw_inv .rbfw_inv_btn_primary:hover { opacity: .88; color: #fff; }
+.rbfw_inv .rbfw_inv_btn_reset   { background: #F1F5F9; color: var(--rbfw-text-2); }
+.rbfw_inv .rbfw_inv_btn_reset:hover { background: #E2E8F0; }
+.rbfw_inv .rbfw_inv_btn_refresh { background: var(--rbfw-green); color: #fff; }
+.rbfw_inv .rbfw_inv_btn_refresh:hover { opacity: .88; color: #fff; }
+
+/* ── Table card ── */
+.rbfw_inv_card {
+    background: var(--rbfw-surface);
+    border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius);
+    box-shadow: var(--rbfw-shadow-sm);
+    overflow: hidden;
+}
+.rbfw_inv_table_scroll { overflow-x: auto; }
+
+.rbfw_inv .rbfw_inv_table {
+    width: 100%;
+    min-width: 900px;
+    border-collapse: collapse;
+    border: none;
+    background: var(--rbfw-surface);
+    margin: 0;
+}
+.rbfw_inv .rbfw_inv_table thead th {
+    background: #F8FAFC;
+    border-bottom: 1px solid var(--rbfw-border);
+    padding: 11px 16px;
+    text-align: center;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+    color: var(--rbfw-text-3);
+    white-space: nowrap;
+}
+.rbfw_inv .rbfw_inv_table thead th:first-child,
+.rbfw_inv .rbfw_inv_table thead th.rbfw_inv_th_left { text-align: left; }
+
+.rbfw_inv .rbfw_inv_table tbody tr {
+    border-bottom: 1px solid var(--rbfw-border);
+    transition: background .14s;
+    background: var(--rbfw-surface);
+}
+.rbfw_inv .rbfw_inv_table tbody tr:last-child { border-bottom: none; }
+.rbfw_inv .rbfw_inv_table tbody tr:hover { background: #F8FAFD; }
+
+.rbfw_inv .rbfw_inv_table td {
+    padding: 13px 16px;
+    vertical-align: middle;
+    font-size: 13px;
+    text-align: center;
+    border: none;
+    color: var(--rbfw-text-2);
+}
+.rbfw_inv .rbfw_inv_table td.rbfw_inv_td_date,
+.rbfw_inv .rbfw_inv_table td.rbfw_inv_td_name { text-align: left; }
+
+.rbfw_inv .rbfw_inv_td_date {
+    color: var(--rbfw-text-3);
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+.rbfw_inv .rbfw_inv_td_name a,
+.rbfw_inv .rbfw_inv_td_name a.rbfw_item_title {
+    color: var(--rbfw-accent);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 1.4;
+}
+.rbfw_inv .rbfw_inv_td_name a:hover { text-decoration: underline; }
+
+/* Stock pill */
+.rbfw_inv .rbfw_inv_stock_wrap {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+}
+.rbfw_inv .rbfw_inv_pill {
+    display: inline-block;
+    background: var(--rbfw-bg);
+    border: 1px solid var(--rbfw-border);
+    border-radius: 20px;
+    padding: 3px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--rbfw-text-2);
+    white-space: nowrap;
+}
+.rbfw_inv .rbfw_inv_pill.full { background: var(--rbfw-green-lt); border-color: #6EE7B7; color: #065F46; }
+.rbfw_inv .rbfw_inv_pill.zero { background: #FEE2E2; border-color: #FCA5A5; color: #991B1B; }
+
+.rbfw_inv .rbfw_inv_view_btn {
+    display: inline-block;
+    height: 26px;
+    line-height: 26px;
+    padding: 0 12px;
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--rbfw-accent-lt);
+    color: var(--rbfw-accent);
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background .15s;
+    white-space: nowrap;
+    text-decoration: none;
+}
+.rbfw_inv .rbfw_inv_view_btn:hover { background: #dde5fd; color: var(--rbfw-accent); }
+
+/* Sold qty badge */
+.rbfw_inv .rbfw_inv_qty_badge {
+    display: inline-block;
+    min-width: 32px;
+    padding: 4px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 700;
+}
+.rbfw_inv .rbfw_inv_qty_zero { background: var(--rbfw-green-lt); color: #065F46; }
+.rbfw_inv .rbfw_inv_qty_pos  { background: var(--rbfw-amber-lt); color: #92400E; }
+
+/* Empty state */
+.rbfw_inv .rbfw_inv_empty_cell {
+    text-align: center;
+    padding: 24px 18px;
+    color: var(--rbfw-text-3);
+    font-size: 13px;
+    font-style: italic;
+}
+
+/* ── Footer / pagination ── */
+.rbfw_inv_footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 20px;
+    border-top: 1px solid var(--rbfw-border);
+    font-size: 12px;
+    color: var(--rbfw-text-3);
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.rbfw_inv_footer:empty { display: none; }
+.rbfw_inv_pager { display: flex; gap: 4px; }
+.rbfw_inv .rbfw_inv_pager_btn {
+    min-width: 30px;
+    height: 30px;
+    padding: 0 6px;
+    border: 1px solid var(--rbfw-border);
+    border-radius: 7px;
+    background: var(--rbfw-surface);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--rbfw-text-2);
+    cursor: pointer;
+    display: inline-grid;
+    place-items: center;
+    transition: all .15s;
+}
+.rbfw_inv .rbfw_inv_pager_btn:hover:not(:disabled) { border-color: var(--rbfw-accent); color: var(--rbfw-accent); }
+.rbfw_inv .rbfw_inv_pager_btn.active { background: var(--rbfw-accent); color: #fff; border-color: var(--rbfw-accent); }
+.rbfw_inv .rbfw_inv_pager_btn:disabled { opacity: .45; cursor: default; }
+
+.rbfw_inv hr.wp-header-end { display: none; }
+
+/* ── Placeholder loader (re-uses plugin's existing markup) ── */
+.rbfw_inv_card .rbfw-inventory-page-ph { display: block; padding: 18px; }
+
+/* =========================================================================
+   Detail modal  (rendered inside the shared mage_modal box)
+   ========================================================================= */
+#rbfw_stock_view_result_wrap {
+    max-width: 500px;
+    width: 94%;
+    padding: 0;
+    border-radius: 18px;
+    overflow: hidden;
+    background: #fff;
+    box-shadow: 0 24px 60px rgba(15,23,42,.30), 0 4px 16px rgba(15,23,42,.10);
+}
+#rbfw_stock_view_result_wrap a.close-mage_modal { display: none !important; }
+#rbfw_stock_view_result_inner_wrap { padding: 0; }
+#rbfw_stock_view_result_inner_wrap .rbfw_rp_loader {
+    display: block;
+    text-align: center;
+    font-size: 22px;
+    color: #4F6EF7;
+    padding: 40px 0;
+}
+
+.rbfw_inv_modal,
+.rbfw_inv_modal * {
+    box-sizing: border-box;
+    font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+.rbfw_inv_modal {
+    --rbfw-border:    #E4E9F2;
+    --rbfw-text-1:    #1A1F36;
+    --rbfw-text-2:    #4A5568;
+    --rbfw-text-3:    #8896B0;
+    --rbfw-accent:    #4F6EF7;
+    --rbfw-accent-lt: #EEF1FE;
+    --rbfw-green:     #10B981;
+    --rbfw-bg:        #F4F6FA;
+    color: var(--rbfw-text-1);
+    display: flex;
+    flex-direction: column;
+    max-height: 86vh;
+}
+
+/* modal header */
+.rbfw_inv_modal_head {
+    padding: 18px 20px 16px;
+    border-bottom: 1px solid var(--rbfw-border);
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    flex-shrink: 0;
+}
+.rbfw_inv_modal_icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    background: var(--rbfw-accent-lt);
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+.rbfw_inv_modal_icon svg.rbfw_inv_ic { font-size: 20px; color: var(--rbfw-accent); }
+.rbfw_inv_modal_title_wrap { flex: 1; min-width: 0; }
+.rbfw_inv_modal_title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--rbfw-text-1);
+    line-height: 1.4;
+    word-break: break-word;
+}
+.rbfw_inv_modal_sub { font-size: 11px; color: var(--rbfw-text-3); margin-top: 3px; }
+.rbfw_inv_modal_close {
+    width: 30px;
+    height: 30px;
+    border-radius: 7px;
+    border: 1px solid var(--rbfw-border);
+    background: var(--rbfw-bg);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    color: var(--rbfw-text-3);
+    font-size: 14px;
+    text-decoration: none;
+    transition: background .15s, color .15s, border-color .15s;
+    flex-shrink: 0;
+}
+.rbfw_inv_modal_close:hover { background: #FEE2E2; color: #DC2626; border-color: #FCA5A5; }
+.rbfw_inv_modal_close svg.rbfw_inv_ic { font-size: 16px; }
+
+/* modal body */
+.rbfw_inv_modal_body { padding: 18px 20px 20px; overflow-y: auto; overflow-x: hidden; flex: 1 1 auto; min-height: 0; }
+
+/* available qty hero */
+.rbfw_inv_avail_hero {
+    background: linear-gradient(135deg, var(--rbfw-accent-lt) 0%, #e8eefe 100%);
+    border: 1px solid #c7d4fb;
+    border-radius: 10px;
+    padding: 14px 18px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+.rbfw_inv_avail_label { font-size: 11px; font-weight: 600; color: var(--rbfw-accent); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 4px; }
+.rbfw_inv_avail_qty { font-size: 26px; font-weight: 800; color: var(--rbfw-accent); line-height: 1; }
+.rbfw_inv_avail_qty.rbfw_inv_avail_zero { color: #DC2626; }
+.rbfw_inv_avail_icon { font-size: 36px; color: var(--rbfw-accent); opacity: .25; }
+
+/* section */
+.rbfw_inv_modal_section { margin-bottom: 14px; }
+.rbfw_inv_section_label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .6px;
+    color: var(--rbfw-text-3);
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.rbfw_inv_section_label svg.rbfw_inv_ic { font-size: 13px; }
+.rbfw_inv_section_label::after { content: ''; flex: 1; height: 1px; background: var(--rbfw-border); }
+
+/* mini table */
+.rbfw_inv_modal .rbfw_inv_mini_table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+    margin: 0;
+}
+.rbfw_inv_modal .rbfw_inv_mini_table thead th {
+    background: #F8FAFC;
+    border: 1px solid var(--rbfw-border);
+    padding: 8px 12px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .4px;
+    color: var(--rbfw-text-3);
+    text-align: left;
+}
+.rbfw_inv_modal .rbfw_inv_mini_table thead th.rbfw_inv_ta_r { text-align: right; width: 120px; }
+.rbfw_inv_modal .rbfw_inv_mini_table tbody td {
+    border: 1px solid var(--rbfw-border);
+    padding: 9px 12px;
+    font-size: 13px;
+    color: var(--rbfw-text-2);
+    word-break: break-word;
+}
+.rbfw_inv_modal .rbfw_inv_mini_table tbody tr:hover td { background: #F8FAFD; }
+.rbfw_inv_modal .rbfw_inv_qty_cell { font-weight: 700; color: var(--rbfw-green); text-align: right; }
+.rbfw_inv_modal .rbfw_inv_qty_cell.rbfw_inv_qty_cell_zero { color: #DC2626; }
+
+.rbfw_inv_empty_modal { text-align: center !important; color: var(--rbfw-text-3); font-style: italic; }
+.rbfw_inv_empty_modal_note { color: var(--rbfw-text-3); font-size: 13px; font-style: italic; }
+
+/* category blocks */
+.rbfw_inv_cat_block { margin-bottom: 12px; }
+.rbfw_inv_cat_block:last-child { margin-bottom: 0; }
+.rbfw_inv_cat_title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--rbfw-text-2);
+    margin-bottom: 6px;
+}
+.rbfw_inv_cat_title svg.rbfw_inv_ic { font-size: 13px; color: var(--rbfw-text-3); }
+
+/* =========================================================================
+   Responsive
+   ========================================================================= */
+
+/* Tablet / collapsed admin menu */
+@media (max-width: 960px) {
+    .rbfw_inv { margin: 14px 12px 40px; }
+    .rbfw_inv_stats { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 782px) {
+    .rbfw_inv { margin: 12px 10px 36px; }
+    .rbfw_inv .rbfw_inv_filters { padding: 14px; gap: 12px; }
+    .rbfw_inv .rbfw_inv_filter_group { flex: 1 1 150px; }
+    .rbfw_inv .rbfw_inv_filter_group input { min-width: 0; width: 100%; }
+    .rbfw_inv_filter_actions { flex: 1 1 100%; }
+    .rbfw_inv .rbfw_inv_btn { flex: 1 1 auto; justify-content: center; }
+    #rbfw_stock_view_result_wrap { width: 96%; }
+}
+
+/* Phones – stack the wide table into per-row cards */
+@media (max-width: 640px) {
+    .rbfw_inv_table_scroll { overflow-x: visible; }
+
+    .rbfw_inv .rbfw_inv_table { min-width: 0; }
+    .rbfw_inv .rbfw_inv_table thead { display: none; }
+    .rbfw_inv .rbfw_inv_table,
+    .rbfw_inv .rbfw_inv_table tbody,
+    .rbfw_inv .rbfw_inv_table tr,
+    .rbfw_inv .rbfw_inv_table td { display: block; width: 100%; }
+
+    .rbfw_inv .rbfw_inv_table tr.rbfw_inv_row {
+        border: 1px solid var(--rbfw-border);
+        border-radius: 10px;
+        margin: 12px;
+        background: #fff;
+        overflow: hidden;
+    }
+    .rbfw_inv .rbfw_inv_table tr.rbfw_inv_row:hover { background: #fff; }
+
+    .rbfw_inv .rbfw_inv_table td {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        text-align: right !important;
+        padding: 10px 14px;
+        border-bottom: 1px dashed var(--rbfw-border);
+    }
+    .rbfw_inv .rbfw_inv_table tr.rbfw_inv_row td:last-child { border-bottom: none; }
+
+    .rbfw_inv .rbfw_inv_table td::before {
+        content: attr(data-th);
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: .5px;
+        color: var(--rbfw-text-3);
+        text-align: left;
+        flex: 0 1 auto;
+        padding-right: 8px;
+    }
+    .rbfw_inv .rbfw_inv_stock_wrap { align-items: flex-end; }
+
+    /* Empty state spans the whole card, no label */
+    .rbfw_inv .rbfw_inv_table td.rbfw_inv_empty_cell { display: block; text-align: center !important; padding: 20px 14px; }
+    .rbfw_inv .rbfw_inv_table td.rbfw_inv_empty_cell::before { content: none; }
+
+    .rbfw_inv_stat_card { padding: 14px 16px; }
+    .rbfw_inv_stat_value { font-size: 20px; }
+    .rbfw_inv_footer { justify-content: center; }
+}
+
+/* Small phones */
+@media (max-width: 380px) {
+    .rbfw_inv_stats { grid-template-columns: 1fr; }
+    .rbfw_inv .rbfw_inv_filter_group { flex: 1 1 100%; }
+}

--- a/admin/css/rbfw_order.css
+++ b/admin/css/rbfw_order.css
@@ -1,0 +1,624 @@
+/* =========================================================================
+   RBFW Order List – modern light redesign
+   Scoped under .rbfw_ol so nothing leaks into the rest of wp-admin.
+   ========================================================================= */
+
+.rbfw_ol {
+    --rbfw-bg:        #F4F6FA;
+    --rbfw-surface:   #FFFFFF;
+    --rbfw-border:    #E4E9F2;
+    --rbfw-text-1:    #1A1F36;
+    --rbfw-text-2:    #4A5568;
+    --rbfw-text-3:    #8896B0;
+    --rbfw-accent:    #4F6EF7;
+    --rbfw-accent-lt: #EEF1FE;
+    --rbfw-green:     #10B981;
+    --rbfw-green-lt:  #D1FAE5;
+    --rbfw-amber:     #F59E0B;
+    --rbfw-amber-lt:  #FEF3C7;
+    --rbfw-red:       #EF4444;
+    --rbfw-red-lt:    #FEE2E2;
+    --rbfw-purple:    #8B5CF6;
+    --rbfw-purple-lt: #EDE9FE;
+    --rbfw-shadow-sm: 0 1px 3px rgba(0,0,0,.06);
+    --rbfw-radius:    12px;
+    --rbfw-radius-sm: 8px;
+
+    max-width: none;
+    margin: 16px 20px 48px 0;
+    color: var(--rbfw-text-1);
+    font-size: 14px;
+    line-height: 1.5;
+}
+.rbfw_ol,
+.rbfw_ol *,
+.rbfw_ol *::before,
+.rbfw_ol *::after {
+    box-sizing: border-box;
+    font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Inline SVG icons */
+.rbfw_ol svg.rbfw_inv_ic {
+    width: 1em; height: 1em; display: inline-block;
+    vertical-align: -0.125em; stroke: currentColor; fill: none; flex: 0 0 auto;
+}
+.rbfw_ol hr.wp-header-end { display: none; }
+
+/* ── Header ── */
+.rbfw_ol_header { display: flex; align-items: center; margin-bottom: 22px; flex-wrap: wrap; gap: 12px; }
+.rbfw_ol_title { display: flex; align-items: center; gap: 10px; }
+.rbfw_ol_title_icon { color: var(--rbfw-accent); font-size: 24px; display: inline-flex; }
+.rbfw_ol .rbfw_ol_title h1 {
+    font-size: 22px; font-weight: 800; letter-spacing: -.4px;
+    color: var(--rbfw-text-1); margin: 0; padding: 0;
+}
+.rbfw_ol_badge_count {
+    background: var(--rbfw-accent-lt); color: var(--rbfw-accent);
+    font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 20px;
+}
+
+/* ── Stat cards ── */
+.rbfw_ol_stats {
+    display: grid; grid-template-columns: repeat(5, 1fr);
+    gap: 14px; margin-bottom: 22px;
+}
+.rbfw_ol_stat {
+    background: var(--rbfw-surface); border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius); padding: 16px 18px;
+    box-shadow: var(--rbfw-shadow-sm); display: flex; align-items: center; gap: 14px;
+}
+.rbfw_ol_stat_icon {
+    width: 44px; height: 44px; border-radius: 11px;
+    display: grid; place-items: center; flex-shrink: 0; font-size: 22px;
+}
+.rbfw_ol_stat_icon.purple { background: var(--rbfw-purple-lt); color: var(--rbfw-purple); }
+.rbfw_ol_stat_icon.red    { background: var(--rbfw-red-lt);    color: var(--rbfw-red); }
+.rbfw_ol_stat_icon.green  { background: var(--rbfw-green-lt);  color: var(--rbfw-green); }
+.rbfw_ol_stat_icon.amber  { background: var(--rbfw-amber-lt);  color: var(--rbfw-amber); }
+.rbfw_ol_stat_icon.blue   { background: var(--rbfw-accent-lt); color: var(--rbfw-accent); }
+.rbfw_ol_stat_info { min-width: 0; }
+.rbfw_ol_stat_num { font-size: 22px; font-weight: 800; color: var(--rbfw-text-1); line-height: 1; }
+.rbfw_ol_stat_lbl {
+    font-size: 11px; font-weight: 600; color: var(--rbfw-text-3);
+    text-transform: uppercase; letter-spacing: .4px; margin-top: 3px;
+}
+.rbfw_ol_stat_amt { font-size: 12px; font-weight: 600; margin-top: 2px; }
+.rbfw_ol_stat_amt.pos  { color: var(--rbfw-green); }
+.rbfw_ol_stat_amt.zero { color: var(--rbfw-text-3); }
+.rbfw_ol_stat_amt .woocommerce-Price-amount,
+.rbfw_ol_stat_amt bdi { color: inherit; }
+
+/* ── Filter bar ── */
+.rbfw_ol_filterbar {
+    display: flex; align-items: stretch; gap: 12px; flex-wrap: wrap; margin-bottom: 18px;
+}
+.rbfw_ol_search {
+    background: var(--rbfw-surface); border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius); padding: 0 16px;
+    display: flex; align-items: center; gap: 10px; height: 46px;
+    box-shadow: var(--rbfw-shadow-sm); transition: border-color .2s, box-shadow .2s;
+    flex: 1 1 260px; min-width: 200px;
+}
+.rbfw_ol_search:focus-within { border-color: var(--rbfw-accent); box-shadow: 0 0 0 3px rgba(79,110,247,.1); }
+.rbfw_ol_search svg.rbfw_inv_ic { color: var(--rbfw-text-3); font-size: 18px; }
+.rbfw_ol .rbfw_ol_search_input {
+    flex: 1; border: none; outline: none; box-shadow: none; background: transparent;
+    font-size: 13px; color: var(--rbfw-text-1); height: 100%; margin: 0; padding: 0;
+}
+.rbfw_ol .rbfw_ol_search_input:focus { box-shadow: none; border: none; }
+.rbfw_ol .rbfw_ol_search_input::placeholder { color: var(--rbfw-text-3); }
+
+.rbfw_ol_filter_field {
+    position: relative;
+    display: flex; align-items: center; gap: 8px; height: 46px; padding: 0 12px;
+    background: var(--rbfw-surface); border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius); box-shadow: var(--rbfw-shadow-sm);
+    transition: border-color .2s, box-shadow .2s;
+}
+.rbfw_ol_filter_field:focus-within { border-color: var(--rbfw-accent); box-shadow: 0 0 0 3px rgba(79,110,247,.1); }
+.rbfw_ol_filter_field .rbfw_ol_filter_ico { display: inline-flex; color: var(--rbfw-text-3); }
+.rbfw_ol_filter_field .rbfw_ol_filter_ico svg.rbfw_inv_ic { width: 16px; height: 16px; }
+.rbfw_ol .rbfw_ol_filter_select,
+.rbfw_ol .rbfw_ol_filter_date {
+    border: none; outline: none; box-shadow: none; background: transparent;
+    font-size: 13px; font-weight: 600; color: var(--rbfw-text-1); height: 100%; margin: 0; padding: 0;
+    line-height: normal; min-height: 0;
+}
+.rbfw_ol .rbfw_ol_filter_select {
+    min-width: 130px; cursor: pointer;
+    -webkit-appearance: none; -moz-appearance: none; appearance: none;
+    background-color: transparent;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%238896B0' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right center; background-size: 13px 13px;
+    padding-right: 20px;
+}
+.rbfw_ol .rbfw_ol_filter_select:focus { outline: none; box-shadow: none; }
+.rbfw_ol .rbfw_ol_filter_date { width: 130px; color-scheme: light; }
+.rbfw_ol_filter_field .rbfw_ol_filter_sep { color: var(--rbfw-text-3); font-weight: 600; }
+
+.rbfw_ol .rbfw_ol_filter_reset {
+    display: inline-flex; align-items: center; gap: 6px; height: 46px; padding: 0 16px;
+    background: var(--rbfw-bg); border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius);
+    color: var(--rbfw-text-2); font-size: 13px; font-weight: 600; cursor: pointer; transition: all .15s;
+}
+.rbfw_ol .rbfw_ol_filter_reset:hover { border-color: var(--rbfw-accent); color: var(--rbfw-accent); background: var(--rbfw-accent-lt); }
+.rbfw_ol .rbfw_ol_filter_reset svg.rbfw_inv_ic { width: 15px; height: 15px; }
+@media (max-width: 782px) {
+    .rbfw_ol_filterbar { gap: 10px; }
+    .rbfw_ol_search { flex-basis: 100%; }
+    .rbfw_ol_filter_field, .rbfw_ol .rbfw_ol_filter_reset { flex: 1 1 auto; }
+}
+
+/* ── Table card ── */
+.rbfw_ol_card {
+    background: var(--rbfw-surface); border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius); box-shadow: var(--rbfw-shadow-sm); overflow: hidden;
+}
+.rbfw_ol_table_scroll { overflow-x: auto; }
+.rbfw_ol .rbfw_ol_table { width: 100%; border-collapse: collapse; min-width: 880px; margin: 0; background: var(--rbfw-surface); }
+.rbfw_ol .rbfw_ol_table thead th {
+    background: #F8FAFC; border-bottom: 1px solid var(--rbfw-border);
+    padding: 12px 16px; font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .5px; color: var(--rbfw-text-3);
+    white-space: nowrap; text-align: left;
+}
+.rbfw_ol .rbfw_ol_table thead th.rbfw_ol_th_action { text-align: right; }
+.rbfw_ol .rbfw_ol_table tbody tr.order-row { border-bottom: 1px solid var(--rbfw-border); transition: background .12s; }
+.rbfw_ol .rbfw_ol_table tbody tr.order-row:hover { background: #F8FAFD; }
+.rbfw_ol .rbfw_ol_table tbody tr.order-row.rbfw_ol_open { background: #F0F3FF; }
+.rbfw_ol .rbfw_ol_table td {
+    padding: 14px 16px; vertical-align: middle; font-size: 13px;
+    color: var(--rbfw-text-2); border: none; text-align: left;
+}
+.rbfw_ol .rbfw_ol_td_order { font-weight: 700; color: var(--rbfw-text-1); white-space: nowrap; }
+.rbfw_ol .rbfw_ol_td_name  { font-weight: 600; color: var(--rbfw-text-1); }
+.rbfw_ol .rbfw_ol_td_date  { white-space: nowrap; }
+.rbfw_ol .rbfw_ol_td_total { font-weight: 700; color: var(--rbfw-green); font-size: 14px; white-space: nowrap; }
+.rbfw_ol .rbfw_ol_td_total .woocommerce-Price-amount,
+.rbfw_ol .rbfw_ol_td_total bdi { color: inherit; }
+.rbfw_ol .rbfw_ol_td_action { text-align: right; width: 1%; white-space: nowrap; }
+
+/* status badges */
+.rbfw_ol .rbfw_ol_badge {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 4px 11px; border-radius: 20px; font-size: 11px; font-weight: 700; white-space: nowrap;
+    background: var(--rbfw-accent-lt); color: var(--rbfw-accent);
+}
+.rbfw_ol .rbfw_ol_badge_completed { background: var(--rbfw-green-lt);  color: #065F46; }
+.rbfw_ol .rbfw_ol_badge_processing,
+.rbfw_ol .rbfw_ol_badge_on-hold   { background: var(--rbfw-accent-lt); color: var(--rbfw-accent); }
+.rbfw_ol .rbfw_ol_badge_pending   { background: var(--rbfw-amber-lt);  color: #92400E; }
+.rbfw_ol .rbfw_ol_badge_cancelled,
+.rbfw_ol .rbfw_ol_badge_failed    { background: var(--rbfw-red-lt);    color: #991B1B; }
+.rbfw_ol .rbfw_ol_badge_refunded  { background: var(--rbfw-purple-lt); color: #6D28D9; }
+
+/* action buttons */
+.rbfw_ol .rbfw_ol_actions { display: inline-flex; gap: 6px; align-items: center; vertical-align: middle; }
+.rbfw_ol .rbfw_ol_act {
+    width: 32px; height: 32px; border-radius: 7px; padding: 0; line-height: 0;
+    border: 1px solid var(--rbfw-border); background: var(--rbfw-bg);
+    cursor: pointer; display: inline-flex; align-items: center; justify-content: center;
+    font-size: 16px; color: var(--rbfw-text-2); text-decoration: none;
+    transition: all .15s; box-sizing: border-box;
+}
+.rbfw_ol .rbfw_ol_act svg.rbfw_inv_ic { display: block; width: 16px; height: 16px; }
+.rbfw_ol .rbfw_ol_act_edit:hover { border-color: var(--rbfw-accent); color: var(--rbfw-accent); background: var(--rbfw-accent-lt); }
+.rbfw_ol .rbfw_ol_act_delete:hover { border-color: var(--rbfw-red); color: var(--rbfw-red); background: var(--rbfw-red-lt); }
+.rbfw_ol .rbfw_ol_act_view:hover { border-color: var(--rbfw-green); color: var(--rbfw-green); background: var(--rbfw-green-lt); }
+.rbfw_ol .rbfw_ol_act_view.rbfw_ol_act_active { border-color: var(--rbfw-green); color: var(--rbfw-green); background: var(--rbfw-green-lt); }
+
+/* empty state */
+.rbfw_ol .rbfw_ol_empty { text-align: center; padding: 28px 16px; color: var(--rbfw-text-3); font-style: italic; }
+
+/* ── Footer / pager ── */
+.rbfw_ol_footer {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 16px; border-top: 1px solid var(--rbfw-border);
+    font-size: 12px; color: var(--rbfw-text-3); flex-wrap: wrap; gap: 8px;
+}
+.rbfw_ol_pager { display: flex; gap: 4px; }
+.rbfw_ol .rbfw_ol_pager_btn {
+    min-width: 30px; height: 30px; padding: 0 6px;
+    border: 1px solid var(--rbfw-border); border-radius: 7px; background: var(--rbfw-surface);
+    font-size: 12px; font-weight: 600; color: var(--rbfw-text-2); cursor: pointer;
+    display: inline-grid; place-items: center; transition: all .15s;
+}
+.rbfw_ol .rbfw_ol_pager_btn:hover:not(:disabled) { border-color: var(--rbfw-accent); color: var(--rbfw-accent); }
+.rbfw_ol .rbfw_ol_pager_btn.active { background: var(--rbfw-accent); color: #fff; border-color: var(--rbfw-accent); }
+.rbfw_ol .rbfw_ol_pager_btn:disabled { opacity: .45; cursor: default; }
+
+/* ── Loader ── */
+.rbfw_ol_loader { align-items: center; justify-content: center; padding: 16px; }
+.rbfw_ol_spinner {
+    width: 26px; height: 26px; border-radius: 50%;
+    border: 3px solid var(--rbfw-accent-lt); border-top-color: var(--rbfw-accent);
+    display: inline-block; animation: rbfw_ol_spin .7s linear infinite;
+}
+@keyframes rbfw_ol_spin { to { transform: rotate(360deg); } }
+
+/* =========================================================================
+   Expandable detail panel (animated) + AJAX content styling
+   ========================================================================= */
+.rbfw_ol .rbfw_ol_detail_row > td { padding: 0; background: #FAFBFF; border-bottom: 1px solid var(--rbfw-border); }
+.rbfw_ol_detail_anim {
+    max-height: 0; overflow: hidden; opacity: 0;
+    transition: max-height .4s cubic-bezier(.4,0,.2,1), opacity .3s ease;
+}
+.rbfw_ol_detail_anim.open { max-height: 4000px; opacity: 1; }
+
+/* AJAX-rendered content (.rbfw_order_meta_box_wrap) restyled to match the mockup.
+   These reset the legacy bordered/boxed look from admin_style.css. */
+.rbfw_ol .rbfw_order_meta_box_wrap {
+    background: transparent; padding: 0; border: 0; border-radius: 0; box-shadow: none; margin: 0;
+}
+.rbfw_ol .rbfw_order_meta_box_wrap:hover { box-shadow: none; }
+.rbfw_ol .rbfw_order_meta_box_body i { color: inherit; }
+.rbfw_ol .rbfw_order_meta_box_head {
+    position: relative;
+    background: linear-gradient(90deg, var(--rbfw-accent) 0%, var(--rbfw-purple) 100%);
+    padding: 14px 54px 14px 20px; margin: 0; text-align: left;
+    display: flex; align-items: center; gap: 10px;
+}
+.rbfw_ol .rbfw_order_meta_box_head .rbfw_ol_dhead {
+    display: flex; align-items: center; gap: 9px; color: #fff; flex: 1 1 auto; min-width: 0;
+}
+.rbfw_ol .rbfw_ol_edit_order_btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    margin-left: auto; padding: 6px 12px; border-radius: 7px; cursor: pointer;
+    background: rgba(255,255,255,.18); border: 1px solid rgba(255,255,255,.35); color: #fff;
+    font-size: 12px; font-weight: 700; line-height: 1; white-space: nowrap; transition: background .15s;
+}
+.rbfw_ol .rbfw_ol_edit_order_btn:hover { background: rgba(255,255,255,.32); }
+.rbfw_ol .rbfw_ol_edit_order_btn svg.rbfw_inv_ic { width: 14px; height: 14px; display: block; }
+.rbfw_ol .rbfw_order_meta_box_head .rbfw_ol_dhead svg.rbfw_inv_ic { font-size: 18px; }
+.rbfw_ol .rbfw_order_meta_box_head .rbfw_ol_dhead_title,
+.rbfw_ol .rbfw_order_meta_box_head h1,
+.rbfw_ol .rbfw_order_meta_box_head h2,
+.rbfw_ol .rbfw_order_meta_box_head h3 {
+    font-size: 15px; font-weight: 700; color: #fff; margin: 0; padding: 0; line-height: 1.4; text-align: left;
+}
+.rbfw_ol_detail_close {
+    position: absolute; top: 50%; right: 16px; transform: translateY(-50%);
+    width: 30px; height: 30px; border-radius: 7px; border: none;
+    background: rgba(255,255,255,.2); color: #fff; cursor: pointer;
+    display: grid; place-items: center; font-size: 16px; transition: background .15s;
+}
+.rbfw_ol_detail_close:hover { background: rgba(255,255,255,.35); }
+
+.rbfw_ol .rbfw_order_meta_box_body {
+    padding: 20px; display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-start;
+}
+.rbfw_ol .rbfw_order_meta_box_body > .wp-list-table {
+    flex: 1 1 calc(50% - 8px); width: auto; min-width: 0; margin: 0;
+    border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    overflow: hidden; border-collapse: separate; border-spacing: 0;
+    background: var(--rbfw-surface); box-shadow: none;
+}
+/* the summary table spans the full width */
+.rbfw_ol .rbfw_order_meta_box_body > .wp-list-table:last-of-type { flex-basis: 100%; }
+
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table thead th,
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table > thead > tr > th {
+    background: #F0F4FF; color: var(--rbfw-accent);
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+    padding: 11px 14px; border-bottom: 1px solid #DDE6FC; text-align: left;
+}
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table thead th .rbfw_ol_sec_ico {
+    display: inline-flex; vertical-align: -0.18em; margin-right: 6px; font-size: 14px;
+}
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table thead th .rbfw_ol_sec_ico svg.rbfw_inv_ic { width: 1em; height: 1em; }
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table:last-of-type thead th {
+    background: #F0FDF7; color: var(--rbfw-green); border-bottom-color: #BBF7D0;
+}
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table td {
+    padding: 10px 14px; font-size: 13px; color: var(--rbfw-text-2);
+    border-top: 1px solid var(--rbfw-border); background: transparent; vertical-align: middle;
+}
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table tr:first-child td { border-top: none; }
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table td:first-child { color: var(--rbfw-text-3); font-weight: 500; }
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table td:last-child { color: var(--rbfw-text-1); font-weight: 600; text-align: right; }
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table td:only-child { text-align: left; }
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table .woocommerce-Price-amount,
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table bdi { color: var(--rbfw-green); font-weight: 700; }
+/* nested tables (services etc.) stay flat */
+.rbfw_ol .rbfw_order_meta_box_body .wp-list-table .wp-list-table { border: none; border-radius: 0; box-shadow: none; }
+
+/* =========================================================================
+   Responsive
+   ========================================================================= */
+@media (max-width: 1100px) { .rbfw_ol_stats { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 782px) {
+    .rbfw_ol { margin: 12px 10px 36px; }
+    .rbfw_ol_stats { grid-template-columns: repeat(2, 1fr); }
+    .rbfw_ol .rbfw_order_meta_box_body > .wp-list-table { flex-basis: 100%; }
+}
+@media (max-width: 640px) {
+    .rbfw_ol_table_scroll { overflow-x: visible; }
+    .rbfw_ol .rbfw_ol_table { min-width: 0; }
+    .rbfw_ol .rbfw_ol_table thead { display: none; }
+    .rbfw_ol .rbfw_ol_table tbody tr.order-row { display: block; border: 1px solid var(--rbfw-border); border-radius: 10px; margin: 12px; overflow: hidden; }
+    .rbfw_ol .rbfw_ol_table tbody tr.order-row:hover { background: #fff; }
+    .rbfw_ol .rbfw_ol_table td {
+        display: flex; align-items: center; justify-content: space-between; gap: 12px;
+        text-align: right; padding: 10px 14px; border-bottom: 1px dashed var(--rbfw-border); width: auto;
+    }
+    .rbfw_ol .rbfw_ol_table tr.order-row td:last-child { border-bottom: none; }
+    .rbfw_ol .rbfw_ol_table td::before {
+        content: attr(data-th); font-size: 10px; font-weight: 700; text-transform: uppercase;
+        letter-spacing: .5px; color: var(--rbfw-text-3); text-align: left; flex: 0 0 auto;
+    }
+    .rbfw_ol .rbfw_ol_td_action { justify-content: flex-end; }
+}
+@media (max-width: 480px) { .rbfw_ol_stats { grid-template-columns: 1fr; } }
+
+/* ── Status edit modal ── */
+.rbfw_ol_status_modal {
+    position: fixed; inset: 0; z-index: 100000;
+    display: flex; align-items: center; justify-content: center; padding: 20px;
+}
+.rbfw_ol_status_modal_overlay {
+    position: absolute; inset: 0; background: rgba(26,31,54,.55);
+    animation: rbfw_ol_fade .2s ease;
+}
+.rbfw_ol_status_modal_box {
+    position: relative; width: 100%; max-width: 420px;
+    background: var(--rbfw-surface); border-radius: var(--rbfw-radius);
+    box-shadow: 0 20px 60px rgba(26,31,54,.3); overflow: hidden;
+    animation: rbfw_ol_pop .22s cubic-bezier(.4,0,.2,1);
+    font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+@keyframes rbfw_ol_fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes rbfw_ol_pop { from { opacity: 0; transform: translateY(12px) scale(.97); } to { opacity: 1; transform: none; } }
+
+.rbfw_ol_status_modal_head {
+    display: flex; align-items: center; gap: 10px;
+    background: linear-gradient(90deg, var(--rbfw-accent) 0%, var(--rbfw-purple) 100%);
+    color: #fff; padding: 16px 18px;
+}
+.rbfw_ol_status_modal_ic { display: inline-flex; }
+.rbfw_ol_status_modal_ic svg.rbfw_inv_ic { width: 18px; height: 18px; display: block; }
+.rbfw_ol_status_modal_head h2 { margin: 0; padding: 0; font-size: 16px; font-weight: 700; color: #fff; flex: 1; line-height: 1.2; }
+.rbfw_ol_status_modal_close {
+    width: 30px; height: 30px; border: 0; border-radius: 7px; cursor: pointer;
+    background: rgba(255,255,255,.18); color: #fff;
+    display: inline-flex; align-items: center; justify-content: center; padding: 0; transition: background .15s;
+}
+.rbfw_ol_status_modal_close:hover { background: rgba(255,255,255,.32); }
+.rbfw_ol_status_modal_close svg.rbfw_inv_ic { width: 16px; height: 16px; display: block; }
+
+.rbfw_ol_status_modal_body { padding: 20px 18px 8px; }
+.rbfw_ol_status_modal_order { margin: 0 0 16px; font-size: 13px; color: var(--rbfw-text-2); }
+.rbfw_ol_status_modal_order strong { color: var(--rbfw-text-1); }
+.rbfw_ol_status_label { display: block; font-size: 12px; font-weight: 700; color: var(--rbfw-text-2); margin-bottom: 6px; text-transform: uppercase; letter-spacing: .4px; }
+.rbfw_ol_status_modal .rbfw_ol_status_select {
+    width: 100%; height: 42px; padding: 0 36px 0 12px; margin: 0;
+    border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    background-color: var(--rbfw-surface); color: var(--rbfw-text-1); font-size: 14px; font-weight: 600;
+    box-shadow: none; outline: none; line-height: normal; transition: border-color .15s, box-shadow .15s;
+    -webkit-appearance: none; -moz-appearance: none; appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%238896B0' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right 12px center; background-size: 14px 14px;
+    cursor: pointer;
+}
+.rbfw_ol_status_modal .rbfw_ol_status_select:focus { border-color: var(--rbfw-accent); box-shadow: 0 0 0 3px rgba(79,110,247,.12); }
+.rbfw_ol_status_msg { margin: 12px 0 0; padding: 8px 12px; border-radius: var(--rbfw-radius-sm); font-size: 12.5px; font-weight: 600; }
+.rbfw_ol_status_msg.is_error { background: var(--rbfw-red-lt); color: #991B1B; }
+.rbfw_ol_status_msg.is_success { background: var(--rbfw-green-lt); color: #065F46; }
+
+.rbfw_ol_status_modal_foot { display: flex; justify-content: flex-end; gap: 10px; padding: 16px 18px 20px; }
+.rbfw_ol_status_modal_foot button { font-family: inherit; font-size: 13px; font-weight: 700; border-radius: var(--rbfw-radius-sm); cursor: pointer; padding: 9px 18px; transition: all .15s; }
+.rbfw_ol_status_cancel { background: var(--rbfw-bg); border: 1px solid var(--rbfw-border); color: var(--rbfw-text-2); }
+.rbfw_ol_status_cancel:hover { background: #E9EDF5; }
+.rbfw_ol_status_save { background: var(--rbfw-accent); border: 1px solid var(--rbfw-accent); color: #fff; min-width: 120px; }
+.rbfw_ol_status_save:hover { background: #3B5BE0; border-color: #3B5BE0; }
+.rbfw_ol_status_save:disabled { opacity: .6; cursor: default; }
+.rbfw_ol_status_save.is_loading { color: transparent; position: relative; }
+.rbfw_ol_status_save.is_loading::after {
+    content: ''; position: absolute; top: 50%; left: 50%; width: 16px; height: 16px; margin: -8px 0 0 -8px;
+    border: 2px solid rgba(255,255,255,.5); border-top-color: #fff; border-radius: 50%;
+    animation: rbfw_ol_spin .6s linear infinite;
+}
+
+/* ── Delete confirm modal ( red variant, reuses the status modal shell ) ── */
+.rbfw_ol_delete_modal .rbfw_ol_delete_head {
+    background: linear-gradient(90deg, var(--rbfw-red) 0%, #B91C1C 100%);
+}
+.rbfw_ol_delete_text { margin: 0 0 14px; font-size: 13.5px; color: var(--rbfw-text-2); line-height: 1.55; }
+.rbfw_ol_delete_confirm {
+    background: var(--rbfw-red); border: 1px solid var(--rbfw-red); color: #fff; min-width: 130px;
+    font-family: inherit; font-size: 13px; font-weight: 700; border-radius: var(--rbfw-radius-sm);
+    cursor: pointer; padding: 9px 18px; transition: all .15s;
+}
+.rbfw_ol_delete_confirm:hover { background: #DC2626; border-color: #DC2626; }
+.rbfw_ol_delete_confirm:disabled { opacity: .6; cursor: default; }
+.rbfw_ol_delete_confirm.is_loading { color: transparent; position: relative; }
+.rbfw_ol_delete_confirm.is_loading::after {
+    content: ''; position: absolute; top: 50%; left: 50%; width: 16px; height: 16px; margin: -8px 0 0 -8px;
+    border: 2px solid rgba(255,255,255,.5); border-top-color: #fff; border-radius: 50%;
+    animation: rbfw_ol_spin .6s linear infinite;
+}
+
+/* ── Service Information (category-wise add-ons) in order detail ── */
+.rbfw_ol .rbfw_ol_svc_tr > td { vertical-align: top; text-align: left; }
+.rbfw_ol .rbfw_ol_svc {
+    display: flex; flex-direction: column; gap: 12px;
+    text-align: left; margin-top: 4px;
+}
+/* Each category is grouped into its own subtle card */
+.rbfw_ol .rbfw_ol_svc_cat {
+    display: flex; flex-direction: column; gap: 8px;
+    background: var(--rbfw-bg);
+    border: 1px solid var(--rbfw-border);
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+.rbfw_ol .rbfw_ol_svc_cat_title {
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px;
+    color: var(--rbfw-accent); margin: 0;
+    padding-bottom: 8px; border-bottom: 1px solid var(--rbfw-border);
+}
+.rbfw_ol .rbfw_ol_svc_row {
+    display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between;
+    gap: 4px 14px; padding: 4px 0;
+}
+.rbfw_ol .rbfw_ol_svc_row + .rbfw_ol_svc_row { border-top: 1px dashed var(--rbfw-border); }
+.rbfw_ol .rbfw_ol_svc_name { font-weight: 600; color: var(--rbfw-text-1); font-size: 13px; }
+.rbfw_ol .rbfw_ol_svc_calc { font-size: 12px; color: var(--rbfw-text-2); white-space: nowrap; }
+.rbfw_ol .rbfw_ol_svc_calc strong { color: var(--rbfw-green); font-weight: 700; }
+.rbfw_ol .rbfw_ol_svc_calc .woocommerce-Price-amount,
+.rbfw_ol .rbfw_ol_svc_calc bdi { color: inherit; }
+
+/* ── Edit Order modal ── */
+.rbfw_ol_edit_modal .rbfw_ol_edit_box { max-width: 560px; }
+.rbfw_ol_edit_modal .rbfw_ol_edit_body { max-height: 62vh; overflow-y: auto; }
+.rbfw_ol_edit_loading { display: flex; justify-content: center; padding: 28px 0; }
+.rbfw_ol_edit_err { color: #991B1B; font-size: 13px; font-weight: 600; margin: 0; padding: 16px 0; text-align: center; }
+
+.rbfw_ol_edit_modal .rbfw_eo_grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 14px; }
+.rbfw_ol_edit_modal .rbfw_eo_field { display: flex; flex-direction: column; gap: 5px; }
+.rbfw_ol_edit_modal .rbfw_eo_field.rbfw_eo_full { grid-column: 1 / -1; }
+.rbfw_ol_edit_modal .rbfw_eo_field label {
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .3px; color: var(--rbfw-text-2);
+}
+.rbfw_ol_edit_modal .rbfw_eo_field input {
+    height: 38px; padding: 0 11px; margin: 0; width: 100%;
+    border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    background: var(--rbfw-surface); color: var(--rbfw-text-1); font-size: 13px; font-weight: 600;
+    box-shadow: none; outline: none; line-height: normal; box-sizing: border-box; transition: border-color .15s, box-shadow .15s;
+}
+.rbfw_ol_edit_modal .rbfw_eo_field input:focus { border-color: var(--rbfw-accent); box-shadow: 0 0 0 3px rgba(79,110,247,.12); }
+
+.rbfw_ol_edit_modal .rbfw_eo_section_title {
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px;
+    color: var(--rbfw-text-3); margin: 18px 0 8px;
+}
+.rbfw_ol_edit_modal .rbfw_eo_svc_cat {
+    border: 1px solid var(--rbfw-border); border-radius: 10px; padding: 10px 12px; margin-bottom: 10px;
+    display: flex; flex-direction: column; gap: 8px; background: var(--rbfw-bg);
+}
+.rbfw_ol_edit_modal .rbfw_eo_svc_cat_title {
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; color: var(--rbfw-accent);
+    padding-bottom: 8px; border-bottom: 1px solid var(--rbfw-border);
+}
+.rbfw_ol_edit_modal .rbfw_eo_svc_row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.rbfw_ol_edit_modal .rbfw_eo_svc_meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.rbfw_ol_edit_modal .rbfw_eo_svc_name { font-weight: 600; color: var(--rbfw-text-1); font-size: 13px; }
+.rbfw_ol_edit_modal .rbfw_eo_svc_price { font-size: 11px; color: var(--rbfw-text-3); font-weight: 600; }
+.rbfw_ol_edit_modal .rbfw_eo_svc_price em { font-style: normal; color: var(--rbfw-accent); margin-left: 4px; }
+.rbfw_ol_edit_modal .rbfw_eo_svc_qty {
+    width: 64px; height: 34px; flex: 0 0 auto; text-align: center;
+    border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    background: var(--rbfw-surface); color: var(--rbfw-text-1); font-size: 14px; font-weight: 700; box-sizing: border-box;
+}
+.rbfw_ol_edit_modal .rbfw_eo_svc_qty:focus { border-color: var(--rbfw-accent); outline: none; box-shadow: 0 0 0 3px rgba(79,110,247,.12); }
+.rbfw_ol_edit_modal .rbfw_eo_costs { margin-top: 16px; }
+
+.rbfw_ol_edit_modal .rbfw_eo_totals {
+    margin-top: 16px; padding: 12px 14px; border-radius: 10px;
+    background: var(--rbfw-accent-lt); border: 1px solid #d7defc;
+}
+.rbfw_ol_edit_modal .rbfw_eo_total_row {
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: 13px; color: var(--rbfw-text-2); padding: 4px 0;
+}
+.rbfw_ol_edit_modal .rbfw_eo_total_row strong { color: var(--rbfw-text-1); font-weight: 700; }
+.rbfw_ol_edit_modal .rbfw_eo_total_row.rbfw_eo_grand { border-top: 1px solid #d0d9fb; margin-top: 4px; padding-top: 8px; font-size: 15px; }
+.rbfw_ol_edit_modal .rbfw_eo_total_row.rbfw_eo_grand strong { color: var(--rbfw-accent); font-size: 17px; }
+
+.rbfw_ol_edit_modal .rbfw_ol_edit_save {
+    background: var(--rbfw-accent); border: 1px solid var(--rbfw-accent); color: #fff; min-width: 130px;
+    font-family: inherit; font-size: 13px; font-weight: 700; border-radius: var(--rbfw-radius-sm);
+    cursor: pointer; padding: 9px 18px; transition: all .15s; position: relative;
+}
+.rbfw_ol_edit_modal .rbfw_ol_edit_save:hover { background: #3B5BE0; border-color: #3B5BE0; }
+.rbfw_ol_edit_modal .rbfw_ol_edit_save:disabled { opacity: .6; cursor: default; }
+.rbfw_ol_edit_modal .rbfw_ol_edit_save.is_loading { color: transparent; }
+.rbfw_ol_edit_modal .rbfw_ol_edit_save.is_loading::after {
+    content: ''; position: absolute; top: 50%; left: 50%; width: 16px; height: 16px; margin: -8px 0 0 -8px;
+    border: 2px solid rgba(255,255,255,.5); border-top-color: #fff; border-radius: 50%;
+    animation: rbfw_ol_spin .6s linear infinite;
+}
+.rbfw_ol_edit_modal .rbfw_ol_edit_msg { margin: 12px 18px 0; }
+@media (max-width: 540px) { .rbfw_ol_edit_modal .rbfw_eo_grid { grid-template-columns: 1fr; } }
+
+/* Filter-by field chooser + item select sizing */
+.rbfw_ol .rbfw_ol_fb_by .rbfw_ol_filter_select { min-width: 92px; }
+.rbfw_ol .rbfw_ol_fb_item_wrap .rbfw_ol_filter_select { min-width: 170px; max-width: 260px; }
+
+/* ── Custom themed dropdown (modern option list) ── */
+.rbfw_ol .rbfw_ol_dd { display: inline-flex; align-items: center; min-width: 0; }
+.rbfw_ol .rbfw_ol_dd_native { display: none; }
+.rbfw_ol .rbfw_ol_dd_trigger {
+    display: inline-flex; align-items: center; gap: 8px; justify-content: space-between;
+    background: transparent; border: none; outline: none; box-shadow: none; cursor: pointer; padding: 0;
+    font-family: inherit; font-size: 13px; font-weight: 600; color: var(--rbfw-text-1);
+    height: 100%; white-space: nowrap; max-width: 100%;
+}
+.rbfw_ol .rbfw_ol_dd_label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rbfw_ol .rbfw_ol_dd_chev { display: inline-flex; color: var(--rbfw-text-3); transition: transform .18s ease; flex: 0 0 auto; }
+.rbfw_ol .rbfw_ol_dd_chev svg { width: 13px; height: 13px; display: block; }
+.rbfw_ol .rbfw_ol_dd_trigger.open .rbfw_ol_dd_chev { transform: rotate(180deg); }
+
+.rbfw_ol .rbfw_ol_dd_panel {
+    position: absolute; top: calc(100% + 6px); left: 0; z-index: 60;
+    min-width: 180px; max-width: 320px;
+    background: var(--rbfw-surface); border: 1px solid var(--rbfw-border); border-radius: 11px;
+    box-shadow: 0 14px 36px rgba(26,31,54,.16); padding: 6px;
+    max-height: 280px; overflow-y: auto;
+    opacity: 0; transform: translateY(-6px); visibility: hidden;
+    transition: opacity .14s ease, transform .14s ease, visibility .14s;
+}
+.rbfw_ol .rbfw_ol_fb_by .rbfw_ol_dd_panel { min-width: 150px; }
+.rbfw_ol .rbfw_ol_dd_panel.open { opacity: 1; transform: none; visibility: visible; }
+.rbfw_ol .rbfw_ol_dd_opt {
+    display: flex; align-items: center; gap: 8px;
+    padding: 9px 12px; border-radius: 8px; font-size: 13px; font-weight: 600;
+    color: var(--rbfw-text-2); cursor: pointer; white-space: nowrap; transition: background .12s, color .12s;
+}
+.rbfw_ol .rbfw_ol_dd_opt:hover { background: var(--rbfw-bg); color: var(--rbfw-text-1); }
+.rbfw_ol .rbfw_ol_dd_opt.selected { background: var(--rbfw-accent-lt); color: var(--rbfw-accent); }
+.rbfw_ol .rbfw_ol_dd_opt.selected::after {
+    content: ''; margin-left: auto; width: 6px; height: 10px; flex: 0 0 auto;
+    border: solid var(--rbfw-accent); border-width: 0 2px 2px 0; transform: rotate(45deg) translateY(-1px);
+}
+
+/* ── Flatpickr calendar – modern theme (popup lives on <body>) ── */
+.flatpickr-calendar {
+    border-radius: 14px; border: 1px solid #E4E9F2;
+    box-shadow: 0 16px 40px rgba(26,31,54,.18); padding: 4px;
+    font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    z-index: 100060;
+}
+/* Time picker (Edit Order modal) accents */
+.flatpickr-time input:hover, .flatpickr-time input:focus,
+.flatpickr-time .flatpickr-am-pm:hover, .flatpickr-time .flatpickr-am-pm:focus { background: #EEF1FE; }
+.flatpickr-time .numInputWrapper span.arrowUp:after { border-bottom-color: #4F6EF7; }
+.flatpickr-time .numInputWrapper span.arrowDown:after { border-top-color: #4F6EF7; }
+.flatpickr-calendar.arrowTop:before, .flatpickr-calendar.arrowTop:after,
+.flatpickr-calendar.arrowBottom:before, .flatpickr-calendar.arrowBottom:after { display: none; }
+.flatpickr-months { padding-top: 4px; }
+.flatpickr-months .flatpickr-month { color: #1A1F36; }
+.flatpickr-current-month .flatpickr-monthDropdown-months,
+.flatpickr-current-month input.cur-year { font-weight: 700; color: #1A1F36; }
+.flatpickr-months .flatpickr-prev-month, .flatpickr-months .flatpickr-next-month { border-radius: 8px; }
+.flatpickr-months .flatpickr-prev-month:hover svg, .flatpickr-months .flatpickr-next-month:hover svg { fill: #4F6EF7; }
+span.flatpickr-weekday { color: #8896B0; font-weight: 700; font-size: 11px; }
+.flatpickr-day {
+    border-radius: 9px; color: #1A1F36; font-weight: 600; height: 36px; line-height: 36px; max-width: 36px;
+}
+.flatpickr-day:hover, .flatpickr-day:focus { background: #EEF1FE; border-color: #EEF1FE; }
+.flatpickr-day.today { border-color: #4F6EF7; }
+.flatpickr-day.today:hover { background: #EEF1FE; color: #1A1F36; }
+.flatpickr-day.selected, .flatpickr-day.selected:hover,
+.flatpickr-day.selected:focus, .flatpickr-day.startRange, .flatpickr-day.endRange {
+    background: #4F6EF7; border-color: #4F6EF7; color: #fff; box-shadow: none;
+}
+.flatpickr-day.inRange { background: #EEF1FE; border-color: #EEF1FE; box-shadow: -5px 0 0 #EEF1FE, 5px 0 0 #EEF1FE; }
+.flatpickr-day.flatpickr-disabled, .flatpickr-day.prevMonthDay, .flatpickr-day.nextMonthDay { color: #C2C9D6; }
+.flatpickr-day.flatpickr-disabled:hover { background: transparent; }
+
+/* Flatpickr inside the Edit Order modal (static positioning) */
+.rbfw_ol_edit_modal .flatpickr-wrapper { display: block; width: 100%; }
+.rbfw_ol_edit_modal .flatpickr-calendar.static,
+.rbfw_ol_edit_modal .flatpickr-calendar.static.open { z-index: 100070; }

--- a/admin/css/rbfw_timeslots.css
+++ b/admin/css/rbfw_timeslots.css
@@ -1,0 +1,313 @@
+/* =========================================================================
+   RBFW Time Slots page – modern light redesign (primary + secondary colours)
+   Scoped under .rbfw_ts (page) and .rbfw_time_slot_edit_form (edit modal),
+   which mage_modal detaches to <body>, so the modal carries its own scope.
+   ========================================================================= */
+
+.rbfw_ts,
+.rbfw_time_slot_edit_form {
+    --rbfw-bg:         #F4F6FA;
+    --rbfw-surface:    #FFFFFF;
+    --rbfw-border:     #E4E9F2;
+    --rbfw-text-1:     #1A1F36;
+    --rbfw-text-2:     #4A5568;
+    --rbfw-text-3:     #8896B0;
+    --rbfw-primary:    #4F6EF7;   /* primary  */
+    --rbfw-primary-lt: #EEF1FE;
+    --rbfw-secondary:    #7C3AED; /* secondary */
+    --rbfw-secondary-lt: #F3E8FF;
+    --rbfw-red:        #DC2626;
+    --rbfw-red-lt:     #FEE2E2;
+    --rbfw-grad:       linear-gradient(135deg, #4F6EF7 0%, #7C3AED 100%);
+    --rbfw-shadow-sm:  0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+    --rbfw-radius:     12px;
+    --rbfw-radius-sm:  8px;
+}
+
+.rbfw_ts {
+    max-width: 1340px;
+    margin: 16px 20px 48px 0;
+    color: var(--rbfw-text-1);
+    font-size: 14px;
+    line-height: 1.5;
+}
+.rbfw_ts,
+.rbfw_ts *,
+.rbfw_ts *::before,
+.rbfw_ts *::after,
+.rbfw_time_slot_edit_form,
+.rbfw_time_slot_edit_form * {
+    box-sizing: border-box;
+    font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Inline SVG icons */
+.rbfw_ts svg.rbfw_inv_ic,
+.rbfw_time_slot_edit_form svg.rbfw_inv_ic {
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    vertical-align: -0.125em;
+    stroke: currentColor;
+    fill: none;
+    flex: 0 0 auto;
+}
+.rbfw_ts hr.wp-header-end { display: none; }
+
+/* ── Header ── */
+.rbfw_ts_header { display: flex; align-items: center; margin-bottom: 22px; flex-wrap: wrap; gap: 12px; }
+.rbfw_ts_title { display: flex; align-items: center; gap: 12px; }
+.rbfw_ts_title_icon {
+    width: 40px; height: 40px; border-radius: 11px;
+    background: var(--rbfw-grad);
+    display: grid; place-items: center;
+    color: #fff; font-size: 21px;
+    box-shadow: 0 6px 16px rgba(124,58,237,.28);
+}
+.rbfw_ts .rbfw_ts_title h1 {
+    font-size: 22px; font-weight: 700; letter-spacing: -.3px;
+    color: var(--rbfw-text-1); margin: 0; padding: 0;
+}
+.rbfw_ts_badge {
+    background: var(--rbfw-secondary-lt);
+    color: var(--rbfw-secondary);
+    font-size: 12px; font-weight: 600;
+    padding: 4px 11px; border-radius: 20px;
+}
+
+/* ── Cards ── */
+.rbfw_ts_card {
+    background: var(--rbfw-surface);
+    border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius);
+    box-shadow: var(--rbfw-shadow-sm);
+    overflow: hidden;
+}
+.rbfw_ts_form_card {
+    padding: 18px 20px 20px;
+    margin-bottom: 20px;
+    position: relative;
+    overflow: hidden;
+}
+.rbfw_ts_form_card::before {
+    content: ''; position: absolute; left: 0; top: 0; bottom: 0;
+    width: 4px; background: var(--rbfw-grad);
+}
+.rbfw_ts_card_label {
+    display: flex; align-items: center; gap: 7px;
+    font-size: 12px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .5px; color: var(--rbfw-text-2);
+    margin-bottom: 14px;
+}
+.rbfw_ts_card_label svg.rbfw_inv_ic { font-size: 15px; color: var(--rbfw-primary); }
+
+/* ── Form ── */
+.rbfw_ts .rbfw_ts_form {
+    display: flex; align-items: flex-end; gap: 14px; flex-wrap: wrap;
+    padding: 0; border: 0; background: transparent; margin: 0;
+}
+.rbfw_ts .rbfw_ts_field { display: flex; flex-direction: column; gap: 5px; margin: 0; flex: 1 1 200px; }
+.rbfw_ts .rbfw_ts_field label {
+    font-size: 11px; font-weight: 600; letter-spacing: .4px; text-transform: uppercase;
+    color: var(--rbfw-text-3); min-height: 0; line-height: 1.4;
+}
+.rbfw_ts .rbfw_ts_field input {
+    height: 40px; width: 100%;
+    border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius-sm);
+    padding: 0 12px; font-size: 13px;
+    color: var(--rbfw-text-1); background: var(--rbfw-bg);
+    outline: none; box-shadow: none; margin: 0; line-height: 38px;
+    transition: border-color .2s, box-shadow .2s;
+}
+.rbfw_ts .rbfw_ts_field input:focus {
+    border-color: var(--rbfw-primary);
+    box-shadow: 0 0 0 3px rgba(79,110,247,.14);
+    background: #fff;
+}
+.rbfw_ts_form_actions { display: flex; gap: 8px; align-items: flex-end; flex-wrap: wrap; }
+
+/* ── Buttons (page + modal) ── */
+.rbfw_ts .rbfw_ts_btn,
+.rbfw_time_slot_edit_form .rbfw_ts_btn {
+    height: 40px; padding: 0 18px; border: 1px solid transparent;
+    border-radius: var(--rbfw-radius-sm);
+    font-size: 13px; font-weight: 600; cursor: pointer;
+    display: inline-flex; align-items: center; gap: 7px;
+    line-height: 1; text-decoration: none; box-shadow: none;
+    transition: opacity .18s, transform .12s, background .18s, border-color .18s;
+}
+.rbfw_ts .rbfw_ts_btn:active,
+.rbfw_time_slot_edit_form .rbfw_ts_btn:active { transform: scale(.97); }
+.rbfw_ts .rbfw_ts_btn svg.rbfw_inv_ic,
+.rbfw_time_slot_edit_form .rbfw_ts_btn svg.rbfw_inv_ic { font-size: 16px; }
+
+.rbfw_ts .rbfw_ts_btn_primary,
+.rbfw_time_slot_edit_form .rbfw_ts_btn_primary {
+    background: var(--rbfw-primary); color: #fff; border-color: var(--rbfw-primary);
+}
+.rbfw_ts .rbfw_ts_btn_primary:hover,
+.rbfw_time_slot_edit_form .rbfw_ts_btn_primary:hover { background: #3f5cdc; color: #fff; }
+
+.rbfw_ts .rbfw_ts_btn_refresh {
+    background: var(--rbfw-secondary); color: #fff; border-color: var(--rbfw-secondary);
+}
+.rbfw_ts .rbfw_ts_btn_refresh:hover { background: #6a2bd0; color: #fff; }
+
+.rbfw_ts .rbfw_ts_btn_ghost {
+    background: #fff; color: var(--rbfw-text-2); border-color: var(--rbfw-border);
+}
+.rbfw_ts .rbfw_ts_btn_ghost:hover { background: #F1F5F9; color: var(--rbfw-text-1); }
+
+/* ── Table ── */
+.rbfw_ts_table_scroll { overflow-x: auto; }
+.rbfw_ts .rbfw_ts_table {
+    width: 100%; border-collapse: collapse; border: 0; margin: 0;
+    background: var(--rbfw-surface);
+}
+.rbfw_ts .rbfw_ts_table thead th {
+    background: #F8FAFC; border-bottom: 1px solid var(--rbfw-border);
+    padding: 12px 18px; text-align: left;
+    font-size: 11px; font-weight: 700; letter-spacing: .5px;
+    text-transform: uppercase; color: var(--rbfw-text-3); white-space: nowrap;
+}
+.rbfw_ts .rbfw_ts_table thead th.rbfw_ts_th_right { text-align: right; width: 1%; white-space: nowrap; }
+.rbfw_ts .rbfw_ts_table tbody tr {
+    border-bottom: 1px solid var(--rbfw-border); transition: background .14s;
+    background: var(--rbfw-surface);
+}
+.rbfw_ts .rbfw_ts_table tbody tr:last-child { border-bottom: none; }
+.rbfw_ts .rbfw_ts_table tbody tr:hover { background: #F8FAFD; }
+.rbfw_ts .rbfw_ts_table td {
+    padding: 13px 18px; vertical-align: middle; font-size: 13px;
+    border: 0; color: var(--rbfw-text-2); text-align: left;
+}
+.rbfw_ts .rbfw_ts_slot_name { font-weight: 600; color: var(--rbfw-text-1); }
+
+/* Slot time pill = secondary colour */
+.rbfw_ts .rbfw_ts_time_pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: var(--rbfw-secondary-lt); color: var(--rbfw-secondary);
+    border: 1px solid #E4D4FB; border-radius: 20px;
+    padding: 4px 12px; font-size: 12px; font-weight: 700;
+    font-variant-numeric: tabular-nums; white-space: nowrap;
+}
+.rbfw_ts .rbfw_ts_time_pill svg.rbfw_inv_ic { font-size: 13px; }
+
+/* Action buttons */
+.rbfw_ts .rbfw_ts_table td.rbfw_ts_td_action { text-align: right; white-space: nowrap; width: 1%; }
+.rbfw_ts .rbfw_ts_action {
+    display: inline-flex; align-items: center; gap: 6px;
+    height: 30px; padding: 0 12px; border-radius: 7px;
+    font-size: 12px; font-weight: 600; text-decoration: none;
+    cursor: pointer; transition: background .15s, color .15s;
+    vertical-align: middle;
+}
+.rbfw_ts .rbfw_ts_action svg.rbfw_inv_ic { font-size: 15px; }
+.rbfw_ts .rbfw_ts_action_edit { background: var(--rbfw-primary-lt); color: var(--rbfw-primary); }
+.rbfw_ts .rbfw_ts_action_edit:hover { background: #dde5fd; color: var(--rbfw-primary); }
+.rbfw_ts .rbfw_ts_action_del {
+    background: var(--rbfw-red-lt); color: var(--rbfw-red);
+    width: 30px; padding: 0; justify-content: center; margin-left: 6px;
+}
+.rbfw_ts .rbfw_ts_action_del:hover { background: #fbcfcf; color: var(--rbfw-red); }
+
+/* Empty state */
+.rbfw_ts .rbfw_ts_empty {
+    text-align: center; padding: 28px 18px;
+    color: var(--rbfw-text-3); font-size: 13px; font-style: italic;
+}
+
+/* =========================================================================
+   Edit modal
+   ========================================================================= */
+.rbfw_time_slot_edit_form {
+    max-width: 440px; width: 94%;
+    padding: 0; border-radius: 18px; overflow: hidden;
+    background: #fff;
+    box-shadow: 0 24px 60px rgba(15,23,42,.30), 0 4px 16px rgba(15,23,42,.10);
+    color: var(--rbfw-text-1);
+}
+.rbfw_time_slot_edit_form a.close-mage_modal { display: none !important; }
+
+.rbfw_ts_modal_head {
+    padding: 18px 20px 16px; border-bottom: 1px solid var(--rbfw-border);
+    display: flex; align-items: flex-start; gap: 12px;
+}
+.rbfw_ts_modal_icon {
+    width: 40px; height: 40px; border-radius: 10px;
+    background: var(--rbfw-grad); color: #fff;
+    display: grid; place-items: center; flex-shrink: 0; margin-top: 2px;
+    font-size: 19px;
+}
+.rbfw_ts_modal_title_wrap { flex: 1; min-width: 0; }
+.rbfw_ts_modal_title { font-size: 15px; font-weight: 700; color: var(--rbfw-text-1); line-height: 1.4; }
+.rbfw_ts_modal_sub { font-size: 11px; color: var(--rbfw-text-3); margin-top: 3px; }
+.rbfw_ts_modal_close {
+    width: 30px; height: 30px; border-radius: 7px;
+    border: 1px solid var(--rbfw-border); background: var(--rbfw-bg);
+    cursor: pointer; display: grid; place-items: center;
+    color: var(--rbfw-text-3); font-size: 15px; text-decoration: none; flex-shrink: 0;
+    transition: background .15s, color .15s, border-color .15s;
+}
+.rbfw_ts_modal_close:hover { background: var(--rbfw-red-lt); color: var(--rbfw-red); border-color: #FCA5A5; }
+
+.rbfw_ts_modal_body { padding: 18px 20px 20px; }
+.rbfw_time_slot_edit_form .rbfw_ts_field { display: flex; flex-direction: column; gap: 6px; margin: 0 0 16px; }
+.rbfw_time_slot_edit_form .rbfw_ts_field label {
+    font-size: 11px; font-weight: 600; letter-spacing: .4px; text-transform: uppercase; color: var(--rbfw-text-3);
+}
+.rbfw_time_slot_edit_form .rbfw_ts_field input[type="text"] {
+    height: 42px; width: 100%;
+    border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    padding: 0 12px; font-size: 14px; color: var(--rbfw-text-1);
+    background: var(--rbfw-bg); outline: none; box-shadow: none;
+    transition: border-color .2s, box-shadow .2s;
+}
+.rbfw_time_slot_edit_form .rbfw_ts_field input[type="text"]:focus {
+    border-color: var(--rbfw-primary); box-shadow: 0 0 0 3px rgba(79,110,247,.14); background: #fff;
+}
+.rbfw_ts_modal_footer { display: flex; justify-content: flex-end; margin: 0; }
+.rbfw_time_slot_edit_form .rbfw_alert_success {
+    margin: 12px 0 0; padding: 9px 12px; border-radius: 8px;
+    background: #D1FAE5; color: #065F46; font-size: 12px; border: 1px solid #6EE7B7;
+}
+
+/* =========================================================================
+   Responsive
+   ========================================================================= */
+@media (max-width: 782px) {
+    .rbfw_ts { margin: 12px 10px 36px; }
+    .rbfw_ts .rbfw_ts_field { flex: 1 1 100%; }
+    .rbfw_ts_form_actions { width: 100%; }
+    .rbfw_ts .rbfw_ts_btn { flex: 1 1 auto; justify-content: center; }
+}
+
+@media (max-width: 600px) {
+    .rbfw_ts_table_scroll { overflow-x: visible; }
+    .rbfw_ts .rbfw_ts_table { min-width: 0; }
+    .rbfw_ts .rbfw_ts_table thead { display: none; }
+    .rbfw_ts .rbfw_ts_table,
+    .rbfw_ts .rbfw_ts_table tbody,
+    .rbfw_ts .rbfw_ts_table tr,
+    .rbfw_ts .rbfw_ts_table td { display: block; width: 100%; }
+    .rbfw_ts .rbfw_ts_table tr.rbfw_ts_row {
+        border: 1px solid var(--rbfw-border); border-radius: 10px;
+        margin: 12px; overflow: hidden;
+    }
+    .rbfw_ts .rbfw_ts_table tr.rbfw_ts_row:hover { background: #fff; }
+    .rbfw_ts .rbfw_ts_table td {
+        display: flex; align-items: center; justify-content: space-between;
+        gap: 12px; text-align: right; padding: 11px 14px;
+        border-bottom: 1px dashed var(--rbfw-border);
+    }
+    .rbfw_ts .rbfw_ts_table tr.rbfw_ts_row td:last-child { border-bottom: none; }
+    .rbfw_ts .rbfw_ts_table td::before {
+        content: attr(data-th);
+        font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+        color: var(--rbfw-text-3); text-align: left; flex: 0 0 auto;
+    }
+    .rbfw_ts .rbfw_ts_table td.rbfw_ts_td_action { width: 100%; justify-content: flex-end; }
+    .rbfw_ts .rbfw_ts_table td.rbfw_ts_empty { display: block; text-align: center; }
+    .rbfw_ts .rbfw_ts_table td.rbfw_ts_empty::before { content: none; }
+}

--- a/admin/js/rbfw_inventory.js
+++ b/admin/js/rbfw_inventory.js
@@ -1,0 +1,148 @@
+/**
+ * RBFW Inventory page – client-side pagination + detail-modal UX.
+ *
+ * This file is intentionally decoupled from mkb-admin.js: it only reads the
+ * DOM that mkb-admin.js produces, so the existing filter / view-details AJAX
+ * keeps working untouched. Pagination re-initialises automatically whenever the
+ * table is replaced (filter / reset) via a MutationObserver.
+ */
+(function ($) {
+    'use strict';
+
+    var PER_PAGE = 10;
+
+    var SVG_CHEV_L = '<svg class="rbfw_inv_ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 6l-6 6 6 6"/></svg>';
+    var SVG_CHEV_R = '<svg class="rbfw_inv_ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>';
+
+    function i18n() {
+        return (typeof window.rbfwInvI18n === 'object' && window.rbfwInvI18n) ? window.rbfwInvI18n : {
+            showing: 'Showing %1$s–%2$s of %3$s entries',
+            showing_all: 'Showing %s entries'
+        };
+    }
+
+    function fmt(str, vals) {
+        var i = 0;
+        return String(str)
+            .replace(/%(\d+)\$s/g, function (m, n) { return vals[parseInt(n, 10) - 1]; })
+            .replace(/%s/g, function () { return vals[i++]; });
+    }
+
+    function paginate() {
+        var $root = $('.rbfw_inv');
+        if (!$root.length) { return; }
+
+        var $table = $root.find('.rbfw_inventory_page_table_wrap table.rbfw_inv_table').first();
+        var $info  = $root.find('.rbfw_inv_row_info');
+        var $pager = $root.find('.rbfw_inv_pager');
+
+        if (!$table.length) {
+            $info.text('');
+            $pager.empty();
+            return;
+        }
+
+        var $rows = $table.find('tbody > tr').not('.rbfw_inv_empty_tr');
+        var total = $rows.length;
+        var t     = i18n();
+
+        if (total === 0) {
+            $info.text(fmt(t.showing_all, [0]));
+            $pager.empty();
+            return;
+        }
+
+        var pages   = Math.ceil(total / PER_PAGE);
+        var current = 1;
+
+        function buildPager() {
+            $pager.empty();
+
+            if (pages <= 1) {
+                $('<button>', { type: 'button', 'class': 'rbfw_inv_pager_btn active', text: '1' }).appendTo($pager);
+                return;
+            }
+
+            var $prev = $('<button>', { type: 'button', 'class': 'rbfw_inv_pager_btn' })
+                .html(SVG_CHEV_L)
+                .prop('disabled', current === 1)
+                .on('click', function () { show(current - 1); });
+            $pager.append($prev);
+
+            for (var p = 1; p <= pages; p++) {
+                (function (page) {
+                    $('<button>', {
+                        type: 'button',
+                        'class': 'rbfw_inv_pager_btn' + (page === current ? ' active' : ''),
+                        text: page
+                    }).on('click', function () { show(page); }).appendTo($pager);
+                })(p);
+            }
+
+            var $next = $('<button>', { type: 'button', 'class': 'rbfw_inv_pager_btn' })
+                .html(SVG_CHEV_R)
+                .prop('disabled', current === pages)
+                .on('click', function () { show(current + 1); });
+            $pager.append($next);
+        }
+
+        function show(page) {
+            current = Math.min(Math.max(1, page), pages);
+            var start = (current - 1) * PER_PAGE;
+            var end   = start + PER_PAGE;
+
+            $rows.each(function (i) {
+                this.style.display = (i >= start && i < end) ? '' : 'none';
+            });
+
+            $info.text(fmt(t.showing, [start + 1, Math.min(end, total), total]));
+            buildPager();
+        }
+
+        show(1);
+    }
+
+    function observeTable() {
+        var wrap = document.querySelector('.rbfw_inv .rbfw_inventory_page_table_wrap');
+        if (!wrap || typeof window.MutationObserver === 'undefined') { return; }
+
+        var timer = null;
+        var observer = new MutationObserver(function () {
+            clearTimeout(timer);
+            timer = setTimeout(paginate, 30);
+        });
+        observer.observe(wrap, { childList: true });
+    }
+
+    function modalIsActive() {
+        return $.mage_modal && typeof $.mage_modal.isActive === 'function' && $.mage_modal.isActive();
+    }
+
+    function closeModal() {
+        if (modalIsActive()) { $.mage_modal.close(); }
+    }
+
+    $(function () {
+        if (!$('.rbfw_inv').length) { return; }
+
+        paginate();
+        observeTable();
+
+        /* Custom close button inside the redesigned modal. */
+        $(document).on('click', '.rbfw_inv_modal_close', function (e) {
+            e.preventDefault();
+            closeModal();
+        });
+
+        /* Click on the dark overlay (outside the modal box) closes it. */
+        $(document).on('click', '.mage_blocker', function (e) {
+            if (e.target === this) { closeModal(); }
+        });
+
+        /* Escape closes it. */
+        $(document).on('keydown.rbfwInv', function (e) {
+            if (e.key === 'Escape' || e.keyCode === 27) { closeModal(); }
+        });
+    });
+
+})(jQuery);

--- a/admin/js/rbfw_order.js
+++ b/admin/js/rbfw_order.js
@@ -1,0 +1,821 @@
+/**
+ * RBFW Order List – client-side pagination, search, and animated detail expand.
+ * Vanilla JS, no icon-font dependency (inline SVG). Reuses the existing
+ * fetch_order_details AJAX endpoint so all server logic stays untouched.
+ */
+(function () {
+    'use strict';
+
+    function ready(fn) {
+        if (document.readyState !== 'loading') { fn(); }
+        else { document.addEventListener('DOMContentLoaded', fn); }
+    }
+
+    var CHEV_L = '<svg class="rbfw_inv_ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6 6 6"/></svg>';
+    var CHEV_R = '<svg class="rbfw_inv_ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
+    var ICON_X = '<svg class="rbfw_inv_ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>';
+
+    ready(function () {
+        var root = document.querySelector('.rbfw_ol');
+        if (!root) { return; }
+        var tbody = document.getElementById('order-list');
+        if (!tbody) { return; }
+
+        var searchInput = document.getElementById('search');
+        var fbFieldSel  = document.getElementById('rbfw_ol_fb_field');
+        var fbItemSel   = document.getElementById('rbfw_ol_fb_item');
+        var fbTextWrap  = document.getElementById('rbfw_ol_fb_textwrap');
+        var fbItemWrap  = document.getElementById('rbfw_ol_fb_itemwrap');
+        var statusSel   = document.getElementById('rbfw_ol_filter_status');
+        var fromInput   = document.getElementById('rbfw_ol_filter_from');
+        var toInput     = document.getElementById('rbfw_ol_filter_to');
+        var resetBtn    = document.getElementById('rbfw_ol_filter_reset');
+        var info  = document.getElementById('row-info');
+        var pager = document.getElementById('rbfw_ol_pager');
+        var loader = document.getElementById('loader');
+
+        var FB_PLACEHOLDERS = {
+            name:  'Search by name...',
+            order: 'Search by order ID...',
+            phone: 'Search by phone...',
+            email: 'Search by email...'
+        };
+
+        var PER_PAGE = 10;
+        var current = 1;
+        var search = '';
+        var fbField = 'name';
+        var fbItem = '';
+        var statusFilter = '';
+        var fromDate = '';
+        var toDate = '';
+        var fpFrom = null, fpTo = null;
+
+        function orderRows() { return Array.prototype.slice.call(tbody.querySelectorAll('tr.order-row')); }
+        function detailFor(row) { var n = row.nextElementSibling; return (n && n.classList.contains('order-details')) ? n : null; }
+
+        function collapseRow(row) {
+            var d = detailFor(row);
+            if (d) {
+                var a = d.querySelector('.rbfw_ol_detail_anim');
+                if (a) { a.classList.remove('open'); }
+                d.style.display = 'none';
+            }
+            row.classList.remove('rbfw_ol_open');
+            var vb = row.querySelector('.rbfw_order_view_btn');
+            if (vb) { vb.classList.remove('rbfw_ol_act_active'); }
+        }
+
+        function filtered() {
+            return orderRows().filter(function (r) {
+                if (fbField === 'item') {
+                    if (fbItem && (r.getAttribute('data-item') || '').split(' ').indexOf(fbItem) === -1) { return false; }
+                } else if (search) {
+                    if ((r.getAttribute('data-' + fbField) || '').indexOf(search) === -1) { return false; }
+                }
+                if (statusFilter && (r.getAttribute('data-status') || '') !== statusFilter) { return false; }
+                var start = r.getAttribute('data-start') || '';
+                if (fromDate && (!start || start < fromDate)) { return false; }
+                if (toDate && (!start || start > toDate)) { return false; }
+                return true;
+            });
+        }
+
+        function mkBtn(html, active) {
+            var b = document.createElement('button');
+            b.type = 'button';
+            b.className = 'rbfw_ol_pager_btn' + (active ? ' active' : '');
+            b.innerHTML = html;
+            return b;
+        }
+
+        function buildPager(pages) {
+            if (!pager) { return; }
+            pager.innerHTML = '';
+            if (pages <= 1) { pager.appendChild(mkBtn('1', true)); return; }
+
+            var prev = mkBtn(CHEV_L, false);
+            prev.disabled = current === 1;
+            prev.addEventListener('click', function () { go(current - 1); });
+            pager.appendChild(prev);
+
+            for (var p = 1; p <= pages; p++) {
+                (function (pg) {
+                    var btn = mkBtn(String(pg), pg === current);
+                    btn.addEventListener('click', function () { go(pg); });
+                    pager.appendChild(btn);
+                })(p);
+            }
+
+            var next = mkBtn(CHEV_R, false);
+            next.disabled = current === pages;
+            next.addEventListener('click', function () { go(current + 1); });
+            pager.appendChild(next);
+        }
+
+        function go(p) {
+            var pages = Math.max(1, Math.ceil(filtered().length / PER_PAGE));
+            current = Math.min(Math.max(1, p), pages);
+            render();
+        }
+
+        function render() {
+            orderRows().forEach(function (r) { r.style.display = 'none'; collapseRow(r); });
+            var list = filtered();
+            var total = list.length;
+            var pages = Math.max(1, Math.ceil(total / PER_PAGE));
+            if (current > pages) { current = pages; }
+            var start = (current - 1) * PER_PAGE;
+            var end = start + PER_PAGE;
+            list.slice(start, end).forEach(function (r) { r.style.display = ''; });
+            if (info) {
+                info.textContent = total
+                    ? ('Showing ' + (start + 1) + '–' + Math.min(end, total) + ' of ' + total + ' orders')
+                    : 'No orders found';
+            }
+            buildPager(pages);
+        }
+
+        if (searchInput) {
+            searchInput.addEventListener('input', function () {
+                search = this.value.toLowerCase().trim();
+                current = 1;
+                render();
+            });
+        }
+        if (fbFieldSel) {
+            fbFieldSel.addEventListener('change', function () {
+                fbField = this.value;
+                if (fbField === 'item') {
+                    if (fbTextWrap) { fbTextWrap.style.display = 'none'; }
+                    if (fbItemWrap) { fbItemWrap.style.display = ''; }
+                    search = '';
+                    if (searchInput) { searchInput.value = ''; }
+                    fbItem = fbItemSel ? fbItemSel.value : '';
+                } else {
+                    if (fbItemWrap) { fbItemWrap.style.display = 'none'; }
+                    if (fbTextWrap) { fbTextWrap.style.display = ''; }
+                    fbItem = '';
+                    if (searchInput) {
+                        searchInput.placeholder = FB_PLACEHOLDERS[fbField] || 'Search...';
+                        search = searchInput.value.toLowerCase().trim();
+                        searchInput.focus();
+                    }
+                }
+                current = 1;
+                render();
+            });
+        }
+        if (fbItemSel) {
+            fbItemSel.addEventListener('change', function () { fbItem = this.value; current = 1; render(); });
+        }
+        if (statusSel) {
+            statusSel.addEventListener('change', function () { statusFilter = this.value; current = 1; render(); });
+        }
+        if (fromInput) {
+            fromInput.addEventListener('change', function () { fromDate = this.value; current = 1; render(); });
+        }
+        if (toInput) {
+            toInput.addEventListener('change', function () { toDate = this.value; current = 1; render(); });
+        }
+        if (typeof flatpickr !== 'undefined') {
+            var fpBase = { dateFormat: 'Y-m-d', altInput: true, altFormat: 'M j, Y', altInputClass: 'rbfw_ol_filter_date rbfw_ol_fp_alt', disableMobile: true };
+            if (fromInput) {
+                fpFrom = flatpickr(fromInput, Object.assign({}, fpBase, {
+                    onChange: function (sel, dateStr) { fromDate = dateStr; current = 1; render(); }
+                }));
+            }
+            if (toInput) {
+                fpTo = flatpickr(toInput, Object.assign({}, fpBase, {
+                    onChange: function (sel, dateStr) { toDate = dateStr; current = 1; render(); }
+                }));
+            }
+        }
+        if (resetBtn) {
+            resetBtn.addEventListener('click', function () {
+                search = ''; statusFilter = ''; fromDate = ''; toDate = '';
+                fbField = 'name'; fbItem = '';
+                if (searchInput) { searchInput.value = ''; searchInput.placeholder = FB_PLACEHOLDERS.name; }
+                if (fbFieldSel) { fbFieldSel.value = 'name'; }
+                if (fbItemSel) { fbItemSel.value = ''; }
+                if (fbItemWrap) { fbItemWrap.style.display = 'none'; }
+                if (fbTextWrap) { fbTextWrap.style.display = ''; }
+                if (statusSel) { statusSel.value = ''; }
+                if (fpFrom) { fpFrom.clear(); } else if (fromInput) { fromInput.value = ''; }
+                if (fpTo) { fpTo.clear(); } else if (toInput) { toInput.value = ''; }
+                rbfwSyncAllDropdowns();
+                current = 1;
+                render();
+            });
+        }
+
+        /* ── modern themed dropdowns (custom option list for the filter selects) ── */
+        var DD_CHEV = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>';
+        var rbfwDropdowns = [];
+        function rbfwCloseAllDropdowns(except) {
+            rbfwDropdowns.forEach(function (dd) { if (dd !== except) { dd.close(); } });
+        }
+        function rbfwSyncAllDropdowns() { rbfwDropdowns.forEach(function (dd) { dd.sync(); }); }
+
+        function rbfwEnhanceSelect(select) {
+            if (!select || select.getAttribute('data-rbfw-dd') === '1') { return; }
+            select.setAttribute('data-rbfw-dd', '1');
+            var field = select.closest('.rbfw_ol_filter_field') || select.parentNode;
+
+            var wrap = document.createElement('span');
+            wrap.className = 'rbfw_ol_dd';
+            select.parentNode.insertBefore(wrap, select);
+            wrap.appendChild(select);
+            select.classList.add('rbfw_ol_dd_native');
+
+            var trigger = document.createElement('button');
+            trigger.type = 'button';
+            trigger.className = 'rbfw_ol_dd_trigger';
+            var lab = document.createElement('span');
+            lab.className = 'rbfw_ol_dd_label';
+            var chev = document.createElement('span');
+            chev.className = 'rbfw_ol_dd_chev';
+            chev.innerHTML = DD_CHEV;
+            trigger.appendChild(lab);
+            trigger.appendChild(chev);
+            wrap.appendChild(trigger);
+
+            var panel = document.createElement('div');
+            panel.className = 'rbfw_ol_dd_panel';
+            field.appendChild(panel);
+
+            var ctx = { open: false };
+            function syncLabel() {
+                var o = select.options[select.selectedIndex];
+                lab.textContent = o ? o.textContent : '';
+            }
+            function build() {
+                panel.innerHTML = '';
+                Array.prototype.forEach.call(select.options, function (opt) {
+                    var it = document.createElement('div');
+                    it.className = 'rbfw_ol_dd_opt' + (opt.value === select.value ? ' selected' : '');
+                    it.textContent = opt.textContent;
+                    it.addEventListener('click', function (e) {
+                        e.stopPropagation();
+                        if (select.value !== opt.value) {
+                            select.value = opt.value;
+                            select.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                        syncLabel();
+                        ctx.close();
+                    });
+                    panel.appendChild(it);
+                });
+            }
+            ctx.close = function () {
+                if (!ctx.open) { return; }
+                panel.classList.remove('open');
+                trigger.classList.remove('open');
+                ctx.open = false;
+            };
+            ctx.sync = syncLabel;
+            trigger.addEventListener('click', function (e) {
+                e.preventDefault(); e.stopPropagation();
+                if (ctx.open) { ctx.close(); return; }
+                rbfwCloseAllDropdowns(ctx);
+                build();
+                panel.classList.add('open');
+                trigger.classList.add('open');
+                ctx.open = true;
+            });
+            syncLabel();
+            rbfwDropdowns.push(ctx);
+        }
+
+        Array.prototype.forEach.call(root.querySelectorAll('.rbfw_ol_filter_select'), rbfwEnhanceSelect);
+        document.addEventListener('click', function () { rbfwCloseAllDropdowns(); });
+        document.addEventListener('keydown', function (e) { if (e.key === 'Escape') { rbfwCloseAllDropdowns(); } });
+
+        /* ── status edit popup ── */
+        var statusModal = document.getElementById('rbfw_ol_status_modal');
+        var statusCtx   = { row: null, btn: null, postId: null };
+
+        function statusEls() {
+            return {
+                orderNo: document.getElementById('rbfw_ol_status_order_no'),
+                select:  document.getElementById('rbfw_ol_status_select'),
+                msg:     document.getElementById('rbfw_ol_status_msg'),
+                save:    statusModal ? statusModal.querySelector('.rbfw_ol_status_save') : null
+            };
+        }
+
+        function showStatusMsg(text, type) {
+            var els = statusEls();
+            if (!els.msg) { return; }
+            els.msg.textContent = text;
+            els.msg.className = 'rbfw_ol_status_msg ' + (type === 'error' ? 'is_error' : 'is_success');
+            els.msg.style.display = 'block';
+        }
+
+        function openStatusModal(btn) {
+            if (!statusModal) { return; }
+            var els = statusEls();
+            statusCtx.btn    = btn;
+            statusCtx.row    = btn.closest('tr.order-row');
+            statusCtx.postId = btn.getAttribute('data-post-id');
+            if (els.orderNo) { els.orderNo.textContent = btn.getAttribute('data-order-no') || ''; }
+            if (els.select)  { els.select.value = btn.getAttribute('data-status') || ''; }
+            if (els.msg)     { els.msg.style.display = 'none'; els.msg.textContent = ''; }
+            if (els.save)    { els.save.disabled = false; els.save.classList.remove('is_loading'); }
+            statusModal.style.display = 'flex';
+            statusModal.setAttribute('aria-hidden', 'false');
+            if (els.select) { els.select.focus(); }
+        }
+
+        function closeStatusModal() {
+            if (!statusModal) { return; }
+            statusModal.style.display = 'none';
+            statusModal.setAttribute('aria-hidden', 'true');
+            statusCtx.row = statusCtx.btn = statusCtx.postId = null;
+        }
+
+        function saveStatus() {
+            if (!statusModal || !statusCtx.postId) { return; }
+            var els = statusEls();
+            var newStatus = els.select ? els.select.value : '';
+            if (!newStatus) { return; }
+            if (els.save) { els.save.disabled = true; els.save.classList.add('is_loading'); }
+            if (els.msg)  { els.msg.style.display = 'none'; }
+
+            var body = 'action=rbfw_update_order_status' +
+                       '&post_id=' + encodeURIComponent(statusCtx.postId) +
+                       '&status='  + encodeURIComponent(newStatus) +
+                       '&nonce='   + encodeURIComponent(rbfw_ajax_admin.nonce_update_order_status);
+
+            fetch(rbfw_ajax_admin.rbfw_ajaxurl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (res) {
+                    if (els.save) { els.save.disabled = false; els.save.classList.remove('is_loading'); }
+                    if (!res || !res.success) {
+                        var emsg = (res && res.data && res.data.message) ? res.data.message : 'Update failed.';
+                        showStatusMsg(emsg, 'error');
+                        return;
+                    }
+                    var status = res.data.status;
+                    var label  = res.data.status_label || status;
+                    /* update the row badge + button so the list reflects the change live */
+                    if (statusCtx.row) {
+                        var badge = statusCtx.row.querySelector('.rbfw_ol_badge');
+                        if (badge) {
+                            badge.className = 'rbfw_ol_badge rbfw_ol_badge_' + status;
+                            badge.textContent = label;
+                        }
+                    }
+                    if (statusCtx.btn) { statusCtx.btn.setAttribute('data-status', status); }
+                    showStatusMsg(res.data.message || 'Order status updated.', 'success');
+                    setTimeout(closeStatusModal, 700);
+                })
+                .catch(function () {
+                    if (els.save) { els.save.disabled = false; els.save.classList.remove('is_loading'); }
+                    showStatusMsg('Network error. Please try again.', 'error');
+                });
+        }
+
+        if (statusModal) {
+            statusModal.addEventListener('click', function (e) {
+                if (e.target.closest('.rbfw_ol_status_save'))   { e.preventDefault(); saveStatus(); return; }
+                if (e.target.closest('.rbfw_ol_status_cancel') ||
+                    e.target.closest('.rbfw_ol_status_modal_close') ||
+                    e.target.classList.contains('rbfw_ol_status_modal_overlay')) {
+                    e.preventDefault(); closeStatusModal();
+                }
+            });
+            document.addEventListener('keydown', function (e) {
+                if (e.key === 'Escape' && statusModal.style.display === 'flex') { closeStatusModal(); }
+            });
+        }
+
+        /* ── delete ( move to trash ) popup ── */
+        var deleteModal = document.getElementById('rbfw_ol_delete_modal');
+        var deleteCtx   = { row: null, postId: null };
+
+        function deleteEls() {
+            return {
+                orderNo: document.getElementById('rbfw_ol_delete_order_no'),
+                msg:     document.getElementById('rbfw_ol_delete_msg'),
+                confirm: deleteModal ? deleteModal.querySelector('.rbfw_ol_delete_confirm') : null
+            };
+        }
+
+        function showDeleteMsg(text, type) {
+            var els = deleteEls();
+            if (!els.msg) { return; }
+            els.msg.textContent = text;
+            els.msg.className = 'rbfw_ol_status_msg ' + (type === 'error' ? 'is_error' : 'is_success');
+            els.msg.style.display = 'block';
+        }
+
+        function openDeleteModal(btn) {
+            if (!deleteModal) { return; }
+            var els = deleteEls();
+            deleteCtx.row    = btn.closest('tr.order-row');
+            deleteCtx.postId = btn.getAttribute('data-post-id');
+            if (els.orderNo) { els.orderNo.textContent = btn.getAttribute('data-order-no') || ''; }
+            if (els.msg)     { els.msg.style.display = 'none'; els.msg.textContent = ''; }
+            if (els.confirm) { els.confirm.disabled = false; els.confirm.classList.remove('is_loading'); }
+            deleteModal.style.display = 'flex';
+            deleteModal.setAttribute('aria-hidden', 'false');
+        }
+
+        function closeDeleteModal() {
+            if (!deleteModal) { return; }
+            deleteModal.style.display = 'none';
+            deleteModal.setAttribute('aria-hidden', 'true');
+            deleteCtx.row = deleteCtx.postId = null;
+        }
+
+        function applyStats(stats, headerText) {
+            if (stats) {
+                Object.keys(stats).forEach(function (key) {
+                    var card = root.querySelector('[data-stat="' + key + '"]');
+                    if (!card) { return; }
+                    var num = card.querySelector('.rbfw_ol_stat_num');
+                    var amt = card.querySelector('.rbfw_ol_stat_amt');
+                    if (num) { num.textContent = stats[key].count; }
+                    if (amt) {
+                        amt.innerHTML = stats[key].amount;
+                        amt.className = 'rbfw_ol_stat_amt ' + (stats[key].pos ? 'pos' : 'zero');
+                    }
+                });
+            }
+            var headBadge = root.querySelector('.rbfw_ol_badge_count');
+            if (headBadge && headerText) { headBadge.textContent = headerText; }
+        }
+
+        function confirmDelete() {
+            if (!deleteModal || !deleteCtx.postId) { return; }
+            var els = deleteEls();
+            if (els.confirm) { els.confirm.disabled = true; els.confirm.classList.add('is_loading'); }
+            if (els.msg)     { els.msg.style.display = 'none'; }
+
+            var body = 'action=rbfw_delete_order' +
+                       '&post_id=' + encodeURIComponent(deleteCtx.postId) +
+                       '&nonce='   + encodeURIComponent(rbfw_ajax_admin.nonce_delete_order);
+
+            fetch(rbfw_ajax_admin.rbfw_ajaxurl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (res) {
+                    if (els.confirm) { els.confirm.disabled = false; els.confirm.classList.remove('is_loading'); }
+                    if (!res || !res.success) {
+                        var emsg = (res && res.data && res.data.message) ? res.data.message : 'Delete failed.';
+                        showDeleteMsg(emsg, 'error');
+                        return;
+                    }
+                    /* remove the order row + its detail row, then refresh stats & pager */
+                    var pid = deleteCtx.postId;
+                    if (deleteCtx.row) { deleteCtx.row.parentNode.removeChild(deleteCtx.row); }
+                    var detail = document.getElementById('order-details-' + pid);
+                    if (detail) { detail.parentNode.removeChild(detail); }
+                    applyStats(res.data.stats, res.data.header);
+                    closeDeleteModal();
+                    render();
+                })
+                .catch(function () {
+                    if (els.confirm) { els.confirm.disabled = false; els.confirm.classList.remove('is_loading'); }
+                    showDeleteMsg('Network error. Please try again.', 'error');
+                });
+        }
+
+        if (deleteModal) {
+            deleteModal.addEventListener('click', function (e) {
+                if (e.target.closest('.rbfw_ol_delete_confirm')) { e.preventDefault(); confirmDelete(); return; }
+                if (e.target.closest('.rbfw_ol_delete_cancel') ||
+                    e.target.closest('.rbfw_ol_status_modal_close') ||
+                    e.target.classList.contains('rbfw_ol_status_modal_overlay')) {
+                    e.preventDefault(); closeDeleteModal();
+                }
+            });
+            document.addEventListener('keydown', function (e) {
+                if (e.key === 'Escape' && deleteModal.style.display === 'flex') { closeDeleteModal(); }
+            });
+        }
+
+        /* ── full order edit popup ── */
+        var editModal = document.getElementById('rbfw_ol_edit_modal');
+        var editBody  = document.getElementById('rbfw_ol_edit_body');
+        var editCtx   = { postId: null };
+        var editPickers = [];
+
+        function eoEls() {
+            return {
+                msg:  document.getElementById('rbfw_ol_edit_msg'),
+                save: editModal ? editModal.querySelector('.rbfw_ol_edit_save') : null
+            };
+        }
+        function eoVal(sel) { var el = editBody ? editBody.querySelector(sel) : null; return el ? el.value : ''; }
+        function eoMoney(n) {
+            var sym = (typeof rbfw_ajax_admin !== 'undefined' && rbfw_ajax_admin.currency_symbol) ? rbfw_ajax_admin.currency_symbol : '';
+            n = Math.round((n + Number.EPSILON) * 100) / 100;
+            return n.toFixed(2) + (sym ? (' ' + sym) : '');
+        }
+        function eoCalcDays() {
+            var sd = eoVal('#rbfw_eo_start_date'), ed = eoVal('#rbfw_eo_end_date');
+            var fb = parseInt(eoVal('#rbfw_eo_total_days'), 10) || 1;
+            if (!sd || !ed) { return fb; }
+            var d = Math.round((new Date(ed) - new Date(sd)) / 86400000);
+            return d > 0 ? d : 1;
+        }
+        function eoRecalc() {
+            if (!editBody) { return; }
+            var days = eoCalcDays();
+            var resource = 0;
+            editBody.querySelectorAll('.rbfw_eo_svc_qty').forEach(function (inp) {
+                var qty = parseInt(inp.value, 10) || 0;
+                if (qty <= 0) { return; }
+                var price = parseFloat(inp.getAttribute('data-price')) || 0;
+                resource += (inp.getAttribute('data-type') === 'day_wise') ? price * qty * days : price * qty;
+            });
+            var duration = parseFloat(eoVal('#rbfw_eo_duration')) || 0;
+            var mgmt     = parseFloat(eoVal('#rbfw_eo_management')) || 0;
+            var disc     = parseFloat(eoVal('#rbfw_eo_discount')) || 0;
+            var dep      = parseFloat(eoVal('#rbfw_eo_deposit')) || 0;
+            var lineTotal = Math.max(0, duration + resource + mgmt - disc);
+            var setT = function (sel, v) { var el = editBody.querySelector(sel); if (el) { el.textContent = v; } };
+            setT('#rbfw_eo_resource', eoMoney(resource));
+            setT('#rbfw_eo_subtotal', eoMoney(lineTotal));
+            setT('#rbfw_eo_total', eoMoney(lineTotal + dep));
+        }
+        function showEoMsg(text, type) {
+            var els = eoEls();
+            if (!els.msg) { return; }
+            els.msg.textContent = text;
+            els.msg.className = 'rbfw_ol_status_msg rbfw_ol_edit_msg ' + (type === 'error' ? 'is_error' : 'is_success');
+            els.msg.style.display = 'block';
+        }
+        function destroyEditPickers() {
+            editPickers.forEach(function (fp) { try { fp.destroy(); } catch (e) {} });
+            editPickers = [];
+        }
+        function initEditPickers() {
+            if (typeof flatpickr === 'undefined' || !editBody) { return; }
+            // static:true keeps the calendar anchored to the input inside the fixed modal
+            // (default body-append + scroll math positions it off-screen on a scrolled page).
+            editBody.querySelectorAll('.rbfw_eo_fp_date').forEach(function (el) {
+                editPickers.push(flatpickr(el, {
+                    dateFormat: 'Y-m-d', altInput: true, altFormat: 'M j, Y',
+                    altInputClass: 'rbfw_eo_fp_alt', disableMobile: true, static: true, onChange: eoRecalc
+                }));
+            });
+            editBody.querySelectorAll('.rbfw_eo_fp_time').forEach(function (el) {
+                editPickers.push(flatpickr(el, {
+                    enableTime: true, noCalendar: true, dateFormat: 'H:i', time_24hr: true,
+                    disableMobile: true, static: true, onChange: eoRecalc
+                }));
+            });
+        }
+        function openEditModal(btn) {
+            if (!editModal || !editBody) { return; }
+            editCtx.postId = btn.getAttribute('data-post-id');
+            var els = eoEls();
+            if (els.msg)  { els.msg.style.display = 'none'; els.msg.textContent = ''; }
+            if (els.save) { els.save.disabled = false; els.save.classList.remove('is_loading'); }
+            destroyEditPickers();
+            editBody.innerHTML = '<div class="rbfw_ol_edit_loading"><span class="rbfw_ol_spinner"></span></div>';
+            editModal.style.display = 'flex';
+            editModal.setAttribute('aria-hidden', 'false');
+
+            var body = 'action=rbfw_get_order_edit_form&post_id=' + encodeURIComponent(editCtx.postId) +
+                       '&nonce=' + encodeURIComponent(rbfw_ajax_admin.nonce_get_order_edit_form);
+            fetch(rbfw_ajax_admin.rbfw_ajaxurl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (res) {
+                    if (!res || !res.success) {
+                        editBody.innerHTML = '<p class="rbfw_ol_edit_err">' + ((res && res.data && res.data.message) ? res.data.message : 'Failed to load.') + '</p>';
+                        return;
+                    }
+                    editBody.innerHTML = res.data.html;
+                    initEditPickers();
+                    eoRecalc();
+                })
+                .catch(function () { editBody.innerHTML = '<p class="rbfw_ol_edit_err">Network error.</p>'; });
+        }
+        function closeEditModal() {
+            if (!editModal) { return; }
+            destroyEditPickers();
+            editModal.style.display = 'none';
+            editModal.setAttribute('aria-hidden', 'true');
+            editCtx.postId = null;
+        }
+        function refreshDetail(postId) {
+            var content = document.querySelector('#order-details-' + postId + ' .order-details-content');
+            if (!content) { return; }
+            var body = 'action=fetch_order_details&post_id=' + encodeURIComponent(postId) +
+                       '&nonce=' + encodeURIComponent(rbfw_ajax_admin.nonce_fetch_order_details);
+            fetch(rbfw_ajax_admin.rbfw_ajaxurl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            })
+                .then(function (r) { return r.text(); })
+                .then(function (html) {
+                    content.innerHTML = html;
+                    content.setAttribute('data-loaded', '1');
+                    injectClose(document.getElementById('order-details-' + postId), postId);
+                });
+        }
+        function saveEdit() {
+            if (!editModal || !editCtx.postId) { return; }
+            var els = eoEls();
+            if (els.save) { els.save.disabled = true; els.save.classList.add('is_loading'); }
+            if (els.msg)  { els.msg.style.display = 'none'; }
+
+            var parts = [
+                'action=rbfw_save_order_edit',
+                'post_id=' + encodeURIComponent(editCtx.postId),
+                'nonce=' + encodeURIComponent(rbfw_ajax_admin.nonce_save_order_edit),
+                'start_date=' + encodeURIComponent(eoVal('#rbfw_eo_start_date')),
+                'start_time=' + encodeURIComponent(eoVal('#rbfw_eo_start_time')),
+                'end_date=' + encodeURIComponent(eoVal('#rbfw_eo_end_date')),
+                'end_time=' + encodeURIComponent(eoVal('#rbfw_eo_end_time')),
+                'duration_cost=' + encodeURIComponent(eoVal('#rbfw_eo_duration')),
+                'management_price=' + encodeURIComponent(eoVal('#rbfw_eo_management')),
+                'discount_amount=' + encodeURIComponent(eoVal('#rbfw_eo_discount')),
+                'security_deposit=' + encodeURIComponent(eoVal('#rbfw_eo_deposit')),
+                'billing_first_name=' + encodeURIComponent(eoVal('#rbfw_eo_b_first')),
+                'billing_last_name=' + encodeURIComponent(eoVal('#rbfw_eo_b_last')),
+                'billing_email=' + encodeURIComponent(eoVal('#rbfw_eo_b_email')),
+                'billing_phone=' + encodeURIComponent(eoVal('#rbfw_eo_b_phone')),
+                'billing_company=' + encodeURIComponent(eoVal('#rbfw_eo_b_company')),
+                'billing_address_1=' + encodeURIComponent(eoVal('#rbfw_eo_b_addr1')),
+                'billing_address_2=' + encodeURIComponent(eoVal('#rbfw_eo_b_addr2')),
+                'billing_city=' + encodeURIComponent(eoVal('#rbfw_eo_b_city')),
+                'billing_state=' + encodeURIComponent(eoVal('#rbfw_eo_b_state')),
+                'billing_postcode=' + encodeURIComponent(eoVal('#rbfw_eo_b_postcode')),
+                'billing_country=' + encodeURIComponent(eoVal('#rbfw_eo_b_country'))
+            ];
+            editBody.querySelectorAll('.rbfw_eo_svc_qty').forEach(function (inp) {
+                var c = inp.getAttribute('data-cat'), s = inp.getAttribute('data-svc');
+                var q = parseInt(inp.value, 10) || 0;
+                parts.push('service_qty[' + encodeURIComponent(c) + '][' + encodeURIComponent(s) + ']=' + encodeURIComponent(q));
+            });
+            editBody.querySelectorAll('.rbfw_eo_regf').forEach(function (inp) {
+                var k = inp.getAttribute('data-key');
+                parts.push('regf[' + encodeURIComponent(k) + ']=' + encodeURIComponent(inp.value));
+            });
+
+            fetch(rbfw_ajax_admin.rbfw_ajaxurl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: parts.join('&')
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (res) {
+                    if (els.save) { els.save.disabled = false; els.save.classList.remove('is_loading'); }
+                    if (!res || !res.success) {
+                        showEoMsg((res && res.data && res.data.message) ? res.data.message : 'Update failed.', 'error');
+                        return;
+                    }
+                    var pid = editCtx.postId;
+                    var vbtn = document.querySelector('.rbfw_order_view_btn[data-post-id="' + pid + '"]');
+                    var row  = vbtn ? vbtn.closest('tr.order-row') : null;
+                    if (row) {
+                        var totalCell = row.querySelector('.rbfw_ol_td_total');
+                        if (totalCell && res.data.total_html) { totalCell.innerHTML = res.data.total_html; }
+                        var nameCell = row.querySelector('.rbfw_ol_td_name');
+                        if (nameCell && res.data.billing) { nameCell.textContent = res.data.billing; }
+                        var dates = row.querySelectorAll('.rbfw_ol_td_date');
+                        if (dates[1] && res.data.start_display) { dates[1].textContent = res.data.start_display; }
+                        if (dates[2] && res.data.end_display) { dates[2].textContent = res.data.end_display; }
+                    }
+                    refreshDetail(pid);
+                    showEoMsg(res.data.message || 'Order updated.', 'success');
+                    setTimeout(closeEditModal, 800);
+                })
+                .catch(function () {
+                    if (els.save) { els.save.disabled = false; els.save.classList.remove('is_loading'); }
+                    showEoMsg('Network error. Please try again.', 'error');
+                });
+        }
+        if (editModal) {
+            if (editBody) { editBody.addEventListener('input', eoRecalc); }
+            editModal.addEventListener('click', function (e) {
+                if (e.target.closest('.rbfw_ol_edit_save')) { e.preventDefault(); saveEdit(); return; }
+                // Only the close (×) and Cancel buttons close this modal — an outside
+                // (overlay) click or Esc must NOT close it, to avoid losing unsaved edits.
+                if (e.target.closest('.rbfw_ol_edit_cancel') ||
+                    e.target.closest('.rbfw_ol_edit_close')) {
+                    e.preventDefault(); closeEditModal();
+                }
+            });
+        }
+
+        /* ── detail expand / collapse with slide animation ── */
+        function injectClose(detailRow, postId) {
+            var head = detailRow.querySelector('.rbfw_order_meta_box_head');
+            if (head && !head.querySelector('.rbfw_ol_detail_close')) {
+                var b = document.createElement('button');
+                b.type = 'button';
+                b.className = 'rbfw_ol_detail_close';
+                b.setAttribute('data-post-id', postId);
+                b.innerHTML = ICON_X;
+                head.appendChild(b);
+            }
+        }
+
+        function openDetail(row, postId) {
+            var detailRow = document.getElementById('order-details-' + postId);
+            if (!detailRow) { return; }
+            var anim = detailRow.querySelector('.rbfw_ol_detail_anim');
+            var content = detailRow.querySelector('.order-details-content');
+            detailRow.style.display = 'table-row';
+            row.classList.add('rbfw_ol_open');
+            var vb = row.querySelector('.rbfw_order_view_btn');
+            if (vb) { vb.classList.add('rbfw_ol_act_active'); }
+
+            if (content.getAttribute('data-loaded') === '1') {
+                requestAnimationFrame(function () { anim.classList.add('open'); });
+                return;
+            }
+
+            if (loader) { loader.style.display = 'flex'; }
+            var body = 'action=fetch_order_details&post_id=' + encodeURIComponent(postId) +
+                       '&nonce=' + encodeURIComponent(rbfw_ajax_admin.nonce_fetch_order_details);
+            fetch(rbfw_ajax_admin.rbfw_ajaxurl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            })
+                .then(function (r) { return r.text(); })
+                .then(function (html) {
+                    content.innerHTML = html;
+                    content.setAttribute('data-loaded', '1');
+                    injectClose(detailRow, postId);
+                    if (loader) { loader.style.display = 'none'; }
+                    requestAnimationFrame(function () {
+                        requestAnimationFrame(function () { anim.classList.add('open'); });
+                    });
+                })
+                .catch(function () { if (loader) { loader.style.display = 'none'; } });
+        }
+
+        function closeDetail(row, postId) {
+            var detailRow = document.getElementById('order-details-' + postId);
+            if (!detailRow) { return; }
+            var anim = detailRow.querySelector('.rbfw_ol_detail_anim');
+            if (anim) { anim.classList.remove('open'); }
+            row.classList.remove('rbfw_ol_open');
+            var vb = row.querySelector('.rbfw_order_view_btn');
+            if (vb) { vb.classList.remove('rbfw_ol_act_active'); }
+            setTimeout(function () { detailRow.style.display = 'none'; }, 380);
+        }
+
+        root.addEventListener('click', function (e) {
+            var statusBtn = e.target.closest ? e.target.closest('.rbfw_order_status_edit_btn') : null;
+            if (statusBtn) {
+                e.preventDefault();
+                openStatusModal(statusBtn);
+                return;
+            }
+            var delBtn = e.target.closest ? e.target.closest('.rbfw_order_delete_btn') : null;
+            if (delBtn) {
+                e.preventDefault();
+                openDeleteModal(delBtn);
+                return;
+            }
+            var editBtn = e.target.closest ? e.target.closest('.rbfw_ol_edit_order_btn') : null;
+            if (editBtn) {
+                e.preventDefault();
+                openEditModal(editBtn);
+                return;
+            }
+            var view = e.target.closest ? e.target.closest('.rbfw_order_view_btn') : null;
+            if (view) {
+                e.preventDefault();
+                var postId = view.getAttribute('data-post-id');
+                var row = view.closest('tr.order-row');
+                var detailRow = document.getElementById('order-details-' + postId);
+                var isOpen = detailRow && detailRow.style.display !== 'none' &&
+                    detailRow.querySelector('.rbfw_ol_detail_anim').classList.contains('open');
+                if (isOpen) { closeDetail(row, postId); } else { openDetail(row, postId); }
+                return;
+            }
+            var close = e.target.closest ? e.target.closest('.rbfw_ol_detail_close') : null;
+            if (close) {
+                e.preventDefault();
+                var pid = close.getAttribute('data-post-id');
+                var vbtn = document.querySelector('.rbfw_order_view_btn[data-post-id="' + pid + '"]');
+                var prow = vbtn ? vbtn.closest('tr.order-row') : null;
+                if (prow) { closeDetail(prow, pid); }
+            }
+        });
+
+        render();
+    });
+})();

--- a/assets/mp_script/md_script.js
+++ b/assets/mp_script/md_script.js
@@ -1329,17 +1329,34 @@ function calculateTotalSingleItem() {
     });
 
     // Loop through qty-based services (Multiple Day — no checkbox)
+    let rbfw_days_label = (typeof rbfw_translation !== 'undefined' && rbfw_translation.days) ? rbfw_translation.days : 'Days';
     jQuery('.multi-service-category-section .rbfw_service_qty').each(function() {
         let qty = parseInt(jQuery(this).val()) || 0;
+        let $row = jQuery(this).closest('tr');
+        let $calc = $row.find('.rbfw_service_day_calc');
         if (qty > 0) {
             let price = parseFloat(jQuery(this).data('price')) || 0;
-            let service_price_type = jQuery(this).closest('tr').find('input[name*="[service_price_type]"]').val() || 'one_time';
+            let service_price_type = $row.find('input[name*="[service_price_type]"]').val() || 'one_time';
+            let line_total;
             if (service_price_type === 'day_wise') {
                 let rbfw_total_days = parseFloat(jQuery('#rbfw_total_days').val()) || 1;
-                service_price += price * qty * rbfw_total_days;
+                line_total = price * qty * rbfw_total_days;
+                service_price += line_total;
+                // Day-wise breakdown badge, e.g. "500.00 × 5 Days × 2 = 2,000.00"
+                $calc.html(wc_price_rbfw(price) + ' &times; ' + rbfw_total_days + ' ' + rbfw_days_label
+                    + (qty > 1 ? ' &times; ' + qty : '') + ' = <strong>' + wc_price_rbfw(line_total) + '</strong>').show();
             } else {
-                service_price += price * qty;
+                line_total = price * qty;
+                service_price += line_total;
+                // One-time: only show the breakdown when qty > 1 (otherwise it is redundant)
+                if (qty > 1) {
+                    $calc.html(wc_price_rbfw(price) + ' &times; ' + qty + ' = <strong>' + wc_price_rbfw(line_total) + '</strong>').show();
+                } else {
+                    $calc.hide().empty();
+                }
             }
+        } else {
+            $calc.hide().empty();
         }
     });
 

--- a/css/rbfw_style.css
+++ b/css/rbfw_style.css
@@ -8054,6 +8054,29 @@ a.rbfw_rent_list_btn:hover{
     font-size: 12px;
     color: var(--rbfw_color_primary);
 }
+/* Day-wise / multi-qty service price breakdown badge (e.g. 500.00 × 5 Days = 2,500.00) */
+.service-price-item .rbfw_service_day_calc {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: fit-content;
+    max-width: 100%;
+    margin-top: 6px;
+    padding: 3px 10px;
+    border-radius: 999px;
+    background: #f3f6fb;
+    border: 1px solid #e3e9f2;
+    color: #5b6678;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.5;
+    white-space: nowrap;
+    letter-spacing: .1px;
+}
+.service-price-item .rbfw_service_day_calc strong {
+    color: var(--rbfw_color_primary, #0058b8);
+    font-weight: 700;
+}
 div.rbfw_day_wise_price table{
     margin:0;
 }

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -103,6 +103,35 @@ if (! class_exists('RBFW_Dependencies')) {
 			wp_enqueue_script('form-field-dependency', plugins_url('admin/js/form-field-dependency.js', __DIR__), array('jquery'), null, false);
 			wp_enqueue_script('rbfw-script', plugins_url('admin/js/mkb-admin.js', __DIR__), array('jquery', 'jquery-ui-datepicker', 'wp-tinymce'), time(), false);
 
+			/* Inventory page only: modern redesign assets (font, icons, layout, pagination). */
+			if ( isset( $hook ) && $hook === 'rbfw_item_page_rbfw_inventory' ) {
+				wp_enqueue_style( 'rbfw-jakarta-font', 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap', array(), null );
+				/* Icons are inline SVG (rbfw_inv_icon) – no icon-font dependency. */
+				wp_enqueue_style( 'rbfw-inventory', plugins_url( 'admin/css/rbfw_inventory.css', __DIR__ ), array( 'rbfw-admin-style' ), filemtime( RBFW_PLUGIN_DIR . '/admin/css/rbfw_inventory.css' ) );
+				wp_enqueue_script( 'rbfw-inventory', plugins_url( 'admin/js/rbfw_inventory.js', __DIR__ ), array( 'jquery', 'rbfw-script', 'jquery.modal.min' ), filemtime( RBFW_PLUGIN_DIR . '/admin/js/rbfw_inventory.js' ), true );
+				wp_localize_script( 'rbfw-inventory', 'rbfwInvI18n', array(
+					/* translators: 1: first row number, 2: last row number, 3: total rows. */
+					'showing'     => __( 'Showing %1$s–%2$s of %3$s entries', 'booking-and-rental-manager-for-woocommerce' ),
+					/* translators: %s: total rows. */
+					'showing_all' => __( 'Showing %s entries', 'booking-and-rental-manager-for-woocommerce' ),
+				) );
+			}
+
+			/* Time Slots page only: modern redesign stylesheet (inline-SVG icons, primary + secondary). */
+			if ( isset( $hook ) && $hook === 'rbfw_item_page_rbfw_time_slots' ) {
+				wp_enqueue_style( 'rbfw-jakarta-font', 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap', array(), null );
+				wp_enqueue_style( 'rbfw-timeslots', plugins_url( 'admin/css/rbfw_timeslots.css', __DIR__ ), array( 'rbfw-admin-style' ), filemtime( RBFW_PLUGIN_DIR . '/admin/css/rbfw_timeslots.css' ) );
+			}
+
+			/* Order List page only: modern redesign (stat cards, search, animated detail panel). */
+			if ( isset( $hook ) && $hook === 'rbfw_item_page_rbfw_order' ) {
+				wp_enqueue_style( 'rbfw-jakarta-font', 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap', array(), null );
+				wp_enqueue_style( 'flatpickr-css', RBFW_PLUGIN_URL . '/assets/flatpickr.min.css', array(), null );
+				wp_enqueue_script( 'flatpickr-js', RBFW_PLUGIN_URL . '/assets/flatpickr.js', array(), null, true );
+				wp_enqueue_style( 'rbfw-order', plugins_url( 'admin/css/rbfw_order.css', __DIR__ ), array( 'rbfw-admin-style', 'flatpickr-css' ), filemtime( RBFW_PLUGIN_DIR . '/admin/css/rbfw_order.css' ) );
+				wp_enqueue_script( 'rbfw-order', plugins_url( 'admin/js/rbfw_order.js', __DIR__ ), array( 'jquery', 'flatpickr-js' ), filemtime( RBFW_PLUGIN_DIR . '/admin/js/rbfw_order.js' ), true );
+			}
+
 			wp_localize_script('jquery', 'rbfw_ajax_front', array(
 				'rbfw_ajaxurl' => admin_url('admin-ajax.php'),
 				'nonce_check_resort_availibility'        => wp_create_nonce('rbfw_check_resort_availibility_action'),
@@ -127,12 +156,17 @@ if (! class_exists('RBFW_Dependencies')) {
 
 			wp_localize_script('jquery', 'rbfw_ajax_admin', array(
 				'rbfw_ajaxurl' => admin_url('admin-ajax.php'),
+				'currency_symbol' => function_exists('get_woocommerce_currency_symbol') ? html_entity_decode( get_woocommerce_currency_symbol() ) : '',
 				'nonce_time_slot'        => wp_create_nonce('rbfw_time_slot_action'),
 				'nonce_duration_form'        => wp_create_nonce('rbfw_duration_form_action'),
 				'nonce_room_types_with_sd_price'        => wp_create_nonce('rbfw_room_types_with_sd_price_action'),
 				'nonce_room_types_with_sessional_price'        => wp_create_nonce('rbfw_room_types_with_sessional_price_action'),
 				'nonce_room_types_with_resort_price_mds'        => wp_create_nonce('rbfw_room_types_with_resort_price_mds_action'),
 				'nonce_fetch_order_details'        => wp_create_nonce('rbfw_fetch_order_details_action'),
+				'nonce_update_order_status'        => wp_create_nonce('rbfw_update_order_status_action'),
+				'nonce_delete_order'        => wp_create_nonce('rbfw_delete_order_action'),
+				'nonce_get_order_edit_form'        => wp_create_nonce('rbfw_get_order_edit_form_action'),
+				'nonce_save_order_edit'        => wp_create_nonce('rbfw_save_order_edit_action'),
 				'nonce_load_more_icons'        => wp_create_nonce('rbfw_load_more_icons_action'),
 				'nonce_update_time_slot'        => wp_create_nonce('rbfw_update_time_slot_action'),
 				'nonce_delete_time_slot'        => wp_create_nonce('rbfw_delete_time_slot_action'),

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -28,6 +28,16 @@
 				'div'   => true,
 				'a'     => true
 			),
+            'thead'     => array(
+                'style'   => true, // Allows inline styles
+                'class'   => true,
+                'id'   => true,
+            ),
+            'tfoot'     => array(
+                'style'   => true, // Allows inline styles
+                'class'   => true,
+                'id'   => true,
+            ),
             'tbody'     => array(
                 'style'   => true, // Allows inline styles
                 'class'   => true,
@@ -43,6 +53,8 @@
                 'style'   => true, // Allows inline styles
                 'class'   => true,
                 'id'   => true,
+                'colspan' => true,
+                'data-th' => true,
             ),
             'th'     => array(
                 'style'   => true, // Allows inline styles

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -781,6 +781,148 @@ function total_variant_quantity($field_label,$variation,$date,$inventory,$invent
 }
 
 
+/**
+ * Compute an rbfw_item's total purchasable stock and total extra-service stock.
+ *
+ * This mirrors the totals logic used by the inventory table so the summary cards
+ * and each table row stay in sync. It is read-only (no side effects).
+ *
+ * @param int $post_id rbfw_item post ID.
+ * @return array{rent_type:string, item_stock:float, es_qty:float}
+ */
+function rbfw_inventory_item_stock_totals( $post_id ) {
+
+    $rent_type = get_post_meta( $post_id, 'rbfw_item_type', true );
+    $rent_type = ! empty( $rent_type ) ? $rent_type : '';
+
+    $rbfw_enable_variations = get_post_meta( $post_id, 'rbfw_enable_variations', true );
+    $rbfw_enable_variations = ! empty( $rbfw_enable_variations ) ? $rbfw_enable_variations : 'no';
+
+    $rbfw_variations_data = get_post_meta( $post_id, 'rbfw_variations_data', true );
+    $rbfw_variations_data = ! empty( $rbfw_variations_data ) ? $rbfw_variations_data : array();
+
+    $rbfw_resort_room_data = get_post_meta( $post_id, 'rbfw_resort_room_data', true );
+    $rbfw_resort_room_data = ! empty( $rbfw_resort_room_data ) ? $rbfw_resort_room_data : array();
+
+    $rbfw_bike_car_sd_data = get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true );
+    $rbfw_bike_car_sd_data = ! empty( $rbfw_bike_car_sd_data ) ? $rbfw_bike_car_sd_data : array();
+
+    $manage_inventory_as_timely = get_post_meta( $post_id, 'manage_inventory_as_timely', true );
+    $manage_inventory_as_timely = ! empty( $manage_inventory_as_timely ) ? $manage_inventory_as_timely : '';
+
+    $rbfw_extra_service_data = get_post_meta( $post_id, 'rbfw_extra_service_data', true );
+    $rbfw_extra_service_data = ! empty( $rbfw_extra_service_data ) ? $rbfw_extra_service_data : array();
+
+    $es_qty = 0;
+    foreach ( $rbfw_extra_service_data as $value ) {
+        $es_qty += ! empty( $value['service_qty'] ) ? $value['service_qty'] : 0;
+    }
+
+    $item_stock = 0;
+    if ( $rent_type == 'bike_car_sd' || $rent_type == 'appointment' ) {
+        if ( $manage_inventory_as_timely == 'on' ) {
+            $timely     = get_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', true );
+            $item_stock = ! empty( $timely ) ? $timely : 0;
+        } else {
+            foreach ( $rbfw_bike_car_sd_data as $bike_car_sd_data ) {
+                $item_stock += ! empty( $bike_car_sd_data['qty'] ) ? $bike_car_sd_data['qty'] : 0;
+            }
+        }
+    } elseif ( $rent_type == 'resort' ) {
+        foreach ( $rbfw_resort_room_data as $resort_room_data ) {
+            $item_stock += ! empty( $resort_room_data['rbfw_room_available_qty'] ) ? $resort_room_data['rbfw_room_available_qty'] : 0;
+        }
+    } else {
+        if ( $rbfw_enable_variations == 'yes' ) {
+            foreach ( $rbfw_variations_data as $_variations_data ) {
+                if ( ! empty( $_variations_data['value'] ) ) {
+                    foreach ( $_variations_data['value'] as $value ) {
+                        if ( ! ( empty( $value['quantity'] ) || $value['quantity'] <= 0 ) ) {
+                            $item_stock = $value['quantity'] + $item_stock;
+                        }
+                    }
+                }
+            }
+        } else {
+            $stock      = get_post_meta( $post_id, 'rbfw_item_stock_quantity', true );
+            $item_stock = ! empty( $stock ) ? $stock : 0;
+        }
+    }
+
+    return array(
+        'rent_type'  => $rent_type,
+        'item_stock' => (float) $item_stock,
+        'es_qty'     => (float) $es_qty,
+    );
+}
+
+/**
+ * Visual state for a stock pill: 'full' (green), 'zero' (red) or '' (neutral).
+ *
+ * @param float $remain Remaining/available quantity.
+ * @param float $total  Total quantity.
+ * @return string
+ */
+function rbfw_inv_stock_state( $remain, $total ) {
+    $remain = (float) $remain;
+    $total  = (float) $total;
+    if ( $total <= 0 || $remain <= 0 ) {
+        return 'zero';
+    }
+    if ( $remain >= $total ) {
+        return 'full';
+    }
+    return '';
+}
+
+/**
+ * Return an inline SVG icon (self-contained — no icon font / CDN dependency).
+ *
+ * The plugin's bundled Font Awesome ships without its webfont files, so icon
+ * fonts do not render in this admin. Inline SVG removes that dependency
+ * entirely. Icons inherit colour via `currentColor` and size via `1em`.
+ *
+ * @param string $name        Icon key.
+ * @param string $extra_class Optional extra class on the <svg>.
+ * @return string Safe, static SVG markup.
+ */
+function rbfw_inv_icon( $name, $extra_class = '' ) {
+    $paths = array(
+        'box'      => '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z"/><path d="M12 12l8-4.5"/><path d="M12 12v9"/><path d="M12 12L4 7.5"/>',
+        'filter'   => '<path d="M4 5h16l-6.5 8v5.5l-3 1.5V13z"/>',
+        'x'        => '<path d="M18 6L6 18"/><path d="M6 6l12 12"/>',
+        'refresh'  => '<path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 4v5h-5"/>',
+        'layers'   => '<path d="M12 3l9 5-9 5-9-5z"/><path d="M3 13l9 5 9-5"/>',
+        'sparkles' => '<path d="M12 3l1.7 4.6L18 9l-4.3 1.4L12 15l-1.7-4.6L6 9l4.3-1.4z"/><path d="M18 14l.8 2.2L21 17l-2.2.8L18 20l-.8-2.2L15 17l2.2-.8z"/>',
+        'tag'      => '<path d="M3 4h8l9 9-7 7-9-9z"/><circle cx="7.5" cy="8.5" r="1.5"/>',
+        'bed'      => '<path d="M3 7v12"/><path d="M3 13h18v6"/><path d="M21 13v-1a3 3 0 0 0-3-3H8v4"/><circle cx="6.5" cy="10.5" r="1.5"/>',
+        'car'      => '<path d="M5 13l1.6-4.4A2 2 0 0 1 8.5 7h7a2 2 0 0 1 1.9 1.6L19 13"/><path d="M4 13h16v4H4z"/><circle cx="7.5" cy="17.5" r="1.5"/><circle cx="16.5" cy="17.5" r="1.5"/>',
+        'clone'    => '<rect x="8" y="8" width="12" height="12" rx="2"/><path d="M4 16V6a2 2 0 0 1 2-2h10"/>',
+        'chev_l'   => '<path d="M15 6l-6 6 6 6"/>',
+        'chev_r'   => '<path d="M9 6l6 6-6 6"/>',
+        'clock'    => '<circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3 2"/>',
+        'plus'     => '<path d="M12 5v14"/><path d="M5 12h14"/>',
+        'pencil'   => '<path d="M4 20h4L19 9l-4-4L4 16z"/><path d="M13.5 6.5l4 4"/>',
+        'trash'    => '<path d="M4 7h16"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M6 7l1 13h10l1-13"/><path d="M9 7V4h6v3"/>',
+        'check'    => '<path d="M5 12l5 5 9-11"/>',
+        'clipboard' => '<rect x="8" y="3.5" width="8" height="4" rx="1.5"/><path d="M9 5.5H6.5A1.5 1.5 0 0 0 5 7v12.5A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V7a1.5 1.5 0 0 0-1.5-1.5H15"/><path d="M8.5 12h7"/><path d="M8.5 16h5"/>',
+        'file'     => '<path d="M14 3v5h5"/><path d="M14 3H6.5A1.5 1.5 0 0 0 5 4.5v15A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V8z"/><path d="M9 13h6"/><path d="M9 17h5"/>',
+        'search'   => '<circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/>',
+        'eye'      => '<path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/>',
+        'calendar' => '<rect x="4" y="5" width="16" height="16" rx="2"/><path d="M4 10h16"/><path d="M8 3v4"/><path d="M16 3v4"/>',
+        'receipt'  => '<path d="M6 3h12v18l-2.2-1.5L13.5 21 12 19.5 10.5 21 8.2 19.5 6 21z"/><path d="M9 8h6"/><path d="M9 12h6"/>',
+        'calculator' => '<rect x="5" y="3" width="14" height="18" rx="2"/><path d="M9 7h6"/><path d="M8.5 12h.01"/><path d="M12 12h.01"/><path d="M15.5 12h.01"/><path d="M8.5 16h.01"/><path d="M12 16h.01"/><path d="M15.5 16h.01"/>',
+    );
+
+    if ( ! isset( $paths[ $name ] ) ) {
+        return '';
+    }
+
+    $class = 'rbfw_inv_ic' . ( $extra_class ? ' ' . $extra_class : '' );
+
+    return '<svg class="' . esc_attr( $class ) . '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">' . $paths[ $name ] . '</svg>';
+}
+
 function rbfw_inventory_page(){
     $args = array(
         'post_type'              => 'rbfw_item',
@@ -790,46 +932,103 @@ function rbfw_inventory_page(){
         'update_term_meta_cache' => true,
     );
     $query = new WP_Query( $args );
-    $total_items = $query->found_posts;
+    $total_items = (int) $query->found_posts;
+
+    /* Summary stats for the cards (read-only). */
+    $in_stock     = 0;
+    $out_of_stock = 0;
+    $with_extra   = 0;
+    if ( ! empty( $query->posts ) ) {
+        foreach ( $query->posts as $inv_post ) {
+            $totals = rbfw_inventory_item_stock_totals( $inv_post->ID );
+            if ( $totals['item_stock'] > 0 ) {
+                $in_stock++;
+            } else {
+                $out_of_stock++;
+            }
+            if ( $totals['es_qty'] > 0 ) {
+                $with_extra++;
+            }
+        }
+    }
     ?>
-    <div class="rbfw_inventory_page_wrap wrap">
-        <h1><?php esc_html_e('Inventory','booking-and-rental-manager-for-woocommerce'); ?></h1>
-        <div class="rbfw_inventory_page_filter">
-            <div class="rbfw_inventory_filter_input_group">
+    <div class="rbfw_inv rbfw_inventory_page_wrap wrap">
+
+        <!-- Header -->
+        <div class="rbfw_inv_header">
+            <div class="rbfw_inv_title">
+                <?php echo rbfw_inv_icon('box'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                <h1><?php esc_html_e('Inventory','booking-and-rental-manager-for-woocommerce'); ?></h1>
+                <span class="rbfw_inv_badge"><?php
+                    /* translators: %s: number of inventory items. */
+                    echo esc_html( sprintf( _n( '%s Item', '%s Items', $total_items, 'booking-and-rental-manager-for-woocommerce' ), number_format_i18n( $total_items ) ) );
+                ?></span>
+            </div>
+        </div>
+        <hr class="wp-header-end">
+
+        <!-- Stat cards -->
+        <div class="rbfw_inv_stats">
+            <div class="rbfw_inv_stat_card">
+                <div class="rbfw_inv_stat_label"><?php esc_html_e('Total Items','booking-and-rental-manager-for-woocommerce'); ?></div>
+                <div class="rbfw_inv_stat_value"><?php echo esc_html( number_format_i18n( $total_items ) ); ?></div>
+                <div class="rbfw_inv_stat_sub"><?php esc_html_e('As of today','booking-and-rental-manager-for-woocommerce'); ?></div>
+            </div>
+            <div class="rbfw_inv_stat_card rbfw_inv_green">
+                <div class="rbfw_inv_stat_label"><?php esc_html_e('In Stock','booking-and-rental-manager-for-woocommerce'); ?></div>
+                <div class="rbfw_inv_stat_value"><?php echo esc_html( number_format_i18n( $in_stock ) ); ?></div>
+                <div class="rbfw_inv_stat_sub"><?php esc_html_e('Items available','booking-and-rental-manager-for-woocommerce'); ?></div>
+            </div>
+            <div class="rbfw_inv_stat_card">
+                <div class="rbfw_inv_stat_label"><?php esc_html_e('Out of Stock','booking-and-rental-manager-for-woocommerce'); ?></div>
+                <div class="rbfw_inv_stat_value"><?php echo esc_html( number_format_i18n( $out_of_stock ) ); ?></div>
+                <div class="rbfw_inv_stat_sub"><?php esc_html_e('Needs restock','booking-and-rental-manager-for-woocommerce'); ?></div>
+            </div>
+            <div class="rbfw_inv_stat_card rbfw_inv_blue">
+                <div class="rbfw_inv_stat_label"><?php esc_html_e('Extra Services','booking-and-rental-manager-for-woocommerce'); ?></div>
+                <div class="rbfw_inv_stat_value"><?php echo esc_html( number_format_i18n( $with_extra ) ); ?></div>
+                <div class="rbfw_inv_stat_sub"><?php esc_html_e('With extra stock','booking-and-rental-manager-for-woocommerce'); ?></div>
+            </div>
+        </div>
+
+        <!-- Filter bar -->
+        <div class="rbfw_inv_filters rbfw_inventory_page_filter">
+            <div class="rbfw_inv_filter_group rbfw_inventory_filter_input_group">
                 <label><?php esc_html_e('Date','booking-and-rental-manager-for-woocommerce'); ?></label>
                 <input type="text" class="rbfw_inventory_filter_date" placeholder="dd-mm-yyyy"/>
             </div>
-            <div class="rbfw_inventory_filter_input_group">
-                <div class="w-50 ms-5 d-flex justify-content-between align-items-center">
-                    <label for="">Start Time:</label>
-                    <div class=" d-flex justify-content-between align-items-center">
-                        <input type="time"  id="rbfw_inventory_event_start_time" value="">
-                    </div>
-                </div>
+            <div class="rbfw_inv_filter_group rbfw_inventory_filter_input_group">
+                <label><?php esc_html_e('Start Time','booking-and-rental-manager-for-woocommerce'); ?></label>
+                <input type="time" id="rbfw_inventory_event_start_time" value="">
             </div>
-            <div class="rbfw_inventory_filter_input_group">
-                <div class="w-50 d-flex justify-content-between align-items-center">
-                    <label for="">End Time:</label>
-                    <div class=" d-flex justify-content-between align-items-center">
-                        <input type="time" id="rbfw_inventory_event_end_time" value="">
-                    </div>
-                </div>
+            <div class="rbfw_inv_filter_group rbfw_inventory_filter_input_group">
+                <label><?php esc_html_e('End Time','booking-and-rental-manager-for-woocommerce'); ?></label>
+                <input type="time" id="rbfw_inventory_event_end_time" value="">
             </div>
-            <div class="rbfw_inventory_filter_input_group">
-                <label></label>
-                <button class="rbfw_inventory_filter_btn"><?php esc_html_e('Filter','booking-and-rental-manager-for-woocommerce'); ?></button>
-            </div>
-            <div class="rbfw_inventory_filter_input_group">
-                <label></label>
-                <button class="rbfw_inventory_reset_btn"><?php esc_html_e('Reset Filter','booking-and-rental-manager-for-woocommerce'); ?></button>
-            </div>
-            <div class="rbfw_inventory_filter_input_group">
-                <label></label>
-                <button class="rbfw_inventory_refresh_btn"><?php esc_html_e('Refresh Page','booking-and-rental-manager-for-woocommerce'); ?></button>
+            <div class="rbfw_inv_filter_actions">
+                <button type="button" class="rbfw_inv_btn rbfw_inv_btn_primary rbfw_inventory_filter_btn">
+                    <?php echo rbfw_inv_icon('filter'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e('Filter','booking-and-rental-manager-for-woocommerce'); ?>
+                </button>
+                <button type="button" class="rbfw_inv_btn rbfw_inv_btn_reset rbfw_inventory_reset_btn">
+                    <?php echo rbfw_inv_icon('x'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e('Reset','booking-and-rental-manager-for-woocommerce'); ?>
+                </button>
+                <button type="button" class="rbfw_inv_btn rbfw_inv_btn_refresh rbfw_inventory_refresh_btn">
+                    <?php echo rbfw_inv_icon('refresh'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e('Refresh','booking-and-rental-manager-for-woocommerce'); ?>
+                </button>
             </div>
         </div>
-        <div class="rbfw_inventory_page_table_wrap">
-            <?php echo wp_kses(rbfw_inventory_page_table($query),rbfw_allowed_html()); ?>
+
+        <!-- Table card -->
+        <div class="rbfw_inv_card">
+            <div class="rbfw_inv_table_scroll">
+                <div class="rbfw_inventory_page_table_wrap">
+                    <?php echo wp_kses(rbfw_inventory_page_table($query),rbfw_allowed_html()); ?>
+                </div>
+            </div>
+            <div class="rbfw_inv_footer">
+                <span class="rbfw_inv_row_info"></span>
+                <div class="rbfw_inv_pager"></div>
+            </div>
         </div>
     </div>
     <div id="rbfw_stock_view_result_wrap">
@@ -922,11 +1121,11 @@ function rbfw_inventory_page_table($query, $date = null, $start_time = null, $en
     ob_start();
     $inventory_based_on_return = rbfw_get_option('inventory_based_on_pickup_return','rbfw_basic_gen_settings');
     ?>
-    <table class="rbfw_inventory_page_table">
-        <thead  class="rbfw_inventory_page_table_head">
-        <tr>
+    <table class="rbfw_inv_table">
+        <thead  class="rbfw_inv_thead">
+        <tr class="rbfw_inv_thead_row">
             <th><?php esc_html_e('Date','booking-and-rental-manager-for-woocommerce'); ?></th>
-            <th><?php esc_html_e('Item Name','booking-and-rental-manager-for-woocommerce'); ?></th>
+            <th class="rbfw_inv_th_left"><?php esc_html_e('Item Name','booking-and-rental-manager-for-woocommerce'); ?></th>
             <th class="rbfw_text_center"><?php esc_html_e('Item Stock','booking-and-rental-manager-for-woocommerce'); ?></th>
             <th class="rbfw_text_center"><?php esc_html_e('Item Sold Qty','booking-and-rental-manager-for-woocommerce'); ?></th>
             <th class="rbfw_text_center"><?php esc_html_e('Extra Service Stock','booking-and-rental-manager-for-woocommerce'); ?></th>
@@ -950,62 +1149,11 @@ function rbfw_inventory_page_table($query, $date = null, $start_time = null, $en
                 global $post;
                 $post_id = $post->ID;
 
-                $_raw = get_post_meta( $post_id, 'rbfw_item_type', true );
-                $rent_type = ! empty( $_raw ) ? $_raw : '';
-
-                $_raw = get_post_meta( $post_id, 'rbfw_enable_variations', true );
-                $rbfw_enable_variations = ! empty( $_raw ) ? $_raw : 'no';
-                $_raw = get_post_meta( $post_id, 'rbfw_variations_data', true );
-                $rbfw_variations_data = ! empty( $_raw ) ? $_raw : [];
-                $_raw = get_post_meta( $post_id, 'rbfw_resort_room_data', true );
-                $rbfw_resort_room_data = ! empty( $_raw ) ? $_raw : [];
-                $_raw = get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true );
-                $rbfw_bike_car_sd_data = ! empty( $_raw ) ? $_raw : [];
-                $_raw = get_post_meta( $post_id, 'manage_inventory_as_timely', true );
-                $manage_inventory_as_timely = ! empty( $_raw ) ? $_raw : [];
-
-                $_raw = get_post_meta( $post_id, 'rbfw_extra_service_data', true );
-                $rbfw_extra_service_data = ! empty( $_raw ) ? $_raw : [];
-                $total_es_qty = 0;
-                foreach ($rbfw_extra_service_data as $value) {
-                    $total_es_qty += !empty($value['service_qty']) ? $value['service_qty'] : 0;
-                }
-
-                $rbfw_item_stock_quantity = 0;
-
-                if ($rent_type == 'bike_car_sd' || $rent_type == 'appointment'){
-                    if($manage_inventory_as_timely=='on'){
-                        $_raw = get_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', true );
-                        $rbfw_item_stock_quantity = ! empty( $_raw ) ? $_raw : 0;
-                    }else{
-                        foreach ($rbfw_bike_car_sd_data as $key => $bike_car_sd_data) {
-                            $rbfw_item_stock_quantity += !empty($bike_car_sd_data['qty']) ? $bike_car_sd_data['qty'] : 0;
-                        }
-                    }
-
-                } elseif ($rent_type == 'resort'){
-                    foreach ($rbfw_resort_room_data as $key => $resort_room_data) {
-                        $rbfw_item_stock_quantity += !empty($resort_room_data['rbfw_room_available_qty']) ? $resort_room_data['rbfw_room_available_qty'] : 0;
-                    }
-                } else {
-
-                    if($rbfw_enable_variations=='yes'){
-                        foreach ($rbfw_variations_data as $_variations_data) {
-                            if(!empty($_variations_data['value'])){
-                                foreach ($_variations_data['value'] as $value) {
-                                    if(empty($value['quantity']) || $value['quantity'] <= 0){
-                                        ////
-                                    } else{
-                                        $rbfw_item_stock_quantity =  $value['quantity'] + $rbfw_item_stock_quantity;
-                                    }
-                                }
-                            }
-                        }
-                    }else{
-                        $_raw = get_post_meta( $post_id, 'rbfw_item_stock_quantity', true );
-                        $rbfw_item_stock_quantity = ! empty( $_raw ) ? $_raw : 0;
-                    }
-                }
+                /* Total item stock + total extra-service stock (shared with the summary cards). */
+                $stock_totals             = rbfw_inventory_item_stock_totals( $post_id );
+                $rent_type                = $stock_totals['rent_type'];
+                $rbfw_item_stock_quantity = $stock_totals['item_stock'];
+                $total_es_qty             = $stock_totals['es_qty'];
 
                 if ( !empty($date) ){
                     $current_date = $date;
@@ -1110,39 +1258,47 @@ function rbfw_inventory_page_table($query, $date = null, $start_time = null, $en
                 }
 
 
+                $cat_total = (float) array_sum( $service_quantity );
+                $cat_stock = (float) array_sum( $service_stock );
+                $cat_sold  = $cat_total - $cat_stock;
+
+                $item_state = rbfw_inv_stock_state( $remaining_item_stock, $rbfw_item_stock_quantity );
+                $es_state   = rbfw_inv_stock_state( $remaining_es_stock, $total_es_qty );
+                /* Category column stays neutral when no category stock is configured. */
+                $cat_state  = $cat_total > 0 ? rbfw_inv_stock_state( $cat_stock, $cat_total ) : '';
                 ?>
-                <tr>
-                    <td><?php echo esc_html(gmdate(get_option('date_format'),strtotime($current_date))); ?></td>
+                <tr class="rbfw_inv_row">
+                    <td class="rbfw_inv_td_date" data-th="<?php esc_attr_e('Date','booking-and-rental-manager-for-woocommerce'); ?>"><?php echo esc_html(gmdate(get_option('date_format'),strtotime($current_date))); ?></td>
 
-                    <td><a href="<?php echo esc_url(admin_url('post.php?post='.$post_id.'&action=edit')); ?>" class="rbfw_item_title"><?php echo esc_html(get_the_title()); ?></a></td>
+                    <td class="rbfw_inv_td_name" data-th="<?php esc_attr_e('Item Name','booking-and-rental-manager-for-woocommerce'); ?>"><a href="<?php echo esc_url(admin_url('post.php?post='.$post_id.'&action=edit')); ?>" class="rbfw_item_title"><?php echo esc_html(get_the_title()); ?></a></td>
 
-                    <td class="rbfw_text_center">
-                        <span class="rbfw_s_qty_span">
-                            <?php echo esc_html( $remaining_item_stock ); ?>/<?php echo esc_html( $rbfw_item_stock_quantity ); ?>
+                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Item Stock','booking-and-rental-manager-for-woocommerce'); ?>">
+                        <span class="rbfw_inv_stock_wrap">
+                            <span class="rbfw_inv_pill <?php echo esc_attr( $item_state ); ?>"><?php echo esc_html( $remaining_item_stock ); ?>/<?php echo esc_html( $rbfw_item_stock_quantity ); ?></span>
+                            <a
+                                class="rbfw_inv_view_btn rbfw_stock_view_details"
+                                data-request="closing"
+                                data-date="<?php echo esc_attr( $current_date ); ?>"
+                                data-id="<?php echo esc_attr( get_the_ID() ); ?>"
+                            >
+                                <?php esc_html_e( 'View Details', 'booking-and-rental-manager-for-woocommerce' ); ?>
+                            </a>
                         </span>
-                        <a 
-                            class="rbfw_stock_view_details" 
-                            data-request="closing" 
-                            data-date="<?php echo esc_attr( $current_date ); ?>" 
-                            data-id="<?php echo esc_attr( get_the_ID() ); ?>"
-                        >
-                            <?php esc_html_e( 'View Details', 'booking-and-rental-manager-for-woocommerce' ); ?>
-                        </a>
                     </td>
 
 
-                    <td class="rbfw_text_center"><?php  echo esc_html($sold_item_qty); ?></td>
-                    <td class="rbfw_text_center"><?php echo esc_html($remaining_es_stock); ?>/<?php echo esc_html($total_es_qty); ?></td>
-                    <td class="rbfw_text_center"><?php echo esc_html($sold_es_qty); ?></td>
-                    <td class="rbfw_text_center"><?php echo esc_html(array_sum($service_stock)); ?>/<?php echo esc_html(array_sum($service_quantity)); ?></td>
-                    <td class="rbfw_text_center"><?php echo esc_html(array_sum($service_quantity)-array_sum($service_stock)); ?></td>
+                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Item Sold Qty','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_qty_badge <?php echo esc_attr( $sold_item_qty > 0 ? 'rbfw_inv_qty_pos' : 'rbfw_inv_qty_zero' ); ?>"><?php echo esc_html($sold_item_qty); ?></span></td>
+                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Extra Service Stock','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_pill <?php echo esc_attr( $es_state ); ?>"><?php echo esc_html($remaining_es_stock); ?>/<?php echo esc_html($total_es_qty); ?></span></td>
+                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Extra Service Sold Qty','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_qty_badge <?php echo esc_attr( $sold_es_qty > 0 ? 'rbfw_inv_qty_pos' : 'rbfw_inv_qty_zero' ); ?>"><?php echo esc_html($sold_es_qty); ?></span></td>
+                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Category Service','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_pill <?php echo esc_attr( $cat_state ); ?>"><?php echo esc_html( $cat_stock ); ?>/<?php echo esc_html( $cat_total ); ?></span></td>
+                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Category Service Sold Qty','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_qty_badge <?php echo esc_attr( $cat_sold > 0 ? 'rbfw_inv_qty_pos' : 'rbfw_inv_qty_zero' ); ?>"><?php echo esc_html( $cat_sold ); ?></span></td>
                 </tr>
                 <?php
             }
         }else{
             ?>
-            <tr>
-                <td colspan="20"><?php esc_html_e( 'Sorry, No data found!', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
+            <tr class="rbfw_inv_empty_tr">
+                <td colspan="20" class="rbfw_inv_empty_cell"><?php esc_html_e( 'Sorry, No data found!', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
             </tr>
             <?php
         }
@@ -1379,189 +1535,137 @@ function rbfw_get_stock_details(){
 
             }
 
+            $modal_title    = get_the_title( $data_id );
+            $modal_date_fmt = $data_date ? gmdate( get_option( 'date_format' ), strtotime( $data_date ) ) : '';
+            $avail_zero     = ( empty( $remaining_item_stock ) || $remaining_item_stock <= 0 );
             ?>
-            <table class="rbfw_inventory_page_inner_table">
-                <thead>
-                    <tr>
-                        <td class="rbfw_inventory_vf_label"><?php esc_html_e('Available Quantity:','booking-and-rental-manager-for-woocommerce'); ?></td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td <?php if(empty($remaining_item_stock) || $remaining_item_stock <= 0){ echo "data-status=empty"; } ?>><?php echo esc_html($remaining_item_stock); ?></td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <?php if(!empty($rbfw_resort_room_data) && $rent_type == 'resort'){ ?>
-                <div class="rbfw_inventory_vf_label"><?php esc_html_e('Room Info:','booking-and-rental-manager-for-woocommerce'); ?></div>
-                <table class="rbfw_inventory_page_inner_table">
-                    <thead>
-                        <tr>
-                            <th class="rbfw_inventory_vf_label"><?php esc_html_e('Room Type','booking-and-rental-manager-for-woocommerce'); ?></th>
-                            <th class="rbfw_inventory_vf_label"><?php esc_html_e('Available Quantity','booking-and-rental-manager-for-woocommerce'); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($rbfw_resort_room_data as $resort_room_data) { ?>
-                        <tr>
-                            <td><?php echo esc_html($resort_room_data['room_type']); ?></td>
-                            <td><?php echo esc_html($resort_room_data['rbfw_room_available_qty']); ?></td>
-                        </tr>
+            <div class="rbfw_inv_modal">
+                <div class="rbfw_inv_modal_head">
+                    <div class="rbfw_inv_modal_icon"><?php echo rbfw_inv_icon('box'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                    <div class="rbfw_inv_modal_title_wrap">
+                        <div class="rbfw_inv_modal_title"><?php echo esc_html( $modal_title ); ?></div>
+                        <?php if ( $modal_date_fmt ) { ?>
+                            <div class="rbfw_inv_modal_sub"><?php echo esc_html( $modal_date_fmt ); ?></div>
                         <?php } ?>
-                    </tbody>
-                </table>
-            <?php } ?>
+                    </div>
+                    <a href="#" class="rbfw_inv_modal_close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon('x'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                </div>
 
-            <?php if(!empty($rbfw_bike_car_sd_data) && ($rent_type == 'bike_car_sd' || $rent_type == 'appointment')){ ?>
-                <div class="rbfw_inventory_vf_label"><?php esc_html_e('Rent Info:','booking-and-rental-manager-for-woocommerce'); ?></div>
-                <table class="rbfw_inventory_page_inner_table">
-                    <thead>
-                        <tr>
-                            <th class="rbfw_inventory_vf_label"><?php esc_html_e('Rent Type','booking-and-rental-manager-for-woocommerce'); ?></th>
-                            <th class="rbfw_inventory_vf_label"><?php esc_html_e('Available Quantity','booking-and-rental-manager-for-woocommerce'); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($rbfw_bike_car_sd_data as $bike_car_sd_data) { ?>
-                        <tr>
-                            <td><?php echo esc_html($bike_car_sd_data['rent_type']); ?></td>
-                            <td><?php echo esc_html($bike_car_sd_data['qty']); ?></td>
-                        </tr>
+                <div class="rbfw_inv_modal_body">
+
+                    <!-- Available qty hero -->
+                    <div class="rbfw_inv_avail_hero">
+                        <div>
+                            <div class="rbfw_inv_avail_label"><?php esc_html_e('Available Quantity','booking-and-rental-manager-for-woocommerce'); ?></div>
+                            <div class="rbfw_inv_avail_qty <?php echo esc_attr( $avail_zero ? 'rbfw_inv_avail_zero' : '' ); ?>"><?php echo esc_html( $remaining_item_stock ); ?></div>
+                        </div>
+                        <?php echo rbfw_inv_icon('layers','rbfw_inv_avail_icon'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                    </div>
+
+                    <?php if(!empty($rbfw_resort_room_data) && $rent_type == 'resort'){ ?>
+                    <div class="rbfw_inv_modal_section">
+                        <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('bed'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e('Room Info','booking-and-rental-manager-for-woocommerce'); ?></div>
+                        <table class="rbfw_inv_mini_table">
+                            <thead><tr><th><?php esc_html_e('Room Type','booking-and-rental-manager-for-woocommerce'); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e('Available Qty','booking-and-rental-manager-for-woocommerce'); ?></th></tr></thead>
+                            <tbody>
+                            <?php foreach ($rbfw_resort_room_data as $resort_room_data) { ?>
+                                <tr><td><?php echo esc_html($resort_room_data['room_type']); ?></td><td class="rbfw_inv_qty_cell"><?php echo esc_html($resort_room_data['rbfw_room_available_qty']); ?></td></tr>
+                            <?php } ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php } ?>
+
+                    <?php if(!empty($rbfw_bike_car_sd_data) && ($rent_type == 'bike_car_sd' || $rent_type == 'appointment')){ ?>
+                    <div class="rbfw_inv_modal_section">
+                        <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('car'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e('Rent Info','booking-and-rental-manager-for-woocommerce'); ?></div>
+                        <table class="rbfw_inv_mini_table">
+                            <thead><tr><th><?php esc_html_e('Rent Type','booking-and-rental-manager-for-woocommerce'); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e('Available Qty','booking-and-rental-manager-for-woocommerce'); ?></th></tr></thead>
+                            <tbody>
+                            <?php foreach ($rbfw_bike_car_sd_data as $bike_car_sd_data) { ?>
+                                <tr><td><?php echo esc_html($bike_car_sd_data['rent_type']); ?></td><td class="rbfw_inv_qty_cell"><?php echo esc_html($bike_car_sd_data['qty']); ?></td></tr>
+                            <?php } ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php } ?>
+
+                    <?php if($rbfw_enable_variations == 'yes' && !empty($rbfw_variations_data) && $rent_type != 'resort' && $rent_type != 'bike_car_sd' && $rent_type != 'appointment'){ ?>
+                        <?php foreach ($rbfw_variations_data as $_variations_data) { ?>
+                        <div class="rbfw_inv_modal_section">
+                            <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('clone'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php echo esc_html( $_variations_data['field_label'] ); ?></div>
+                            <?php if(!empty($_variations_data['value'])){ ?>
+                            <table class="rbfw_inv_mini_table">
+                                <thead><tr><th><?php esc_html_e('Name','booking-and-rental-manager-for-woocommerce'); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e('Available Qty','booking-and-rental-manager-for-woocommerce'); ?></th></tr></thead>
+                                <tbody>
+                                <?php foreach ($_variations_data['value'] as $value) {
+                                    $v_zero = ( empty( $value['quantity'] ) || $value['quantity'] <= 0 ); ?>
+                                    <tr><td><?php echo esc_html($value['name']); ?></td><td class="rbfw_inv_qty_cell <?php echo esc_attr( $v_zero ? 'rbfw_inv_qty_cell_zero' : '' ); ?>"><?php echo esc_html( $value['quantity'] ); ?></td></tr>
+                                <?php } ?>
+                                </tbody>
+                            </table>
+                            <?php } ?>
+                        </div>
                         <?php } ?>
-                    </tbody>
-                </table>
+                    <?php } ?>
 
-           <?php } ?>
-<?php
+                    <!-- Extra services -->
+                    <div class="rbfw_inv_modal_section">
+                        <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('sparkles'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e('Extra Services','booking-and-rental-manager-for-woocommerce'); ?></div>
+                        <table class="rbfw_inv_mini_table">
+                            <thead><tr><th><?php esc_html_e('Service Name','booking-and-rental-manager-for-woocommerce'); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e('Available Qty','booking-and-rental-manager-for-woocommerce'); ?></th></tr></thead>
+                            <tbody>
+                            <?php if(!empty($rbfw_extra_service_data)){
+                                foreach ($rbfw_extra_service_data as $extra_service_data) { ?>
+                                <tr><td><?php echo esc_html($extra_service_data['service_name']); ?></td><td class="rbfw_inv_qty_cell"><?php echo esc_html($extra_service_data['service_qty']); ?></td></tr>
+                            <?php }
+                            } else { ?>
+                                <tr><td colspan="2" class="rbfw_inv_empty_modal"><?php esc_html_e('No extra services available','booking-and-rental-manager-for-woocommerce'); ?></td></tr>
+                            <?php } ?>
+                            </tbody>
+                        </table>
+                    </div>
 
-if($rbfw_enable_variations == 'yes' && !empty($rbfw_variations_data) && $rent_type != 'resort' && $rent_type != 'bike_car_sd' && $rent_type != 'appointment'){
-
-    ?>
-            <table class="rbfw_inventory_page_inner_table">
-                <thead>
-                    <tr>
-                        <td class="rbfw_inventory_vf_label"><?php esc_html_e('Variation Stock:','booking-and-rental-manager-for-woocommerce'); ?></td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>
-
-                           <table class="rbfw_inventory_page_inner_table rbfw_border_none">
-
-
-                              <?php foreach ($rbfw_variations_data as $_variations_data) {   ?>
-
-                                       <tr>
-                                            <th class="rbfw_inventory_page_inner_vf_th">
-                                                <div class="rbfw_inventory_vf_label">
-                                                   <?php echo esc_html($_variations_data['field_label']).':' ?>
-                                                </div>
-                                                <?php if(!empty($_variations_data['value'])){ ?>
-                                                    <table class="rbfw_inventory_page_inner_table">
-                                                        <thead>
-                                                           <tr>
-                                                                <th class="rbfw_inventory_vf_label">
-                                                                    <?php esc_html_e('Name','booking-and-rental-manager-for-woocommerce'); ?>
-                                                                </th>
-                                                                <th class="rbfw_inventory_vf_label">
-                                                                    <?php esc_html_e('Available Quantity','booking-and-rental-manager-for-woocommerce'); ?>
-                                                               </th>
-                                                            </tr>
-                                                       </thead>
-
-                                                    <?php foreach ($_variations_data['value'] as $value) { ?>
-                                                        <tbody>
-                                                            <tr>
-                                                                <td>
-                                                                   <?php echo esc_html($value['name']); ?>
-                                                                </td>
-                                                                <td data-status="<?php echo esc_attr( ( empty( $value['quantity'] ) || $value['quantity'] <= 0 ) ? 'empty' : '' ); ?>">
-                                                                    <?php echo esc_html( $value['quantity'] ); ?>
-                                                                </td>
-                                                            </tr>
-                                                        </tbody>
-                                                   <?php } ?>
-                                                    </table>
-                                                <?php } ?>
-                                            </th>
-                                        </tr>
-                                    <?php } ?>
-                                </table>
-
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <?php } ?>
-
-            <?php if(!empty($rbfw_extra_service_data)){ ?>
-                <div class="rbfw_inventory_vf_label"><?php esc_html_e('Extra Services:','booking-and-rental-manager-for-woocommerce'); ?></div>
-                <table class="rbfw_inventory_page_inner_table">
-                    <thead>
-                        <tr>
-                            <th class="rbfw_inventory_vf_label"><?php esc_html_e('Service Name','booking-and-rental-manager-for-woocommerce'); ?></th>
-                            <th class="rbfw_inventory_vf_label"><?php esc_html_e('Available Quantity','booking-and-rental-manager-for-woocommerce'); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($rbfw_extra_service_data as $extra_service_data) { ?>
-                        <tr>
-                            <td><?php echo esc_html($extra_service_data['service_name']); ?></td>
-                            <td><?php echo esc_html($extra_service_data['service_qty']); ?></td>
-                        </tr>
-                        <?php } ?>
-                    </tbody>
-                </table>
-            <?php } ?>
-
-            <?php
-
-            $rbfw_service_category_price = get_post_meta($data_id, 'rbfw_service_category_price', true);
-
-            if(!is_array($rbfw_service_category_price)){
-                $rbfw_service_category_price = json_decode($rbfw_service_category_price, true);
-            }
-
-
-            $service_stock = [];
-            if (!empty($rbfw_service_category_price)) { ?>
-                <div class="rbfw_inventory_vf_label"><?php esc_html_e('Category wise service:','booking-and-rental-manager-for-woocommerce'); ?></div>
-                <table class="rbfw_inventory_page_inner_table">
-                <?php
-                foreach($rbfw_service_category_price as $key=>$item1){
-                    $cat_title = $item1['cat_title'];
-                    ?>
-                    <tr><th colspan="2" class="rbfw_inventory_vf_label"> <?php echo esc_html($cat_title); ?></th></tr>
-
+                    <!-- Category wise -->
                     <?php
-                    $service_q = [];
-                    foreach ($item1['cat_services'] as $key1=>$single){
-                        if($single['title']){
-                            ?>
-                            <tr>
-                            <td><?php echo esc_html($single['title']); ?></td>
-                            <?php
-                            $service_q[] = array('date'=>$data_date,$single['title']=>total_service_quantity($cat_title,$single['title'],$data_date,$rbfw_inventory,$inventory_based_on_return));
-                            ?>
-                            <td>
-                            <?php echo esc_html($single['stock_quantity'] - max(array_column($service_q, $single['title']))); ?>
-                            </td>
-                            </tr>
-                           <?php
-                        }
+                    $rbfw_service_category_price = get_post_meta($data_id, 'rbfw_service_category_price', true);
+                    if(!is_array($rbfw_service_category_price)){
+                        $rbfw_service_category_price = json_decode($rbfw_service_category_price, true);
                     }
                     ?>
+                    <div class="rbfw_inv_modal_section">
+                        <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('tag'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e('Category Wise Service','booking-and-rental-manager-for-woocommerce'); ?></div>
+                        <?php if (!empty($rbfw_service_category_price)) {
+                            foreach($rbfw_service_category_price as $key=>$item1){
+                                $cat_title = $item1['cat_title'];
+                                ?>
+                                <div class="rbfw_inv_cat_block">
+                                    <div class="rbfw_inv_cat_title"><?php echo rbfw_inv_icon('tag'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php echo esc_html($cat_title); ?></div>
+                                    <table class="rbfw_inv_mini_table">
+                                        <tbody>
+                                        <?php
+                                        $service_q = [];
+                                        foreach ($item1['cat_services'] as $key1=>$single){
+                                            if($single['title']){
+                                                $service_q[] = array('date'=>$data_date,$single['title']=>total_service_quantity($cat_title,$single['title'],$data_date,$rbfw_inventory,$inventory_based_on_return));
+                                                ?>
+                                                <tr><td><?php echo esc_html($single['title']); ?></td><td class="rbfw_inv_qty_cell"><?php echo esc_html($single['stock_quantity'] - max(array_column($service_q, $single['title']))); ?></td></tr>
+                                                <?php
+                                            }
+                                        }
+                                        ?>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            <?php }
+                        } else { ?>
+                            <div class="rbfw_inv_empty_modal_note"><?php esc_html_e('No category services configured','booking-and-rental-manager-for-woocommerce'); ?></div>
+                        <?php } ?>
+                    </div>
 
-                    <?php
-                }
-                ?>
-                <table>
-                <?php
-            }
-            ?>
-             <?php
+                </div><!-- /.rbfw_inv_modal_body -->
+            </div><!-- /.rbfw_inv_modal -->
+            <?php
             wp_die();
         }
 

--- a/inc/rbfw_order_meta.php
+++ b/inc/rbfw_order_meta.php
@@ -11,6 +11,704 @@ function rbfw_order_meta_box() {
     add_meta_box( 'rbfw-order-meta-box', esc_html__( 'Order Details', 'booking-and-rental-manager-for-woocommerce' ), 'rbfw_order_meta_box_callback' );
     add_meta_box( 'rbfw-order-meta-box-sidebar', esc_html__( 'Order Status Update', 'booking-and-rental-manager-for-woocommerce' ), 'rbfw_order_meta_box_sidebar_callback', '', 'side', 'core' );
 }
+/**
+ * AJAX: update a WooCommerce order status straight from the Order List popup.
+ *
+ * Mirrors the side effects of the classic "Order Status Update" meta-box save
+ * (revision log + reports + inventory sync) so both flows stay consistent.
+ */
+add_action( 'wp_ajax_rbfw_update_order_status', 'rbfw_update_order_status_callback' );
+function rbfw_update_order_status_callback() {
+
+    check_ajax_referer( 'rbfw_update_order_status_action', 'nonce' );
+
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+    }
+
+    if ( ! function_exists( 'wc_get_order' ) || ! function_exists( 'wc_get_order_statuses' ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'WooCommerce is not active.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    $post_id    = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+    $new_status = isset( $_POST['status'] ) ? sanitize_key( wp_unslash( $_POST['status'] ) ) : '';
+
+    if ( ! $post_id || '' === $new_status ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Missing required data.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    // Build an allow-list of valid statuses ( slug without the wc- prefix => label ).
+    $allowed = array();
+    foreach ( wc_get_order_statuses() as $key => $label ) {
+        $allowed[ str_replace( 'wc-', '', $key ) ] = $label;
+    }
+    if ( ! isset( $allowed[ $new_status ] ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Invalid order status.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    $wc_order_id = get_post_meta( $post_id, 'rbfw_order_id', true );
+    $order       = $wc_order_id ? wc_get_order( $wc_order_id ) : false;
+    if ( ! $order ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Order not found.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    // Nothing to do if the status is unchanged.
+    if ( $order->get_status() === $new_status ) {
+        wp_send_json_success( array(
+            'status'       => $new_status,
+            'status_label' => ucfirst( $new_status ),
+            'message'      => esc_html__( 'Status is already set.', 'booking-and-rental-manager-for-woocommerce' ),
+        ) );
+    }
+
+    // Update the WooCommerce order. This fires woocommerce_order_status_changed,
+    // which the plugin already hooks ( rbfw_wc_status_update ) for its own side effects.
+    $order->update_status( $new_status, '', true );
+
+    // Keep the booking CPT + reports + inventory in sync with the new status.
+    update_post_meta( $post_id, 'rbfw_order_status', $new_status );
+
+    $current_user  = wp_get_current_user();
+    $username      = $current_user->user_login;
+    $modified_date = current_datetime()->format( 'F j, Y h:i a' );
+    $note          = 'Status changed to ' . wp_kses( '<strong>' . $allowed[ $new_status ] . '</strong>', rbfw_allowed_html() ) . ' by ' . $username . ' on ' . $modified_date;
+    $revisions     = get_post_meta( $post_id, 'rbfw_order_status_revision', true );
+    if ( empty( $revisions ) || ! is_array( $revisions ) ) {
+        $revisions = array();
+    }
+    $revisions[] = $note;
+    update_post_meta( $post_id, 'rbfw_order_status_revision', $revisions );
+
+    if ( function_exists( 'rbfw_update_reports_status' ) ) {
+        rbfw_update_reports_status( $wc_order_id, $new_status );
+    }
+    if ( function_exists( 'rbfw_update_inventory' ) ) {
+        rbfw_update_inventory( $wc_order_id, $new_status );
+    }
+
+    wp_send_json_success( array(
+        'status'       => $new_status,
+        'status_label' => ucfirst( $new_status ),
+        'message'      => esc_html__( 'Order status updated.', 'booking-and-rental-manager-for-woocommerce' ),
+    ) );
+}
+
+/**
+ * Recalculate the Order List dashboard stats ( counts + amounts per bucket ).
+ *
+ * Single source of truth used by the AJAX delete handler to return fresh
+ * numbers. Keep the status→bucket mapping in sync with the inline calculation
+ * in MageRBFWClass::rbfw_order_list().
+ *
+ * @return array
+ */
+function rbfw_calculate_order_list_stats() {
+    $stats = array(
+        'total_orders'     => 0, 'total_amount'     => 0,
+        'completed_orders' => 0, 'completed_amount' => 0,
+        'cancelled_orders' => 0, 'cancelled_amount' => 0,
+        'pending_orders'   => 0, 'pending_amount'   => 0,
+        'refunded_orders'  => 0, 'refunded_amount'  => 0,
+    );
+
+    if ( ! function_exists( 'wc_get_order' ) ) {
+        return $stats;
+    }
+
+    $query = new WP_Query( array(
+        'post_type'      => 'rbfw_order',
+        'order'          => 'DESC',
+        'posts_per_page' => -1,
+        'fields'         => 'ids',
+        'post_status'    => array( 'publish', 'private', 'draft', 'pending', 'future', 'inherit' ),
+    ) );
+
+    foreach ( $query->posts as $post_id ) {
+        $wc_order_id = get_post_meta( $post_id, 'rbfw_order_id', true );
+        $order       = wc_get_order( $wc_order_id );
+        if ( ! $order ) {
+            continue;
+        }
+        $status = $order->get_status();
+        if ( 'trash' === $status || 'wc-trash' === $status ) {
+            continue;
+        }
+        $order_total = $order->get_total();
+        $stats['total_orders']++;
+        $stats['total_amount'] += $order_total;
+
+        switch ( str_replace( 'wc-', '', $status ) ) {
+            case 'completed':
+                $stats['completed_orders']++;
+                $stats['completed_amount'] += $order_total;
+                break;
+            case 'cancelled':
+            case 'canceled':
+            case 'failed':
+                $stats['cancelled_orders']++;
+                $stats['cancelled_amount'] += $order_total;
+                break;
+            case 'refunded':
+                $stats['refunded_orders']++;
+                $stats['refunded_amount'] += $order_total;
+                break;
+            case 'pending':
+            case 'on-hold':
+            case 'processing':
+                $stats['pending_orders']++;
+                $stats['pending_amount'] += $order_total;
+                break;
+        }
+    }
+    wp_reset_postdata();
+
+    return $stats;
+}
+
+/**
+ * AJAX: move a booking + its linked WooCommerce order to Trash from the list.
+ *
+ * Both records are trashed together ( recoverable ). Returns freshly
+ * recalculated dashboard stats so the list updates without a page reload.
+ */
+add_action( 'wp_ajax_rbfw_delete_order', 'rbfw_delete_order_callback' );
+function rbfw_delete_order_callback() {
+
+    check_ajax_referer( 'rbfw_delete_order_action', 'nonce' );
+
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+    }
+
+    $post_id = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+    if ( ! $post_id || 'rbfw_order' !== get_post_type( $post_id ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Invalid order.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    // Trash the linked WooCommerce order ( HPOS-safe via the WC API ).
+    $wc_order_id = get_post_meta( $post_id, 'rbfw_order_id', true );
+    if ( $wc_order_id && function_exists( 'wc_get_order' ) ) {
+        $order = wc_get_order( $wc_order_id );
+        if ( $order ) {
+            $order->delete( false ); // false = move to Trash, not permanent.
+        }
+    }
+
+    // Trash the booking record.
+    wp_trash_post( $post_id );
+
+    $stats = rbfw_calculate_order_list_stats();
+    $fmt   = static function ( $count, $amount ) {
+        return array(
+            'count'  => number_format_i18n( $count ),
+            'amount' => wc_price( $amount ),
+            'pos'    => $amount > 0,
+        );
+    };
+
+    wp_send_json_success( array(
+        'message' => esc_html__( 'Order moved to Trash.', 'booking-and-rental-manager-for-woocommerce' ),
+        'header'  => sprintf(
+            /* translators: %s: number of orders. */
+            _n( '%s Order', '%s Orders', $stats['total_orders'], 'booking-and-rental-manager-for-woocommerce' ),
+            number_format_i18n( $stats['total_orders'] )
+        ),
+        'stats'   => array(
+            'total'     => $fmt( $stats['total_orders'], $stats['total_amount'] ),
+            'cancelled' => $fmt( $stats['cancelled_orders'], $stats['cancelled_amount'] ),
+            'completed' => $fmt( $stats['completed_orders'], $stats['completed_amount'] ),
+            'pending'   => $fmt( $stats['pending_orders'], $stats['pending_amount'] ),
+            'refunded'  => $fmt( $stats['refunded_orders'], $stats['refunded_amount'] ),
+        ),
+    ) );
+}
+
+/**
+ * Helper: load the first ticket-info entry for a booking order, plus its key.
+ *
+ * @return array { 'all' => full ticket array, 'key' => first key, 'ticket' => first entry }
+ */
+function rbfw_get_order_first_ticket( $post_id ) {
+    $all = maybe_unserialize( get_post_meta( $post_id, 'rbfw_ticket_info', true ) );
+    if ( ! is_array( $all ) || empty( $all ) ) {
+        return array( 'all' => array(), 'key' => null, 'ticket' => array() );
+    }
+    $keys = array_keys( $all );
+    $key  = $keys[0];
+    return array( 'all' => $all, 'key' => $key, 'ticket' => is_array( $all[ $key ] ) ? $all[ $key ] : array() );
+}
+
+/**
+ * Helper: load an item's category-wise service catalog as a clean array.
+ */
+function rbfw_get_item_service_catalog( $rbfw_id ) {
+    $cats = get_post_meta( $rbfw_id, 'rbfw_service_category_price', true );
+    if ( ! is_array( $cats ) ) {
+        $cats = json_decode( $cats, true );
+    }
+    return is_array( $cats ) ? $cats : array();
+}
+
+/**
+ * Propagate an order edit into the Reports store ( rbfw_order_meta attendee posts ).
+ *
+ * The Reports dashboard reads flat post-meta copied from the ticket at checkout, so
+ * an edit must be mirrored onto every attendee post linked to the WooCommerce order.
+ */
+function rbfw_sync_attendee_meta_from_edit( $wc_order_id, $t, $billing, $billing_fields, $grand_total, $order_total ) {
+    if ( ! $wc_order_id ) {
+        return;
+    }
+    $query = new WP_Query( array(
+        'post_type'      => 'rbfw_order_meta',
+        'posts_per_page' => -1,
+        'fields'         => 'ids',
+        'post_status'    => 'any',
+        'meta_query'     => array(
+            'relation' => 'OR',
+            array( 'key' => 'rbfw_link_order_id', 'value' => $wc_order_id ),
+            array( 'key' => 'rbfw_order_id', 'value' => $wc_order_id ),
+        ),
+    ) );
+    if ( empty( $query->posts ) ) {
+        return;
+    }
+
+    $start_dt = isset( $t['rbfw_start_datetime'] ) ? $t['rbfw_start_datetime'] : '';
+    $end_dt   = isset( $t['rbfw_end_datetime'] ) ? $t['rbfw_end_datetime'] : '';
+    $address  = trim( $billing_fields['address_1'] . ' ' . $billing_fields['address_2'] );
+
+    $meta = array(
+        'ticket_price'            => $grand_total,
+        'rbfw_ticket_total_price' => $order_total,
+        'duration_cost'           => isset( $t['duration_cost'] ) ? $t['duration_cost'] : 0,
+        'service_cost'            => isset( $t['service_cost'] ) ? $t['service_cost'] : 0,
+        'total_days'              => isset( $t['total_days'] ) ? $t['total_days'] : 1,
+        'discount_amount'         => isset( $t['discount_amount'] ) ? $t['discount_amount'] : 0,
+        'rbfw_management_price'   => isset( $t['rbfw_management_price'] ) ? $t['rbfw_management_price'] : 0,
+        'security_deposit_amount' => isset( $t['security_deposit_amount'] ) ? $t['security_deposit_amount'] : 0,
+        'rbfw_service_infos'      => isset( $t['rbfw_service_infos'] ) ? $t['rbfw_service_infos'] : array(),
+        'rbfw_start_date'         => isset( $t['rbfw_start_date'] ) ? gmdate( 'Y-m-d', strtotime( $t['rbfw_start_date'] ) ) : '',
+        'end_date'                => isset( $t['rbfw_end_date'] ) ? gmdate( 'Y-m-d', strtotime( $t['rbfw_end_date'] ) ) : '',
+        'start_date'              => isset( $t['rbfw_start_date'] ) ? gmdate( 'Y-m-d', strtotime( $t['rbfw_start_date'] ) ) : '',
+        'rbfw_end_date'           => isset( $t['rbfw_end_date'] ) ? gmdate( 'Y-m-d', strtotime( $t['rbfw_end_date'] ) ) : '',
+        'rbfw_start_datetime'     => $start_dt ? gmdate( 'Y-m-d h:i A', strtotime( $start_dt ) ) : '',
+        'rbfw_end_datetime'       => $end_dt ? gmdate( 'Y-m-d h:i A', strtotime( $end_dt ) ) : '',
+        'rbfw_billing_phone'      => $billing_fields['phone'],
+        'rbfw_billing_address'    => $address,
+    );
+    if ( '' !== $billing ) {
+        $meta['rbfw_billing_name'] = $billing;
+    }
+    if ( '' !== $billing_fields['email'] ) {
+        $meta['rbfw_billing_email'] = $billing_fields['email'];
+    }
+    if ( isset( $t['rbfw_regf_info'] ) ) {
+        $meta['rbfw_regf_info'] = $t['rbfw_regf_info'];
+    }
+
+    foreach ( $query->posts as $attendee_id ) {
+        foreach ( $meta as $key => $value ) {
+            update_post_meta( $attendee_id, $key, $value );
+        }
+    }
+}
+
+/**
+ * AJAX: return the "Edit Order" modal form HTML for a given booking order.
+ */
+add_action( 'wp_ajax_rbfw_get_order_edit_form', 'rbfw_get_order_edit_form_callback' );
+function rbfw_get_order_edit_form_callback() {
+
+    check_ajax_referer( 'rbfw_get_order_edit_form_action', 'nonce' );
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+    }
+
+    $post_id = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+    if ( ! $post_id || 'rbfw_order' !== get_post_type( $post_id ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Invalid order.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    $data = rbfw_get_order_first_ticket( $post_id );
+    $t    = $data['ticket'];
+    if ( empty( $t ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'This order has no editable booking data.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    $rbfw_id      = isset( $t['rbfw_id'] ) ? $t['rbfw_id'] : 0;
+    $catalog      = rbfw_get_item_service_catalog( $rbfw_id );
+
+    // WooCommerce billing details (full address).
+    $wc_order_id = get_post_meta( $post_id, 'rbfw_order_id', true );
+    $wc_order    = ( $wc_order_id && function_exists( 'wc_get_order' ) ) ? wc_get_order( $wc_order_id ) : false;
+    $billing     = array(
+        'first_name' => $wc_order ? $wc_order->get_billing_first_name() : '',
+        'last_name'  => $wc_order ? $wc_order->get_billing_last_name() : '',
+        'company'    => $wc_order ? $wc_order->get_billing_company() : '',
+        'email'      => $wc_order ? $wc_order->get_billing_email() : get_post_meta( $post_id, 'rbfw_billing_email', true ),
+        'phone'      => $wc_order ? $wc_order->get_billing_phone() : '',
+        'address_1'  => $wc_order ? $wc_order->get_billing_address_1() : '',
+        'address_2'  => $wc_order ? $wc_order->get_billing_address_2() : '',
+        'city'       => $wc_order ? $wc_order->get_billing_city() : '',
+        'state'      => $wc_order ? $wc_order->get_billing_state() : '',
+        'postcode'   => $wc_order ? $wc_order->get_billing_postcode() : '',
+        'country'    => $wc_order ? $wc_order->get_billing_country() : '',
+    );
+    if ( '' === $billing['first_name'] && '' === $billing['last_name'] ) {
+        $billing['first_name'] = get_post_meta( $post_id, 'rbfw_billing_name', true );
+    }
+
+    // Attendee / registration form values stored on the booking ( label => value per field ).
+    $regf_info = ( ! empty( $t['rbfw_regf_info'] ) && is_array( $t['rbfw_regf_info'] ) ) ? $t['rbfw_regf_info'] : array();
+
+    // Map existing selected quantities by service title.
+    $existing_qty = array();
+    if ( ! empty( $t['rbfw_service_infos'] ) && is_array( $t['rbfw_service_infos'] ) ) {
+        foreach ( $t['rbfw_service_infos'] as $svcs ) {
+            if ( is_array( $svcs ) ) {
+                foreach ( $svcs as $s ) {
+                    if ( ! empty( $s['name'] ) ) {
+                        $existing_qty[ $s['name'] ] = (int) ( isset( $s['quantity'] ) ? $s['quantity'] : 0 );
+                    }
+                }
+            }
+        }
+    }
+
+    $get = static function ( $key, $default = '' ) use ( $t ) {
+        return isset( $t[ $key ] ) ? $t[ $key ] : $default;
+    };
+
+    ob_start();
+    ?>
+    <input type="hidden" id="rbfw_eo_post_id" value="<?php echo esc_attr( $post_id ); ?>">
+    <input type="hidden" id="rbfw_eo_total_days" value="<?php echo esc_attr( (int) $get( 'total_days', 1 ) ); ?>">
+
+    <div class="rbfw_eo_section_title"><?php esc_html_e( 'Booking Dates', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+    <div class="rbfw_eo_grid">
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Start Date', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_start_date" class="rbfw_eo_fp_date" value="<?php echo esc_attr( $get( 'rbfw_start_date' ) ); ?>" autocomplete="off">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Start Time', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_start_time" class="rbfw_eo_fp_time" value="<?php echo esc_attr( $get( 'rbfw_start_time' ) ); ?>" autocomplete="off">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'End Date', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_end_date" class="rbfw_eo_fp_date" value="<?php echo esc_attr( $get( 'rbfw_end_date' ) ); ?>" autocomplete="off">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'End Time', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_end_time" class="rbfw_eo_fp_time" value="<?php echo esc_attr( $get( 'rbfw_end_time' ) ); ?>" autocomplete="off">
+        </div>
+    </div>
+
+    <div class="rbfw_eo_section_title"><?php esc_html_e( 'Billing Details', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+    <div class="rbfw_eo_grid">
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'First Name', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_first" value="<?php echo esc_attr( $billing['first_name'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Last Name', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_last" value="<?php echo esc_attr( $billing['last_name'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Email', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="email" id="rbfw_eo_b_email" value="<?php echo esc_attr( $billing['email'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Phone', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_phone" value="<?php echo esc_attr( $billing['phone'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Company', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_company" value="<?php echo esc_attr( $billing['company'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Country', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_country" value="<?php echo esc_attr( $billing['country'] ); ?>" placeholder="<?php esc_attr_e( 'e.g. BD, US', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+        </div>
+        <div class="rbfw_eo_field rbfw_eo_full">
+            <label><?php esc_html_e( 'Address Line 1', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_addr1" value="<?php echo esc_attr( $billing['address_1'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field rbfw_eo_full">
+            <label><?php esc_html_e( 'Address Line 2', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_addr2" value="<?php echo esc_attr( $billing['address_2'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'City', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_city" value="<?php echo esc_attr( $billing['city'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'State', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_state" value="<?php echo esc_attr( $billing['state'] ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Postcode', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="text" id="rbfw_eo_b_postcode" value="<?php echo esc_attr( $billing['postcode'] ); ?>">
+        </div>
+    </div>
+
+    <?php if ( ! empty( $regf_info ) ) { ?>
+        <div class="rbfw_eo_section_title"><?php esc_html_e( 'Attendee / Customer Information', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+        <div class="rbfw_eo_grid">
+            <?php foreach ( $regf_info as $regf_key => $regf_field ) {
+                $regf_label = is_array( $regf_field ) && isset( $regf_field['label'] ) ? $regf_field['label'] : $regf_key;
+                $regf_value = is_array( $regf_field ) && isset( $regf_field['value'] ) ? $regf_field['value'] : '';
+                ?>
+                <div class="rbfw_eo_field rbfw_eo_full">
+                    <label><?php echo esc_html( $regf_label ); ?></label>
+                    <input type="text" class="rbfw_eo_regf" data-key="<?php echo esc_attr( $regf_key ); ?>" value="<?php echo esc_attr( $regf_value ); ?>">
+                </div>
+            <?php } ?>
+        </div>
+    <?php } ?>
+
+    <?php if ( ! empty( $catalog ) ) { ?>
+        <div class="rbfw_eo_section_title"><?php esc_html_e( 'Service Add-ons', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+        <div class="rbfw_eo_services">
+            <?php foreach ( $catalog as $ck => $cat ) {
+                $cat_title    = isset( $cat['cat_title'] ) ? $cat['cat_title'] : '';
+                $cat_services = ( ! empty( $cat['cat_services'] ) && is_array( $cat['cat_services'] ) ) ? $cat['cat_services'] : array();
+                if ( empty( $cat_services ) ) {
+                    continue;
+                }
+                ?>
+                <div class="rbfw_eo_svc_cat">
+                    <?php if ( '' !== (string) $cat_title ) { ?>
+                        <div class="rbfw_eo_svc_cat_title"><?php echo esc_html( $cat_title ); ?></div>
+                    <?php } ?>
+                    <?php foreach ( $cat_services as $sk => $svc ) {
+                        if ( empty( $svc['title'] ) ) {
+                            continue;
+                        }
+                        $s_price = isset( $svc['price'] ) ? (float) $svc['price'] : 0;
+                        $s_type  = isset( $svc['service_price_type'] ) ? $svc['service_price_type'] : '';
+                        $s_qty   = isset( $existing_qty[ $svc['title'] ] ) ? (int) $existing_qty[ $svc['title'] ] : 0;
+                        ?>
+                        <div class="rbfw_eo_svc_row">
+                            <div class="rbfw_eo_svc_meta">
+                                <span class="rbfw_eo_svc_name"><?php echo esc_html( $svc['title'] ); ?></span>
+                                <span class="rbfw_eo_svc_price"><?php echo wp_kses( wc_price( $s_price ), rbfw_allowed_html() ); ?>
+                                    <em><?php echo ( 'day_wise' === $s_type ) ? esc_html__( 'Day Wise', 'booking-and-rental-manager-for-woocommerce' ) : esc_html__( 'One Time', 'booking-and-rental-manager-for-woocommerce' ); ?></em>
+                                </span>
+                            </div>
+                            <input type="number" min="0" step="1"
+                                   class="rbfw_eo_svc_qty"
+                                   data-price="<?php echo esc_attr( $s_price ); ?>"
+                                   data-type="<?php echo esc_attr( $s_type ); ?>"
+                                   data-cat="<?php echo esc_attr( $ck ); ?>"
+                                   data-svc="<?php echo esc_attr( $sk ); ?>"
+                                   value="<?php echo esc_attr( $s_qty ); ?>">
+                        </div>
+                    <?php } ?>
+                </div>
+            <?php } ?>
+        </div>
+    <?php } ?>
+
+    <div class="rbfw_eo_grid rbfw_eo_costs">
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Duration Cost', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="number" min="0" step="0.01" id="rbfw_eo_duration" value="<?php echo esc_attr( (float) $get( 'duration_cost', 0 ) ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Fee / Management', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="number" min="0" step="0.01" id="rbfw_eo_management" value="<?php echo esc_attr( (float) $get( 'rbfw_management_price', 0 ) ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Discount', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="number" min="0" step="0.01" id="rbfw_eo_discount" value="<?php echo esc_attr( (float) $get( 'discount_amount', 0 ) ); ?>">
+        </div>
+        <div class="rbfw_eo_field">
+            <label><?php esc_html_e( 'Security Deposit', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+            <input type="number" min="0" step="0.01" id="rbfw_eo_deposit" value="<?php echo esc_attr( (float) $get( 'security_deposit_amount', 0 ) ); ?>">
+        </div>
+    </div>
+
+    <div class="rbfw_eo_totals">
+        <div class="rbfw_eo_total_row"><span><?php esc_html_e( 'Resource Cost', 'booking-and-rental-manager-for-woocommerce' ); ?></span><strong id="rbfw_eo_resource">—</strong></div>
+        <div class="rbfw_eo_total_row"><span><?php esc_html_e( 'Subtotal', 'booking-and-rental-manager-for-woocommerce' ); ?></span><strong id="rbfw_eo_subtotal">—</strong></div>
+        <div class="rbfw_eo_total_row rbfw_eo_grand"><span><?php esc_html_e( 'Total', 'booking-and-rental-manager-for-woocommerce' ); ?></span><strong id="rbfw_eo_total">—</strong></div>
+    </div>
+    <?php
+    $html = ob_get_clean();
+    wp_send_json_success( array( 'html' => $html ) );
+}
+
+/**
+ * AJAX: save the edited order — recompute prices server-side, update the booking
+ * ticket meta and the linked WooCommerce order total.
+ */
+add_action( 'wp_ajax_rbfw_save_order_edit', 'rbfw_save_order_edit_callback' );
+function rbfw_save_order_edit_callback() {
+
+    check_ajax_referer( 'rbfw_save_order_edit_action', 'nonce' );
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+    }
+
+    $post_id = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+    if ( ! $post_id || 'rbfw_order' !== get_post_type( $post_id ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'Invalid order.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+
+    $data = rbfw_get_order_first_ticket( $post_id );
+    if ( null === $data['key'] || empty( $data['ticket'] ) ) {
+        wp_send_json_error( array( 'message' => esc_html__( 'This order has no editable booking data.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+    }
+    $all     = $data['all'];
+    $tkey    = $data['key'];
+    $t       = $data['ticket'];
+    $rbfw_id = isset( $t['rbfw_id'] ) ? $t['rbfw_id'] : 0;
+
+    // ── sanitize inputs ──
+    $billing_fields = array();
+    foreach ( array( 'first_name', 'last_name', 'company', 'phone', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country' ) as $bf ) {
+        $billing_fields[ $bf ] = isset( $_POST[ 'billing_' . $bf ] ) ? sanitize_text_field( wp_unslash( $_POST[ 'billing_' . $bf ] ) ) : '';
+    }
+    $billing_fields['email'] = isset( $_POST['billing_email'] ) ? sanitize_email( wp_unslash( $_POST['billing_email'] ) ) : '';
+    $billing = trim( $billing_fields['first_name'] . ' ' . $billing_fields['last_name'] );
+    $regf_in = ( isset( $_POST['regf'] ) && is_array( $_POST['regf'] ) ) ? wp_unslash( $_POST['regf'] ) : array();
+    $start_date    = isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : ( isset( $t['rbfw_start_date'] ) ? $t['rbfw_start_date'] : '' );
+    $start_time    = isset( $_POST['start_time'] ) ? sanitize_text_field( wp_unslash( $_POST['start_time'] ) ) : ( isset( $t['rbfw_start_time'] ) ? $t['rbfw_start_time'] : '' );
+    $end_date      = isset( $_POST['end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) : ( isset( $t['rbfw_end_date'] ) ? $t['rbfw_end_date'] : '' );
+    $end_time      = isset( $_POST['end_time'] ) ? sanitize_text_field( wp_unslash( $_POST['end_time'] ) ) : ( isset( $t['rbfw_end_time'] ) ? $t['rbfw_end_time'] : '' );
+    $duration_cost = isset( $_POST['duration_cost'] ) ? max( 0, (float) wp_unslash( $_POST['duration_cost'] ) ) : 0;
+    $management    = isset( $_POST['management_price'] ) ? max( 0, (float) wp_unslash( $_POST['management_price'] ) ) : 0;
+    $discount      = isset( $_POST['discount_amount'] ) ? max( 0, (float) wp_unslash( $_POST['discount_amount'] ) ) : 0;
+    $deposit       = isset( $_POST['security_deposit'] ) ? max( 0, (float) wp_unslash( $_POST['security_deposit'] ) ) : 0;
+    $qty_in        = ( isset( $_POST['service_qty'] ) && is_array( $_POST['service_qty'] ) ) ? wp_unslash( $_POST['service_qty'] ) : array();
+
+    // ── total days from the (new) date range ──
+    $s_ts       = strtotime( $start_date );
+    $e_ts       = strtotime( $end_date );
+    $total_days = ( $s_ts && $e_ts && $e_ts > $s_ts ) ? max( 1, (int) round( ( $e_ts - $s_ts ) / DAY_IN_SECONDS ) ) : 1;
+
+    // ── recompute services from the item catalog ( authoritative prices ) ──
+    $catalog       = rbfw_get_item_service_catalog( $rbfw_id );
+    $service_cost  = 0;
+    $service_infos = array();
+    foreach ( $catalog as $ck => $cat ) {
+        $cat_title    = isset( $cat['cat_title'] ) ? $cat['cat_title'] : '';
+        $cat_services = ( ! empty( $cat['cat_services'] ) && is_array( $cat['cat_services'] ) ) ? $cat['cat_services'] : array();
+        foreach ( $cat_services as $sk => $svc ) {
+            $qty = isset( $qty_in[ $ck ][ $sk ] ) ? max( 0, (int) $qty_in[ $ck ][ $sk ] ) : 0;
+            if ( $qty <= 0 || empty( $svc['title'] ) ) {
+                continue;
+            }
+            $price = isset( $svc['price'] ) ? (float) $svc['price'] : 0;
+            $type  = isset( $svc['service_price_type'] ) ? $svc['service_price_type'] : '';
+            $service_cost += ( 'day_wise' === $type ) ? $price * $qty * $total_days : $price * $qty;
+            if ( ! isset( $service_infos[ $cat_title ] ) ) {
+                $service_infos[ $cat_title ] = array();
+            }
+            $service_infos[ $cat_title ][] = array(
+                'name'               => sanitize_text_field( $svc['title'] ),
+                'price'              => $price,
+                'quantity'           => $qty,
+                'service_price_type' => $type,
+            );
+        }
+    }
+
+    $line_total  = max( 0, $duration_cost + $service_cost + $management - $discount );
+    $grand_total = $line_total + $deposit;
+
+    // ── persist the booking ticket meta ──
+    $t['rbfw_start_date']         = $start_date;
+    $t['rbfw_start_time']         = $start_time;
+    $t['rbfw_end_date']           = $end_date;
+    $t['rbfw_end_time']           = $end_time;
+    $t['rbfw_start_datetime']     = gmdate( 'Y-m-d H:i', strtotime( $start_date . ' ' . $start_time ) );
+    $t['rbfw_end_datetime']       = gmdate( 'Y-m-d H:i', strtotime( $end_date . ' ' . $end_time ) );
+    $t['duration_cost']           = $duration_cost;
+    $t['service_cost']            = $service_cost;
+    $t['rbfw_service_infos']      = $service_infos;
+    $t['total_days']              = $total_days;
+    $t['rbfw_management_price']   = $management;
+    $t['discount_amount']         = $discount;
+    $t['security_deposit_amount'] = $deposit;
+    $t['ticket_price']            = $grand_total;
+
+    // ── attendee / registration form values ( update existing fields only ) ──
+    if ( ! empty( $regf_in ) && ! empty( $t['rbfw_regf_info'] ) && is_array( $t['rbfw_regf_info'] ) ) {
+        foreach ( $t['rbfw_regf_info'] as $regf_key => $regf_field ) {
+            if ( is_array( $regf_field ) && array_key_exists( $regf_key, $regf_in ) ) {
+                $t['rbfw_regf_info'][ $regf_key ]['value'] = sanitize_text_field( $regf_in[ $regf_key ] );
+            }
+        }
+    }
+
+    $all[ $tkey ] = $t;
+    update_post_meta( $post_id, 'rbfw_ticket_info', $all );
+    update_post_meta( $post_id, 'rbfw_ticket_total_price', $grand_total );
+
+    // ── billing name + post title ──
+    $wc_order_id = get_post_meta( $post_id, 'rbfw_order_id', true );
+    if ( '' !== $billing ) {
+        update_post_meta( $post_id, 'rbfw_billing_name', $billing );
+        wp_update_post( array( 'ID' => $post_id, 'post_title' => '#' . $wc_order_id . ' ' . $billing ) );
+    }
+    if ( '' !== $billing_fields['email'] ) {
+        update_post_meta( $post_id, 'rbfw_billing_email', $billing_fields['email'] );
+    }
+
+    // ── sync the linked WooCommerce order ( total + billing details ) ──
+    $order       = ( $wc_order_id && function_exists( 'wc_get_order' ) ) ? wc_get_order( $wc_order_id ) : false;
+    $order_total = $grand_total;
+    if ( $order ) {
+        foreach ( $order->get_items() as $item ) {
+            if ( (string) $item->get_meta( '_rbfw_id', true ) === (string) $rbfw_id ) {
+                $item->set_subtotal( $line_total );
+                $item->set_total( $line_total );
+                // Keep the line-item ticket snapshot in sync (read by the detail panel + PDF).
+                $item->update_meta_data( '_rbfw_ticket_info', $all );
+                $item->save();
+                break;
+            }
+        }
+        // Billing address.
+        $order->set_billing_first_name( $billing_fields['first_name'] );
+        $order->set_billing_last_name( $billing_fields['last_name'] );
+        $order->set_billing_company( $billing_fields['company'] );
+        if ( '' !== $billing_fields['email'] ) {
+            $order->set_billing_email( $billing_fields['email'] );
+        }
+        $order->set_billing_phone( $billing_fields['phone'] );
+        $order->set_billing_address_1( $billing_fields['address_1'] );
+        $order->set_billing_address_2( $billing_fields['address_2'] );
+        $order->set_billing_city( $billing_fields['city'] );
+        $order->set_billing_state( $billing_fields['state'] );
+        $order->set_billing_postcode( $billing_fields['postcode'] );
+        $order->set_billing_country( $billing_fields['country'] );
+        $order->calculate_totals( false );
+        $order->save();
+        $order_total = $order->get_total();
+        $order->add_order_note( sprintf(
+            /* translators: %s: formatted order total. */
+            __( 'Order details edited from the Order List. New total: %s', 'booking-and-rental-manager-for-woocommerce' ),
+            wp_strip_all_tags( wc_price( $order_total ) )
+        ) );
+    }
+
+    // ── propagate to the Reports store ( rbfw_order_meta attendee posts ) ──
+    rbfw_sync_attendee_meta_from_edit( $wc_order_id, $t, $billing, $billing_fields, $grand_total, $order_total );
+
+    wp_send_json_success( array(
+        'message'       => esc_html__( 'Order updated successfully.', 'booking-and-rental-manager-for-woocommerce' ),
+        'order_total'   => (float) $order_total,
+        'total_html'    => wc_price( $order_total ),
+        'billing'       => $billing,
+        'start_display' => $s_ts ? date_i18n( 'F j, Y g:i a', strtotime( $t['rbfw_start_datetime'] ) ) : '',
+        'end_display'   => $e_ts ? date_i18n( 'F j, Y g:i a', strtotime( $t['rbfw_end_datetime'] ) ) : '',
+    ) );
+}
+
 add_action( 'wp_ajax_fetch_order_details', 'fetch_order_details_callback' );
 function fetch_order_details_callback() {
 
@@ -34,25 +732,41 @@ function fetch_order_details_callback() {
         ?>
         <div class="rbfw_order_meta_box_wrap">
             <div class="rbfw_order_meta_box_head">
-                <h1>
-                    <?php esc_html_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?>
-                    <?php echo '#' . esc_html( $wc_order_id ); ?>
-                    <?php esc_html_e( 'Details', 'booking-and-rental-manager-for-woocommerce' ); ?>
-                </h1>
+                <div class="rbfw_ol_dhead">
+                    <?php echo rbfw_inv_icon( 'receipt' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                    <span class="rbfw_ol_dhead_title"><?php
+                        /* translators: %s: WooCommerce order number. */
+                        echo esc_html( sprintf( __( 'Order #%s Details', 'booking-and-rental-manager-for-woocommerce' ), $wc_order_id ) );
+                    ?></span>
+                </div>
+                <button type="button" class="rbfw_ol_edit_order_btn" data-post-id="<?php echo esc_attr( $rbfw_order_id ); ?>">
+                    <?php echo rbfw_inv_icon( 'pencil' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                    <span><?php esc_html_e( 'Edit Order', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                </button>
             </div>
             <div class="rbfw_order_meta_box_body">
                 <?php
                 $total_security_deposit_amount = 0;
                 foreach ( $wc_order_details->get_items() as $item_id => $item ) {
                     $ticket_info = $item->get_meta( '_rbfw_ticket_info', true );
-                    $ticket_info = $ticket_info[0];
+                    // Some line items have no rental ticket data (e.g. plain WooCommerce
+                    // products or legacy/partial meta). Normalise to a single ticket array
+                    // and skip the item entirely when none is present, instead of fataling.
+                    if ( is_array( $ticket_info ) && isset( $ticket_info[0] ) && is_array( $ticket_info[0] ) ) {
+                        $ticket_info = $ticket_info[0];
+                    } elseif ( is_array( $ticket_info ) && ! empty( $ticket_info ) && is_array( reset( $ticket_info ) ) ) {
+                        $ticket_info = reset( $ticket_info );
+                    }
+                    if ( ! is_array( $ticket_info ) || empty( $ticket_info ) ) {
+                        continue;
+                    }
 
                     $item_name = ! empty( $ticket_info['ticket_name'] ) ? $ticket_info['ticket_name'] : '';
-                    $rbfw_id   = $ticket_info['rbfw_id'];
+                    $rbfw_id   = isset( $ticket_info['rbfw_id'] ) ? $ticket_info['rbfw_id'] : 0;
                     $item_id   = $rbfw_id;
-                    $rent_type = $ticket_info['rbfw_rent_type'];
-                    $rbfw_start_datetime = rbfw_get_datetime( $ticket_info['rbfw_start_datetime'], 'date-time-text' );
-                    $rbfw_end_datetime   = rbfw_get_datetime( $ticket_info['rbfw_end_datetime'], 'date-time-text' );
+                    $rent_type = isset( $ticket_info['rbfw_rent_type'] ) ? $ticket_info['rbfw_rent_type'] : '';
+                    $rbfw_start_datetime = ! empty( $ticket_info['rbfw_start_datetime'] ) ? rbfw_get_datetime( $ticket_info['rbfw_start_datetime'], 'date-time-text' ) : '';
+                    $rbfw_end_datetime   = ! empty( $ticket_info['rbfw_end_datetime'] ) ? rbfw_get_datetime( $ticket_info['rbfw_end_datetime'], 'date-time-text' ) : '';
                     $rbfw_start_time     = ! empty( $ticket_info['rbfw_start_time'] ) ? $ticket_info['rbfw_start_time'] : '';
                     $rbfw_end_time       = ! empty( $ticket_info['rbfw_end_time'] ) ? $ticket_info['rbfw_end_time'] : '';
                     $rbfw_management_info       = ! empty( $ticket_info['rbfw_management_info'] ) ? $ticket_info['rbfw_management_info'] : '';
@@ -101,6 +815,17 @@ function fetch_order_details_callback() {
                         $service_info = '';
                     }
                     $variation_info = ! empty( $ticket_info['rbfw_variation_info'] ) ? $ticket_info['rbfw_variation_info'] : [];
+                    // Category-wise extra services ( bike_car_md / dress / equipment / others ).
+                    $service_infos     = ! empty( $ticket_info['rbfw_service_infos'] ) ? $ticket_info['rbfw_service_infos'] : [];
+                    $has_service_infos = false;
+                    if ( is_array( $service_infos ) ) {
+                        foreach ( $service_infos as $sv_cat_services ) {
+                            if ( is_array( $sv_cat_services ) && count( $sv_cat_services ) ) {
+                                $has_service_infos = true;
+                                break;
+                            }
+                        }
+                    }
                     $duration_cost  =  $ticket_info['duration_cost'] ;
                     $discount_amount         = ! empty( $ticket_info['discount_amount'] ) ? (float) $ticket_info['discount_amount'] : 0;
                     $security_deposit_amount = ! empty( $ticket_info['security_deposit_amount'] ) ? (float) $ticket_info['security_deposit_amount'] : 0;
@@ -112,7 +837,7 @@ function fetch_order_details_callback() {
                         <thead>
                         <tr>
                             <th colspan="2">
-                               <?php rbfw_string( 'rbfw_text_item_information', __( 'Item Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                               <span class="rbfw_ol_sec_ico"><?php echo rbfw_inv_icon( 'box' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span><?php rbfw_string( 'rbfw_text_item_information', __( 'Item Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                             </th>
                         </tr>
                         </thead>
@@ -120,16 +845,16 @@ function fetch_order_details_callback() {
                         <?php if ( $rent_type == 'bike_car_md' || $rent_type == 'dress' || $rent_type == 'equipment' || $rent_type == 'others' ) { ?>
                             <tr>
                                 <td>
-                                    <strong><?php rbfw_string( 'rbfw_text_item_name', __( 'Item Name', 'booking-and-rental-manager-for-woocommerce' ) ); echo ':'; ?>
+                                    <strong><?php rbfw_string( 'rbfw_text_item_name', __( 'Item Name', 'booking-and-rental-manager-for-woocommerce' ) );  ?>
                                     </strong>
                                 </td>
-                                <td><?php echo esc_html( $item_name ) . ' * ' . esc_html( $item_quantity ); ?></td>
+                                <td><?php echo esc_html( $item_name ) . ' × ' . esc_html( $item_quantity ); ?></td>
                             </tr>
                         <?php } else { ?>
                             <tr>
                                 <td>
                                     <strong>
-                                        <?php rbfw_string( 'rbfw_text_item_name', __( 'Item Name', 'booking-and-rental-manager-for-woocommerce' ) ); echo ':'; ?>
+                                        <?php rbfw_string( 'rbfw_text_item_name', __( 'Item Name', 'booking-and-rental-manager-for-woocommerce' ) );  ?>
                                     </strong>
                                 </td>
                                 <td><?php echo esc_html( $item_name ); ?></td>
@@ -138,7 +863,7 @@ function fetch_order_details_callback() {
                         <tr>
                             <td>
                                 <strong>
-                                    <?php rbfw_string( 'rbfw_text_item_type', __( 'Item Type', 'booking-and-rental-manager-for-woocommerce' ) ); echo ':'; ?>
+                                    <?php rbfw_string( 'rbfw_text_item_type', __( 'Item Type', 'booking-and-rental-manager-for-woocommerce' ) );  ?>
                                 </strong>
                             </td>
                             <td><?php echo esc_html( rbfw_get_type_label( $rent_type ) ); ?></td>
@@ -147,14 +872,14 @@ function fetch_order_details_callback() {
                             <?php if ( $pickup_point ) { ?>
                                 <tr>
                                     <td><strong><?php rbfw_string( 'rbfw_text_pickup_location', __( 'Pickup Location', 'booking-and-rental-manager-for-woocommerce' ) );
-                                            echo ':'; ?></strong></td>
+                                             ?></strong></td>
                                     <td><?php echo esc_html( $pickup_point ); ?></td>
                                 </tr>
                             <?php } ?>
                             <?php if ( $dropoff_point ) { ?>
                                 <tr>
                                     <td><strong><?php rbfw_string( 'rbfw_text_dropoff_location', __( 'Drop-off Location', 'booking-and-rental-manager-for-woocommerce' ) );
-                                            echo ':'; ?></strong></td>
+                                             ?></strong></td>
                                     <td><?php echo esc_html( $dropoff_point ); ?></td>
                                 </tr>
                             <?php } ?>
@@ -216,7 +941,7 @@ function fetch_order_details_callback() {
                             <tr>
                                 <td>
                                     <strong>
-                                        <?php rbfw_string( 'rbfw_text_room_information', __( 'Room Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                        <?php rbfw_string( 'rbfw_text_room_information', __( 'Room Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                     </strong>
                                 </td>
                                 <td>
@@ -306,7 +1031,7 @@ function fetch_order_details_callback() {
                                             ?>
                                             <tr>
                                                 <th>
-                                                    <?php echo esc_html($service_label); ?> <?php echo esc_html($refundable); ?>:
+                                                    <?php echo esc_html($service_label); ?> <?php echo esc_html($refundable); ?>
                                                 </th>
                                                 <td>
                                                     (<?php echo wp_kses($service_price_desc,rbfw_allowed_html()); ?>)  = <?php echo wp_kses(wc_price($service_price),rbfw_allowed_html()); ?>
@@ -322,24 +1047,24 @@ function fetch_order_details_callback() {
                         <tr>
                             <td>
                                 <strong>
-                                    <?php rbfw_string( 'rbfw_text_room_information', __( 'Room Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                    <?php rbfw_string( 'rbfw_text_room_information', __( 'Room Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                 </strong>
                             </td>
                             <td>
+                                <?php if ( ! empty( $rent_info ) ) { ?>
                                 <table class="wp-list-table widefat fixed striped table-view-list">
                                     <?php
-                                    if ( ! empty( $rent_info ) ) {
-                                        foreach ( $rent_info as $key => $value ) {
-                                            ?>
-                                            <tr>
-                                                <td><strong><?php echo esc_html( $key ); ?></strong></td>
-                                                <td><?php echo wp_kses( $value, rbfw_allowed_html() ); ?></td>
-                                            </tr>
-                                            <?php
-                                        }
+                                    foreach ( $rent_info as $key => $value ) {
+                                        ?>
+                                        <tr>
+                                            <td><strong><?php echo esc_html( $key ); ?></strong></td>
+                                            <td><?php echo wp_kses( $value, rbfw_allowed_html() ); ?></td>
+                                        </tr>
+                                        <?php
                                     }
                                     ?>
                                 </table>
+                                <?php } else { echo '&mdash;'; } ?>
                             </td>
                         </tr>
 
@@ -359,7 +1084,7 @@ function fetch_order_details_callback() {
                                                     ?>
                                                     <tr>
                                                         <th>
-                                                            <?php echo esc_html($value['item_name']); ?>:
+                                                            <?php echo esc_html($value['item_name']); ?>
                                                         </th>
                                                         <td>(<?php echo wp_kses(wc_price($value['item_price']),rbfw_allowed_html()); ?> x <?php echo esc_html($value['item_qty']); ?> x <?php echo esc_html($duration_qty); ?>) = <?php echo wp_kses(wc_price($value['item_price'] * $value['item_qty']),rbfw_allowed_html()); ?></td>
                                                     </tr>
@@ -374,7 +1099,7 @@ function fetch_order_details_callback() {
                         <?php } ?>
 
 
-                        <?php if ( ! empty( $rent_type == 'multiple_items' ) ) { ?>
+                        <?php if ( $rent_type === 'multiple_items' && ! empty( $rbfw_category_wise_info ) ) { ?>
                             <tr>
                                 <td>
                                     <strong>
@@ -418,11 +1143,56 @@ function fetch_order_details_callback() {
                             </tr>
                         <?php } ?>
 
+                        <?php if ( $has_service_infos ) {
+                            $sv_total_days = isset( $total_days ) ? (int) $total_days : 1;
+                            ?>
+                            <tr class="rbfw_ol_svc_tr">
+                                <td>
+                                    <strong>
+                                        <?php rbfw_string( 'rbfw_text_service_information', __( 'Service Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+                                    </strong>
+                                </td>
+                                <td>
+                                    <div class="rbfw_ol_svc">
+                                        <?php foreach ( $service_infos as $sv_cat_title => $sv_cat_services ) {
+                                            if ( empty( $sv_cat_services ) || ! is_array( $sv_cat_services ) ) {
+                                                continue; // skip categories with no selected service
+                                            }
+                                            ?>
+                                            <div class="rbfw_ol_svc_cat">
+                                                <?php if ( '' !== (string) $sv_cat_title ) { ?>
+                                                    <div class="rbfw_ol_svc_cat_title"><?php echo esc_html( $sv_cat_title ); ?></div>
+                                                <?php } ?>
+                                                <?php foreach ( $sv_cat_services as $sv_item ) {
+                                                    if ( empty( $sv_item['name'] ) ) {
+                                                        continue;
+                                                    }
+                                                    $sv_price = isset( $sv_item['price'] ) ? (float) $sv_item['price'] : 0;
+                                                    $sv_qty   = isset( $sv_item['quantity'] ) ? (int) $sv_item['quantity'] : 0;
+                                                    $sv_type  = isset( $sv_item['service_price_type'] ) ? $sv_item['service_price_type'] : '';
+                                                    if ( 'day_wise' === $sv_type ) {
+                                                        $sv_calc = wc_price( $sv_price ) . ' &times; ' . $sv_qty . ' &times; ' . $sv_total_days . ' = <strong>' . wc_price( $sv_price * $sv_qty * $sv_total_days ) . '</strong>';
+                                                    } else {
+                                                        $sv_calc = wc_price( $sv_price ) . ' &times; ' . $sv_qty . ' = <strong>' . wc_price( $sv_price * $sv_qty ) . '</strong>';
+                                                    }
+                                                    ?>
+                                                    <div class="rbfw_ol_svc_row">
+                                                        <span class="rbfw_ol_svc_name"><?php echo esc_html( $sv_item['name'] ); ?></span>
+                                                        <span class="rbfw_ol_svc_calc"><?php echo wp_kses( $sv_calc, rbfw_allowed_html() ); ?></span>
+                                                    </div>
+                                                <?php } ?>
+                                            </div>
+                                        <?php } ?>
+                                    </div>
+                                </td>
+                            </tr>
+                        <?php } ?>
+
                         <?php if ( ! empty( $rbfw_regf_info ) ) { ?>
                             <tr>
                                 <td>
                                     <strong>
-                                        <?php rbfw_string( 'rbfw_text_customer_information', __( 'Customer Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                        <?php rbfw_string( 'rbfw_text_customer_information', __( 'Customer Information', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                     </strong>
                                 </td>
                                 <td>
@@ -478,7 +1248,7 @@ function fetch_order_details_callback() {
                         <?php $total_security_deposit_amount = $total_security_deposit_amount + $security_deposit_amount;
                         if ( ! empty( $security_deposit_amount ) ) { ?>
                             <tr>
-                                <td><strong><?php echo esc_html__( 'Security Deposit', 'booking-and-rental-manager-for-woocommerce' ); ?>:</strong></td>
+                                <td><strong><?php echo esc_html__( 'Security Deposit', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></td>
                                 <td><?php echo wp_kses( wc_price( $security_deposit_amount ), rbfw_allowed_html() ); ?></td>
                             </tr>
                         <?php } ?>
@@ -489,14 +1259,14 @@ function fetch_order_details_callback() {
                     <table class="wp-list-table widefat fixed striped table-view-list rental-details-table">
                         <thead>
                         <tr>
-                            <th colspan="2"><?php rbfw_string( 'rbfw_text_rental_details', __( 'Rental Details', 'booking-and-rental-manager-for-woocommerce' ) ); ?></th>
+                            <th colspan="2"><span class="rbfw_ol_sec_ico"><?php echo rbfw_inv_icon( 'calendar' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span><?php rbfw_string( 'rbfw_text_rental_details', __( 'Rental Details', 'booking-and-rental-manager-for-woocommerce' ) ); ?></th>
                         </tr>
                         </thead>
                         <tbody>
                         <tr>
                             <td>
                                 <strong>
-                                    <?php rbfw_string( 'rbfw_text_start_date_and_time', __( 'Start Date and Time', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                    <?php rbfw_string( 'rbfw_text_start_date_and_time', __( 'Start Date and Time', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                 </strong>
                             </td>
                             <td><?php echo esc_html( $rbfw_start_datetime ); ?></td>
@@ -504,7 +1274,7 @@ function fetch_order_details_callback() {
                         <tr>
                             <td>
                                 <strong>
-                                    <?php rbfw_string( 'rbfw_text_end_date_and_time', __( 'End Date and Time', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                    <?php rbfw_string( 'rbfw_text_end_date_and_time', __( 'End Date and Time', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                 </strong>
                             </td>
                             <td><?php echo esc_html( $rbfw_end_datetime ); ?></td>
@@ -513,7 +1283,7 @@ function fetch_order_details_callback() {
                         <tr>
                             <td>
                                 <strong>
-                                    <?php rbfw_string( 'rbfw_text_duration_cost', __( 'Duration Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                    <?php rbfw_string( 'rbfw_text_duration_cost', __( 'Duration Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                 </strong>
                             </td>
                             <td><?php echo wp_kses( wc_price( $duration_cost ), rbfw_allowed_html() ); ?></td>
@@ -524,7 +1294,7 @@ function fetch_order_details_callback() {
                         <tr>
                             <td>
                                 <strong>
-                                    <?php rbfw_string( 'rbfw_text_resource_cost', __( 'Resource Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                    <?php rbfw_string( 'rbfw_text_resource_cost', __( 'Resource Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                 </strong>
                             </td>
                             <td><?php echo wp_kses( wc_price( $ticket_info['service_cost'] ), rbfw_allowed_html() ); ?></td>
@@ -535,7 +1305,7 @@ function fetch_order_details_callback() {
                             <tr>
                                 <td>
                                     <strong>
-                                        <?php rbfw_string( 'rbfw_text_resource_cost', __( 'Fee Management Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                        <?php rbfw_string( 'rbfw_text_resource_cost', __( 'Fee Management Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                     </strong>
                                 </td>
                                 <td><?php echo wp_kses( wc_price( $rbfw_management_price ), rbfw_allowed_html() ); ?></td>
@@ -551,14 +1321,14 @@ function fetch_order_details_callback() {
                 <table class="wp-list-table widefat fixed striped table-view-list">
                     <thead>
                     <tr>
-                        <th colspan="2"><?php rbfw_string( 'rbfw_text_total', __( 'Summary', 'booking-and-rental-manager-for-woocommerce' ) ); ?></th>
+                        <th colspan="2"><span class="rbfw_ol_sec_ico"><?php echo rbfw_inv_icon( 'calculator' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span><?php rbfw_string( 'rbfw_text_total', __( 'Summary', 'booking-and-rental-manager-for-woocommerce' ) ); ?></th>
                     </tr>
                     </thead>
                     <tbody>
                     <tr>
                         <td>
                             <strong>
-                                <?php rbfw_string( 'rbfw_text_summary', __( 'Subtotal', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                <?php rbfw_string( 'rbfw_text_summary', __( 'Subtotal', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                             </strong>
                         </td>
                         <td><?php echo wp_kses( wc_price( $wc_order_details->get_total() - $total_security_deposit_amount - $wc_order_details->get_total_tax() ), rbfw_allowed_html() ); ?></td>
@@ -566,7 +1336,7 @@ function fetch_order_details_callback() {
                     <?php if ( $wc_order_details->get_total_tax() ) { ?>
                         <tr>
                             <td>
-                                <strong><?php rbfw_string( 'rbfw_text_tax', __( 'Tax', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                <strong><?php rbfw_string( 'rbfw_text_tax', __( 'Tax', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                                 </strong>
                             </td>
                             <td><?php echo wp_kses( wc_price( $wc_order_details->get_total_tax() ), rbfw_allowed_html() ); ?></td>
@@ -576,7 +1346,7 @@ function fetch_order_details_callback() {
                     <?php if ( $total_security_deposit_amount ) { ?>
                         <tr>
                             <td>
-                                <strong><?php echo esc_html__( 'Security Deposit', 'booking-and-rental-manager-for-woocommerce' ); ?>:
+                                <strong><?php echo esc_html__( 'Security Deposit', 'booking-and-rental-manager-for-woocommerce' ); ?>
                                 </strong>
                             </td>
                             <td><?php echo wp_kses( wc_price( $total_security_deposit_amount ), rbfw_allowed_html() ); ?></td>
@@ -585,7 +1355,7 @@ function fetch_order_details_callback() {
                     <tr>
                         <td>
                             <strong>
-                                <?php rbfw_string( 'rbfw_text_total_cost', __( 'Total Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>:
+                                <?php rbfw_string( 'rbfw_text_total_cost', __( 'Total Cost', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                             </strong>
                         </td>
                         <td><?php echo wp_kses( wc_price( $wc_order_details->get_total() ), rbfw_allowed_html() ); ?></td>

--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -45,15 +45,10 @@
 			}
 
 			public function rbfw_admin_enqueue_scripts( $hook ) {
-				// Only load on our order list page
-				if ( $hook === 'rbfw_item_page_rbfw_order' ) {
-					wp_enqueue_style( 
-						'rbfw-order-list-modern', 
-						plugin_dir_url( __FILE__ ) . '../../assets/admin/css/rbfw-order-list-modern.css', 
-						array(), 
-						'1.0.0' 
-					);
-				}
+				// The Order List page is fully styled by the modern admin/css/rbfw_order.css
+				// (scoped under .rbfw_ol). The legacy rbfw-order-list-modern.css was retired:
+				// it wrapped the page in a centered max-width card (margin:0 auto -> side gaps)
+				// and shipped a global "*"/"body" reset that leaked into the rest of wp-admin.
 			}
 
 			public function rbfw_time_slots() {
@@ -137,265 +132,278 @@
 					wp_reset_postdata();
 				}
 				?>
-                <div class="rental-order-list-dashboard">
-                    <div class="rental-order-list-header">
-                        <h1><?php esc_html_e( 'ORDER LIST', 'booking-and-rental-manager-for-woocommerce' ); ?></h1>
-                    </div>
-                    
-                    <!-- Stats Cards -->
-                    <div class="rental-order-list-stats-grid">
-                        <div class="rental-order-list-stat-card rental-order-list-total">
-                            <div class="rental-order-list-stat-icon">📊</div>
-                            <div class="rental-order-list-stat-info">
-                                <div class="rental-order-list-stat-number"><?php echo esc_html( $total_orders ); ?></div>
-                                <div class="rental-order-list-stat-label"><?php esc_html_e( 'Total Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
-                                <div class="rental-order-list-stat-amount"><?php echo wp_kses_post( wc_price( $total_amount ) ); ?></div>
-                            </div>
-                        </div>
-                        <div class="rental-order-list-stat-card rental-order-list-cancelled">
-                            <div class="rental-order-list-stat-icon">❌</div>
-                            <div class="rental-order-list-stat-info">
-                                <div class="rental-order-list-stat-number"><?php echo esc_html( $cancelled_orders ); ?></div>
-                                <div class="rental-order-list-stat-label"><?php esc_html_e( 'Cancelled Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
-                                <div class="rental-order-list-stat-amount"><?php echo wp_kses_post( wc_price( $cancelled_amount ) ); ?></div>
-                            </div>
-                        </div>
-                        <div class="rental-order-list-stat-card rental-order-list-completed">
-                            <div class="rental-order-list-stat-icon">✅</div>
-                            <div class="rental-order-list-stat-info">
-                                <div class="rental-order-list-stat-number"><?php echo esc_html( $completed_orders ); ?></div>
-                                <div class="rental-order-list-stat-label"><?php esc_html_e( 'Completed Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
-                                <div class="rental-order-list-stat-amount"><?php echo wp_kses_post( wc_price( $completed_amount ) ); ?></div>
-                            </div>
-                        </div>
-                        <div class="rental-order-list-stat-card rental-order-list-pending">
-                            <div class="rental-order-list-stat-icon">⏳</div>
-                            <div class="rental-order-list-stat-info">
-                                <div class="rental-order-list-stat-number"><?php echo esc_html( $pending_orders ); ?></div>
-                                <div class="rental-order-list-stat-label"><?php esc_html_e( 'Pending Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
-                                <div class="rental-order-list-stat-amount"><?php echo wp_kses_post( wc_price( $pending_amount ) ); ?></div>
-                            </div>
-                        </div>
-                        <div class="rental-order-list-stat-card rental-order-list-refunded">
-                            <div class="rental-order-list-stat-icon">🔄</div>
-                            <div class="rental-order-list-stat-info">
-                                <div class="rental-order-list-stat-number"><?php echo esc_html( $refunded_orders ); ?></div>
-                                <div class="rental-order-list-stat-label"><?php esc_html_e( 'Refunded Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
-                                <div class="rental-order-list-stat-amount"><?php echo wp_kses_post( wc_price( $refunded_amount ) ); ?></div>
-                            </div>
+                <div class="rbfw_ol rental-order-list-dashboard wrap">
+                    <div class="rbfw_ol_header">
+                        <div class="rbfw_ol_title">
+                            <span class="rbfw_ol_title_icon"><?php echo rbfw_inv_icon( 'clipboard' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                            <h1><?php esc_html_e( 'Order List', 'booking-and-rental-manager-for-woocommerce' ); ?></h1>
+                            <span class="rbfw_ol_badge_count"><?php
+                                /* translators: %s: number of orders. */
+                                echo esc_html( sprintf( _n( '%s Order', '%s Orders', $total_orders, 'booking-and-rental-manager-for-woocommerce' ), number_format_i18n( $total_orders ) ) );
+                            ?></span>
                         </div>
                     </div>
-                    
-                    <div class="rental-order-list-search-container">
-                        <div class="rental-order-list-search-icon">🔍</div>
-                        <input type="text" id="search" class="rental-order-list-search-input" placeholder="<?php esc_attr_e( 'Search by order id or customer name..', 'booking-and-rental-manager-for-woocommerce' ); ?>"/>
-                    </div>
-                    
-                    <div class="rental-order-list-table-container">
-                        <table class="rental-order-list-table">
-                        <thead>
-                        <tr>
-                            <th><?php esc_html_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Billing Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Order Created Date', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Booking Start Date', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Booking End Date', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Status', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Total', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                        </tr>
-                        </thead>
-                        <tbody id="order-list">
-						<?php if ( $query->have_posts() ) : while ( $query->have_posts() ) : $query->the_post();
-							global $post;
-							$post_id             = $post->ID;
+                    <hr class="wp-header-end">
 
-							$billing_name        = get_post_meta( $post_id, 'rbfw_billing_name', true );
-							$wc_order_id       = get_post_meta( $post_id, 'rbfw_order_id', true );
-
-                            $order = wc_get_order($wc_order_id);
-                            if (!$order) {
-                                continue;
-                            }
-                            
-                            // Skip orders with trash status
-                            if ($order->get_status() === 'trash') {
-                                continue;
-                            }
-
-							$status              = $order->get_status();
-							$total_price         = $order->get_total();
-							$ticket_infos        = get_post_meta( $post_id, 'rbfw_ticket_info', true );
-							$ticket_info_array   = maybe_unserialize( $ticket_infos );
-							$rbfw_start_datetime = '';
-							$rbfw_end_datetime   = '';
-							if ( ! empty( $ticket_info_array ) && is_array( $ticket_info_array ) ) {
-								foreach ( $ticket_info_array as $ticket_info ) {
-									$rbfw_start_datetime = isset( $ticket_info['rbfw_start_datetime'] ) ? $ticket_info['rbfw_start_datetime'] : '';
-									$rbfw_end_datetime   = isset( $ticket_info['rbfw_end_datetime'] ) ? $ticket_info['rbfw_end_datetime'] : '';
-								}
-							}
-							?>
-                            <tr class="order-row">
-                                <td><?php echo esc_html( $wc_order_id ); ?></td>
-                                <td><?php echo esc_html( $billing_name ); ?></td>
-                                <td><?php echo esc_html( get_the_date( 'F j, Y' ) . ' ' . get_the_time() ); ?></td>
-                                <td><?php echo esc_html( ! empty( $rbfw_start_datetime ) ? date_i18n( 'F j, Y g:i a', strtotime( $rbfw_start_datetime ) ) : '' ); ?></td>
-                                <td><?php echo esc_html( ! empty( $rbfw_end_datetime ) ? date_i18n( 'F j, Y g:i a', strtotime( $rbfw_end_datetime ) ) : '' ); ?></td>
-                                <td><span class="rental-order-list-status-badge rental-order-list-status-<?php echo esc_attr( $status ); ?>"><?php echo esc_html( ucfirst($status) ); ?></span></td>
-                                <td><span class="rental-order-list-price"><?php echo wp_kses_post( wc_price( $total_price ) ); ?></span></td>
-								<?php if ( function_exists( 'rbfw_pro_tab_menu_list' ) ) { ?>
-                                    <td>
-                                        <div class="rental-order-list-action-buttons">
-                                            <a href="javascript:void(0);" class="rental-order-list-btn rental-order-list-btn-view rbfw_order_view_btn" data-post-id="<?php echo esc_attr( $post_id ); ?>">
-                                                👁️
-                                            </a>
-                                            <a href="<?php echo esc_url( admin_url( 'post.php?post=' . $post_id . '&action=edit' ) ); ?>" class="rental-order-list-btn rental-order-list-btn-edit">
-                                                ✏️
-                                            </a>
-                                        </div>
-                                    </td>
-								<?php
-									} else {
-								?>
-                                    <td>
-                                        <div class="rental-order-list-action-buttons">
-                                            <a href="javascript:void(0);" class="rental-order-list-btn rental-order-list-btn-view pro-overlay">
-                                                👁️
-                                            </a>
-                                            <a href="javascript:void(0);" class="rental-order-list-btn rental-order-list-btn-edit pro-overlay">
-                                                ✏️
-                                            </a>
-                                        </div>
-                                    </td>
-                                    <script>
-										document.querySelectorAll('.pro-overlay').forEach(function (button) {
-											button.replaceWith(button.cloneNode(true));
-										});
-
-										document.querySelectorAll('.pro-overlay').forEach(function (button) {
-											button.addEventListener('click', function (event) {
-												event.preventDefault(); // Prevent default link behavior
-												window.open('<?php echo esc_js( esc_url( 'https://mage-people.com/product/booking-and-rental-manager-for-woocommerce/' ) ); ?>', '_blank');
-											});
-										});
-									</script>
-									<?php
-								}
-								?>
-                            </tr>
-                            <tr id="order-details-<?php echo esc_attr( $post_id ); ?>" class="order-details" style="display: none;">
-                                <td colspan="12">
-                                    <div class="order-details-content"></div>
-                                </td>
-                            </tr>
-						<?php endwhile; else : ?>
-                            <tr>
-                                <td colspan="12"><?php esc_html_e( 'Sorry, No data found!', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
-                            </tr>
-						<?php endif;
-							wp_reset_postdata(); ?>
-                        </tbody>
-                    </table>
+                    <!-- Stat cards -->
+                    <div class="rbfw_ol_stats">
+                        <div class="rbfw_ol_stat" data-stat="total">
+                            <div class="rbfw_ol_stat_icon purple"><?php echo rbfw_inv_icon( 'file' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_ol_stat_info">
+                                <div class="rbfw_ol_stat_num"><?php echo esc_html( number_format_i18n( $total_orders ) ); ?></div>
+                                <div class="rbfw_ol_stat_lbl"><?php esc_html_e( 'Total Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_ol_stat_amt <?php echo $total_amount > 0 ? 'pos' : 'zero'; ?>"><?php echo wp_kses_post( wc_price( $total_amount ) ); ?></div>
+                            </div>
+                        </div>
+                        <div class="rbfw_ol_stat" data-stat="cancelled">
+                            <div class="rbfw_ol_stat_icon red"><?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_ol_stat_info">
+                                <div class="rbfw_ol_stat_num"><?php echo esc_html( number_format_i18n( $cancelled_orders ) ); ?></div>
+                                <div class="rbfw_ol_stat_lbl"><?php esc_html_e( 'Cancelled', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_ol_stat_amt <?php echo $cancelled_amount > 0 ? 'pos' : 'zero'; ?>"><?php echo wp_kses_post( wc_price( $cancelled_amount ) ); ?></div>
+                            </div>
+                        </div>
+                        <div class="rbfw_ol_stat" data-stat="completed">
+                            <div class="rbfw_ol_stat_icon green"><?php echo rbfw_inv_icon( 'check' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_ol_stat_info">
+                                <div class="rbfw_ol_stat_num"><?php echo esc_html( number_format_i18n( $completed_orders ) ); ?></div>
+                                <div class="rbfw_ol_stat_lbl"><?php esc_html_e( 'Completed', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_ol_stat_amt <?php echo $completed_amount > 0 ? 'pos' : 'zero'; ?>"><?php echo wp_kses_post( wc_price( $completed_amount ) ); ?></div>
+                            </div>
+                        </div>
+                        <div class="rbfw_ol_stat" data-stat="pending">
+                            <div class="rbfw_ol_stat_icon amber"><?php echo rbfw_inv_icon( 'clock' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_ol_stat_info">
+                                <div class="rbfw_ol_stat_num"><?php echo esc_html( number_format_i18n( $pending_orders ) ); ?></div>
+                                <div class="rbfw_ol_stat_lbl"><?php esc_html_e( 'Pending', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_ol_stat_amt <?php echo $pending_amount > 0 ? 'pos' : 'zero'; ?>"><?php echo wp_kses_post( wc_price( $pending_amount ) ); ?></div>
+                            </div>
+                        </div>
+                        <div class="rbfw_ol_stat" data-stat="refunded">
+                            <div class="rbfw_ol_stat_icon blue"><?php echo rbfw_inv_icon( 'refresh' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_ol_stat_info">
+                                <div class="rbfw_ol_stat_num"><?php echo esc_html( number_format_i18n( $refunded_orders ) ); ?></div>
+                                <div class="rbfw_ol_stat_lbl"><?php esc_html_e( 'Refunded', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_ol_stat_amt <?php echo $refunded_amount > 0 ? 'pos' : 'zero'; ?>"><?php echo wp_kses_post( wc_price( $refunded_amount ) ); ?></div>
+                            </div>
+                        </div>
                     </div>
-                    
-                    <div id="loader" style="display: none;">
-                        <div class="loader"></div> <!-- Loader element -->
+
+                    <!-- Filter bar -->
+                    <div class="rbfw_ol_filterbar">
+                        <div class="rbfw_ol_filter_field rbfw_ol_fb_by">
+                            <span class="rbfw_ol_filter_ico"><?php echo rbfw_inv_icon( 'filter' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                            <select id="rbfw_ol_fb_field" class="rbfw_ol_filter_select" aria-label="<?php esc_attr_e( 'Filter by field', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                <option value="name"><?php esc_html_e( 'Name', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                <option value="order"><?php esc_html_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                <option value="phone"><?php esc_html_e( 'Phone', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                <option value="email"><?php esc_html_e( 'Email', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                <option value="item"><?php esc_html_e( 'Item', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                            </select>
+                        </div>
+                        <div class="rbfw_ol_search" id="rbfw_ol_fb_textwrap">
+                            <?php echo rbfw_inv_icon( 'search' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                            <input type="text" id="search" class="rbfw_ol_search_input" placeholder="<?php esc_attr_e( 'Search by name...', 'booking-and-rental-manager-for-woocommerce' ); ?>"/>
+                        </div>
+                        <div class="rbfw_ol_filter_field rbfw_ol_fb_item_wrap" id="rbfw_ol_fb_itemwrap" style="display:none;">
+                            <span class="rbfw_ol_filter_ico"><?php echo rbfw_inv_icon( 'box' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                            <select id="rbfw_ol_fb_item" class="rbfw_ol_filter_select" aria-label="<?php esc_attr_e( 'Filter by item', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                <option value=""><?php esc_html_e( 'All Items', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                <?php
+                                $rbfw_filter_items = get_posts( array( 'post_type' => 'rbfw_item', 'numberposts' => -1, 'orderby' => 'title', 'order' => 'ASC', 'post_status' => 'publish' ) );
+                                foreach ( $rbfw_filter_items as $rbfw_filter_item ) : ?>
+                                    <option value="<?php echo esc_attr( $rbfw_filter_item->ID ); ?>"><?php echo esc_html( get_the_title( $rbfw_filter_item->ID ) ); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="rbfw_ol_filter_field">
+                            <span class="rbfw_ol_filter_ico"><?php echo rbfw_inv_icon( 'filter' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                            <select id="rbfw_ol_filter_status" class="rbfw_ol_filter_select" aria-label="<?php esc_attr_e( 'Filter by status', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                <option value=""><?php esc_html_e( 'All Statuses', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                <?php if ( function_exists( 'wc_get_order_statuses' ) ) :
+                                    foreach ( wc_get_order_statuses() as $rbfw_fs_key => $rbfw_fs_label ) : ?>
+                                        <option value="<?php echo esc_attr( str_replace( 'wc-', '', $rbfw_fs_key ) ); ?>"><?php echo esc_html( $rbfw_fs_label ); ?></option>
+                                    <?php endforeach;
+                                endif; ?>
+                            </select>
+                        </div>
+                        <div class="rbfw_ol_filter_field rbfw_ol_filter_dates">
+                            <span class="rbfw_ol_filter_ico"><?php echo rbfw_inv_icon( 'calendar' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                            <input type="text" id="rbfw_ol_filter_from" class="rbfw_ol_filter_date" placeholder="<?php esc_attr_e( 'From', 'booking-and-rental-manager-for-woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Booking start from', 'booking-and-rental-manager-for-woocommerce' ); ?>" readonly>
+                            <span class="rbfw_ol_filter_sep">&ndash;</span>
+                            <input type="text" id="rbfw_ol_filter_to" class="rbfw_ol_filter_date" placeholder="<?php esc_attr_e( 'To', 'booking-and-rental-manager-for-woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Booking start to', 'booking-and-rental-manager-for-woocommerce' ); ?>" readonly>
+                        </div>
+                        <button type="button" id="rbfw_ol_filter_reset" class="rbfw_ol_filter_reset">
+                            <?php echo rbfw_inv_icon( 'refresh' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                            <span><?php esc_html_e( 'Reset', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                        </button>
                     </div>
-                    
-                    <div class="rental-order-list-load-more-container">
-                        <button id="load-more-btn" class="rental-order-list-load-more-btn" style="display: <?php echo ($total_orders > 10) ? 'block' : 'none'; ?>;"><?php esc_html_e( 'Load More Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+
+                    <!-- Table -->
+                    <div class="rbfw_ol_card">
+                        <div class="rbfw_ol_table_scroll">
+                            <table class="rbfw_ol_table">
+                                <thead>
+                                <tr>
+                                    <th><?php esc_html_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                    <th><?php esc_html_e( 'Billing Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                    <th><?php esc_html_e( 'Order Created', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                    <th><?php esc_html_e( 'Booking Start', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                    <th><?php esc_html_e( 'Booking End', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                    <th><?php esc_html_e( 'Status', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                    <th><?php esc_html_e( 'Total', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                    <th class="rbfw_ol_th_action"><?php esc_html_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                </tr>
+                                </thead>
+                                <tbody id="order-list">
+                                <?php if ( $query->have_posts() ) : while ( $query->have_posts() ) : $query->the_post();
+                                    global $post;
+                                    $post_id      = $post->ID;
+                                    $billing_name = get_post_meta( $post_id, 'rbfw_billing_name', true );
+                                    $wc_order_id  = get_post_meta( $post_id, 'rbfw_order_id', true );
+                                    $order        = wc_get_order( $wc_order_id );
+                                    if ( ! $order ) { continue; }
+                                    if ( $order->get_status() === 'trash' ) { continue; }
+                                    $status      = $order->get_status();
+                                    $total_price = $order->get_total();
+                                    $billing_phone = $order->get_billing_phone();
+                                    $billing_email = $order->get_billing_email();
+                                    $ticket_infos      = get_post_meta( $post_id, 'rbfw_ticket_info', true );
+                                    $ticket_info_array = maybe_unserialize( $ticket_infos );
+                                    $rbfw_start_datetime = '';
+                                    $rbfw_end_datetime   = '';
+                                    $rbfw_row_item_ids   = array();
+                                    if ( ! empty( $ticket_info_array ) && is_array( $ticket_info_array ) ) {
+                                        foreach ( $ticket_info_array as $ticket_info ) {
+                                            $rbfw_start_datetime = isset( $ticket_info['rbfw_start_datetime'] ) ? $ticket_info['rbfw_start_datetime'] : '';
+                                            $rbfw_end_datetime   = isset( $ticket_info['rbfw_end_datetime'] ) ? $ticket_info['rbfw_end_datetime'] : '';
+                                            if ( ! empty( $ticket_info['rbfw_id'] ) ) {
+                                                $rbfw_row_item_ids[] = (string) $ticket_info['rbfw_id'];
+                                            }
+                                        }
+                                    }
+                                    $rbfw_is_pro = function_exists( 'rbfw_pro_tab_menu_list' );
+                                    ?>
+                                    <tr class="order-row rbfw_ol_row" data-order="<?php echo esc_attr( strtolower( (string) $wc_order_id ) ); ?>" data-name="<?php echo esc_attr( strtolower( (string) $billing_name ) ); ?>" data-phone="<?php echo esc_attr( strtolower( (string) $billing_phone ) ); ?>" data-email="<?php echo esc_attr( strtolower( (string) $billing_email ) ); ?>" data-item="<?php echo esc_attr( implode( ' ', array_unique( $rbfw_row_item_ids ) ) ); ?>" data-status="<?php echo esc_attr( $status ); ?>" data-start="<?php echo esc_attr( ! empty( $rbfw_start_datetime ) ? gmdate( 'Y-m-d', strtotime( $rbfw_start_datetime ) ) : '' ); ?>">
+                                        <td class="rbfw_ol_td_order" data-th="<?php esc_attr_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?>">#<?php echo esc_html( $wc_order_id ); ?></td>
+                                        <td class="rbfw_ol_td_name" data-th="<?php esc_attr_e( 'Billing Name', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( $billing_name ); ?></td>
+                                        <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Order Created', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( get_the_date( 'F j, Y' ) . ' ' . get_the_time() ); ?></td>
+                                        <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Booking Start', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( ! empty( $rbfw_start_datetime ) ? date_i18n( 'F j, Y g:i a', strtotime( $rbfw_start_datetime ) ) : '—' ); ?></td>
+                                        <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Booking End', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( ! empty( $rbfw_end_datetime ) ? date_i18n( 'F j, Y g:i a', strtotime( $rbfw_end_datetime ) ) : '—' ); ?></td>
+                                        <td data-th="<?php esc_attr_e( 'Status', 'booking-and-rental-manager-for-woocommerce' ); ?>"><span class="rbfw_ol_badge rbfw_ol_badge_<?php echo esc_attr( $status ); ?>"><?php echo esc_html( ucfirst( $status ) ); ?></span></td>
+                                        <td class="rbfw_ol_td_total" data-th="<?php esc_attr_e( 'Total', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo wp_kses_post( wc_price( $total_price ) ); ?></td>
+                                        <td class="rbfw_ol_td_action" data-th="<?php esc_attr_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                            <div class="rbfw_ol_actions">
+                                                <?php if ( $rbfw_is_pro ) { ?>
+                                                    <a href="javascript:void(0);" class="rbfw_ol_act rbfw_ol_act_view rbfw_order_view_btn" data-post-id="<?php echo esc_attr( $post_id ); ?>" title="<?php esc_attr_e( 'View Details', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'eye' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                                                    <a href="javascript:void(0);" class="rbfw_ol_act rbfw_ol_act_edit rbfw_order_status_edit_btn" data-post-id="<?php echo esc_attr( $post_id ); ?>" data-order-no="<?php echo esc_attr( $wc_order_id ); ?>" data-status="<?php echo esc_attr( $status ); ?>" title="<?php esc_attr_e( 'Edit Status', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'pencil' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                                                    <a href="javascript:void(0);" class="rbfw_ol_act rbfw_ol_act_delete rbfw_order_delete_btn" data-post-id="<?php echo esc_attr( $post_id ); ?>" data-order-no="<?php echo esc_attr( $wc_order_id ); ?>" title="<?php esc_attr_e( 'Delete', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'trash' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                                                <?php } else { ?>
+                                                    <a href="javascript:void(0);" class="rbfw_ol_act rbfw_ol_act_view pro-overlay" title="<?php esc_attr_e( 'View Details', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'eye' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                                                    <a href="javascript:void(0);" class="rbfw_ol_act rbfw_ol_act_edit pro-overlay" title="<?php esc_attr_e( 'Edit', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'pencil' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                                                <?php } ?>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr id="order-details-<?php echo esc_attr( $post_id ); ?>" class="order-details rbfw_ol_detail_row" style="display: none;">
+                                        <td colspan="8"><div class="rbfw_ol_detail_anim"><div class="order-details-content"></div></div></td>
+                                    </tr>
+                                <?php endwhile; else : ?>
+                                    <tr class="rbfw_ol_empty_tr">
+                                        <td colspan="8" class="rbfw_ol_empty"><?php esc_html_e( 'No orders found.', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
+                                    </tr>
+                                <?php endif;
+                                    wp_reset_postdata(); ?>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="rbfw_ol_footer">
+                            <span class="rbfw_ol_rowinfo" id="row-info"></span>
+                            <div class="rbfw_ol_pager" id="rbfw_ol_pager"></div>
+                        </div>
                     </div>
+
+                    <div id="loader" class="rbfw_ol_loader" style="display: none;"><span class="rbfw_ol_spinner"></span></div>
+
+                    <?php if ( function_exists( 'rbfw_pro_tab_menu_list' ) ) {
+                        $rbfw_wc_statuses = function_exists( 'wc_get_order_statuses' ) ? wc_get_order_statuses() : array();
+                        ?>
+                        <div id="rbfw_ol_status_modal" class="rbfw_ol_status_modal" style="display:none;" aria-hidden="true">
+                            <div class="rbfw_ol_status_modal_overlay"></div>
+                            <div class="rbfw_ol_status_modal_box" role="dialog" aria-modal="true" aria-labelledby="rbfw_ol_status_modal_title">
+                                <div class="rbfw_ol_status_modal_head">
+                                    <span class="rbfw_ol_status_modal_ic"><?php echo rbfw_inv_icon( 'pencil' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                                    <h2 id="rbfw_ol_status_modal_title"><?php esc_html_e( 'Update Order Status', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+                                    <button type="button" class="rbfw_ol_status_modal_close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></button>
+                                </div>
+                                <div class="rbfw_ol_status_modal_body">
+                                    <p class="rbfw_ol_status_modal_order"><?php esc_html_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?> <strong>#<span id="rbfw_ol_status_order_no"></span></strong></p>
+                                    <label class="rbfw_ol_status_label" for="rbfw_ol_status_select"><?php esc_html_e( 'Order Status', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                                    <select id="rbfw_ol_status_select" class="rbfw_ol_status_select">
+                                        <?php foreach ( $rbfw_wc_statuses as $rbfw_st_key => $rbfw_st_label ) : ?>
+                                            <option value="<?php echo esc_attr( str_replace( 'wc-', '', $rbfw_st_key ) ); ?>"><?php echo esc_html( $rbfw_st_label ); ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <p class="rbfw_ol_status_msg" id="rbfw_ol_status_msg" style="display:none;"></p>
+                                </div>
+                                <div class="rbfw_ol_status_modal_foot">
+                                    <button type="button" class="rbfw_ol_status_cancel"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                    <button type="button" class="rbfw_ol_status_save"><?php esc_html_e( 'Save Changes', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div id="rbfw_ol_delete_modal" class="rbfw_ol_status_modal rbfw_ol_delete_modal" style="display:none;" aria-hidden="true">
+                            <div class="rbfw_ol_status_modal_overlay"></div>
+                            <div class="rbfw_ol_status_modal_box" role="dialog" aria-modal="true" aria-labelledby="rbfw_ol_delete_modal_title">
+                                <div class="rbfw_ol_status_modal_head rbfw_ol_delete_head">
+                                    <span class="rbfw_ol_status_modal_ic"><?php echo rbfw_inv_icon( 'trash' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                                    <h2 id="rbfw_ol_delete_modal_title"><?php esc_html_e( 'Delete Order', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+                                    <button type="button" class="rbfw_ol_status_modal_close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></button>
+                                </div>
+                                <div class="rbfw_ol_status_modal_body">
+                                    <p class="rbfw_ol_delete_text"><?php esc_html_e( 'This will move the booking and its linked WooCommerce order to Trash. You can restore them later from the Trash.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+                                    <p class="rbfw_ol_status_modal_order"><?php esc_html_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?> <strong>#<span id="rbfw_ol_delete_order_no"></span></strong></p>
+                                    <p class="rbfw_ol_status_msg" id="rbfw_ol_delete_msg" style="display:none;"></p>
+                                </div>
+                                <div class="rbfw_ol_status_modal_foot">
+                                    <button type="button" class="rbfw_ol_status_cancel rbfw_ol_delete_cancel"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                    <button type="button" class="rbfw_ol_delete_confirm"><?php esc_html_e( 'Move to Trash', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div id="rbfw_ol_edit_modal" class="rbfw_ol_status_modal rbfw_ol_edit_modal" style="display:none;" aria-hidden="true">
+                            <div class="rbfw_ol_status_modal_overlay"></div>
+                            <div class="rbfw_ol_status_modal_box rbfw_ol_edit_box" role="dialog" aria-modal="true" aria-labelledby="rbfw_ol_edit_modal_title">
+                                <div class="rbfw_ol_status_modal_head">
+                                    <span class="rbfw_ol_status_modal_ic"><?php echo rbfw_inv_icon( 'pencil' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                                    <h2 id="rbfw_ol_edit_modal_title"><?php esc_html_e( 'Edit Order', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+                                    <button type="button" class="rbfw_ol_status_modal_close rbfw_ol_edit_close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></button>
+                                </div>
+                                <div class="rbfw_ol_status_modal_body rbfw_ol_edit_body" id="rbfw_ol_edit_body">
+                                    <div class="rbfw_ol_edit_loading"><span class="rbfw_ol_spinner"></span></div>
+                                </div>
+                                <p class="rbfw_ol_status_msg rbfw_ol_edit_msg" id="rbfw_ol_edit_msg" style="display:none;"></p>
+                                <div class="rbfw_ol_status_modal_foot">
+                                    <button type="button" class="rbfw_ol_status_cancel rbfw_ol_edit_cancel"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                    <button type="button" class="rbfw_ol_edit_save"><?php esc_html_e( 'Save Changes', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                </div>
+                            </div>
+                        </div>
+                    <?php } ?>
+
+                    <?php if ( ! function_exists( 'rbfw_pro_tab_menu_list' ) ) { ?>
+                    <script>
+                        document.querySelectorAll('.pro-overlay').forEach(function (button) {
+                            button.addEventListener('click', function (event) {
+                                event.preventDefault();
+                                window.open('<?php echo esc_js( esc_url( 'https://mage-people.com/product/booking-and-rental-manager-for-woocommerce/' ) ); ?>', '_blank');
+                            });
+                        });
+                    </script>
+                    <?php } ?>
                 </div>
-                <script>
-                    document.addEventListener('DOMContentLoaded', function () {
-                        const rows = document.querySelectorAll('.order-row');
-                        let rowsPerPage = 10;
-                        let currentlyShown = rowsPerPage;
-                        let filteredRows = Array.from(rows);
-                        
-                        function displayRows(rowsToShow = filteredRows) {
-                            // Hide all rows first
-                            rows.forEach(row => row.style.display = 'none');
-                            
-                            // Show only the rows we want to display
-                            rowsToShow.slice(0, currentlyShown).forEach(row => {
-                                row.style.display = '';
-                            });
-                            
-                            // Update load more button
-                            const loadMoreBtn = document.getElementById('load-more-btn');
-                            if (currentlyShown >= rowsToShow.length) {
-                                loadMoreBtn.style.display = 'none';
-                            } else {
-                                loadMoreBtn.style.display = 'block';
-                            }
-                        }
-                        
-                        // Load more functionality
-                        document.getElementById('load-more-btn').addEventListener('click', function() {
-                            currentlyShown += rowsPerPage;
-                            displayRows(filteredRows);
-                        });
-                        
-                        // Search functionality
-                        document.getElementById('search').addEventListener('keyup', function () {
-                            const filter = this.value.toLowerCase();
-                            filteredRows = Array.from(rows).filter(row => {
-                                const orderId = row.cells[0].textContent.toLowerCase();
-                                const billingName = row.cells[1].textContent.toLowerCase();
-                                return orderId.includes(filter) || billingName.includes(filter);
-                            });
-                            currentlyShown = rowsPerPage; // Reset to initial load
-                            displayRows(filteredRows);
-                        });
-                        
-                        // Initial setup
-                        displayRows(filteredRows);
-                    });
-                </script>
-                <script>
-					document.addEventListener('DOMContentLoaded', function () {
-						document.querySelectorAll('.rbfw_order_view_btn').forEach(function (button) {
-							button.addEventListener('click', function () {
-								const postId = this.getAttribute('data-post-id'); // Ensure post_id is sanitized on the server side
-								const orderDetailsRow = document.getElementById(`order-details-${postId}`);
-								const loader = document.getElementById('loader');
-								
-								if (orderDetailsRow.style.display === 'none') {
-									// Show the loader
-									loader.style.display = 'flex';
-									// Make an AJAX request to fetch the order details
-									fetch('<?php echo esc_url( admin_url('admin-ajax.php') ); ?>', {
-										method: 'POST',
-										headers: {
-											'Content-Type': 'application/x-www-form-urlencoded',
-										},
-										body: new URLSearchParams({
-											action: 'fetch_order_details',
-											post_id: postId,
-                                            'nonce': rbfw_ajax_admin.nonce_fetch_order_details
-										})
-									})
-										.then(response => response.text())
-										.then(data => {
-											orderDetailsRow.querySelector('.order-details-content').innerHTML = data;
-											orderDetailsRow.style.display = 'table-row';
-											// Hide the loader
-											loader.style.display = 'none';
-										})
-										.catch(error => {
-											console.error('Error:', error);
-											// Hide the loader in case of an error
-											loader.style.display = 'none';
-										});
-								} else {
-									orderDetailsRow.style.display = 'none';
-								}
-							});
-						});
-					});
-				</script>
 				<?php
 			}
 

--- a/lib/classes/class-time-slots-page.php
+++ b/lib/classes/class-time-slots-page.php
@@ -18,12 +18,24 @@
 			}
 
 			public function rbfw_time_slots_page() {
+				$rbfw_time_slots = ! empty( get_option( 'rbfw_time_slots' ) ) ? get_option( 'rbfw_time_slots' ) : [];
+				$total_slots     = is_array( $rbfw_time_slots ) ? count( $rbfw_time_slots ) : 0;
 				?>
-                <div class="rbfw_time_slots_page_wrap wrap">
-                    <h1><?php esc_html_e( 'Time Slots', 'booking-and-rental-manager-for-woocommerce' ); ?></h1>
+                <div class="rbfw_ts rbfw_time_slots_page_wrap wrap">
+                    <div class="rbfw_ts_header">
+                        <div class="rbfw_ts_title">
+                            <span class="rbfw_ts_title_icon"><?php echo rbfw_inv_icon( 'clock' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                            <h1><?php esc_html_e( 'Time Slots', 'booking-and-rental-manager-for-woocommerce' ); ?></h1>
+                            <span class="rbfw_ts_badge"><?php
+                                /* translators: %s: number of time slots. */
+                                echo esc_html( sprintf( _n( '%s Slot', '%s Slots', $total_slots, 'booking-and-rental-manager-for-woocommerce' ), number_format_i18n( $total_slots ) ) );
+                            ?></span>
+                        </div>
+                    </div>
+                    <hr class="wp-header-end">
 					<?php
 						$this->rbfw_time_slots_form();
-						$this->rbfw_time_slots_table();
+						$this->rbfw_time_slots_table( $rbfw_time_slots );
 					?>
                 </div>
 				<?php
@@ -31,26 +43,22 @@
 
 			public function rbfw_time_slots_form() {
 				?>
-                <div class="rbfw_time_slot_page_form">
-                    <div class="rbfw_time_slot_form_input_group">
-                        <label><?php esc_html_e( 'Slot Label', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
-                        <input type="text" class="rbfw_time_slot_label" placeholder="Enter slot label here"/>
-                    </div>
-                    <div class="rbfw_time_slot_form_input_group">
-                        <label><?php esc_html_e( 'Slot Time', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
-                        <input type="time" class="rbfw_time_slot_time" placeholder="10:00 AM"/>
-                    </div>
-                    <div class="rbfw_time_slot_form_input_group">
-                        <label></label>
-                        <button class="rbfw_time_slot_add_btn"><?php esc_html_e( 'Add Time Slot', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
-                    </div>
-                    <div class="rbfw_time_slot_form_input_group">
-                        <label></label>
-                        <button class="rbfw_time_slot_reset_btn"><?php esc_html_e( 'Reset Form', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
-                    </div>
-                    <div class="rbfw_time_slot_form_input_group">
-                        <label></label>
-                        <button class="rbfw_time_slot_refresh_btn"><?php esc_html_e( 'Refresh Page', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                <div class="rbfw_ts_card rbfw_ts_form_card">
+                    <div class="rbfw_ts_card_label"><?php echo rbfw_inv_icon( 'plus' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Add New Time Slot', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                    <div class="rbfw_ts_form rbfw_time_slot_page_form">
+                        <div class="rbfw_ts_field rbfw_time_slot_form_input_group">
+                            <label><?php esc_html_e( 'Slot Label', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                            <input type="text" class="rbfw_time_slot_label" placeholder="<?php esc_attr_e( 'e.g. Morning', 'booking-and-rental-manager-for-woocommerce' ); ?>"/>
+                        </div>
+                        <div class="rbfw_ts_field rbfw_time_slot_form_input_group">
+                            <label><?php esc_html_e( 'Slot Time', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                            <input type="time" class="rbfw_time_slot_time"/>
+                        </div>
+                        <div class="rbfw_ts_form_actions">
+                            <button type="button" class="rbfw_ts_btn rbfw_ts_btn_primary rbfw_time_slot_add_btn"><?php echo rbfw_inv_icon( 'plus' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Add Time Slot', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                            <button type="button" class="rbfw_ts_btn rbfw_ts_btn_ghost rbfw_time_slot_reset_btn"><?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Reset', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                            <button type="button" class="rbfw_ts_btn rbfw_ts_btn_refresh rbfw_time_slot_refresh_btn"><?php echo rbfw_inv_icon( 'refresh' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Refresh', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                        </div>
                     </div>
                 </div>
 				<?php
@@ -68,56 +76,69 @@
 				return $arr;
 			}
 
-			public function rbfw_time_slots_table() {
-				$rbfw_time_slots = ! empty( get_option( 'rbfw_time_slots' ) ) ? get_option( 'rbfw_time_slots' ) : [];
-				//$rbfw_time_slots = usort($rbfw_time_slots);
-				//echo '<pre>';print_r($rbfw_time_slots);echo '<pre>';exit;
+			public function rbfw_time_slots_table( $rbfw_time_slots = null ) {
+				if ( null === $rbfw_time_slots ) {
+					$rbfw_time_slots = ! empty( get_option( 'rbfw_time_slots' ) ) ? get_option( 'rbfw_time_slots' ) : [];
+				}
 				?>
-                <table class="rbfw_time_slots_page_table">
-                    <thead>
-                    <tr>
-                        <th><?php esc_html_e( 'Slot Label', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                        <th><?php esc_html_e( 'Slot Time', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                        <th style="text-align:right"><?php esc_html_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                    </tr>
-                    </thead>
-                    <tbody>
-					<?php
-						if ( ! empty( $rbfw_time_slots ) ) {
-							$rbfw_time_slots = $this->rbfw_format_time_slot( $rbfw_time_slots );
-							asort( $rbfw_time_slots );
-							foreach ( $rbfw_time_slots as $key => $value ) {
-								?>
-                                <tr>
-                                    <td><?php echo esc_html( $key ); ?></td>
-                                    <td><?php echo esc_html( wp_strip_all_tags( $value ) ); ?></td>
-                                    <td style="text-align:right">
-                                        <a href="#" class="rbfw_time_slot_edit_btn" data-label="<?php echo esc_attr( $key ); ?>"><i class="fas fa-pen-to-square"></i> <?php esc_html_e( 'Edit', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
-                                        <a href="#" class="rbfw_time_slot_remove_btn" data-time="<?php echo esc_attr( $value ); ?>" data-label="<?php echo esc_attr( $key ); ?>"><i class="fas fa-trash-can"></i></a>
-                                    </td>
-                                </tr>
-								<?php
-							}
-						} else {
-							?>
+                <div class="rbfw_ts_card">
+                    <div class="rbfw_ts_table_scroll">
+                        <table class="rbfw_ts_table">
+                            <thead>
                             <tr>
-                                <td colspan="3"><?php esc_html_e( 'Sorry, no data found!', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
+                                <th><?php esc_html_e( 'Slot Label', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                <th><?php esc_html_e( 'Slot Time', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                <th class="rbfw_ts_th_right"><?php esc_html_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
                             </tr>
+                            </thead>
+                            <tbody>
 							<?php
-						}
-					?>
-                    </tbody>
-                </table>
-                <div class="rbfw_time_slot_edit_form">
-                    <h3><?php esc_html_e( 'Edit Time Slot', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
-                    <hr>
-                    <div class="rbfw_time_slot_edit_form_group first_child">
-                        <label><?php esc_html_e( 'Slot Label', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
-                        <input type="text" class="rbfw_time_slot_edit_slot_label"/>
+								if ( ! empty( $rbfw_time_slots ) ) {
+									$rbfw_time_slots = $this->rbfw_format_time_slot( $rbfw_time_slots );
+									asort( $rbfw_time_slots );
+									foreach ( $rbfw_time_slots as $key => $value ) {
+										?>
+                                        <tr class="rbfw_ts_row">
+                                            <td class="rbfw_ts_td_label" data-th="<?php esc_attr_e( 'Slot Label', 'booking-and-rental-manager-for-woocommerce' ); ?>"><span class="rbfw_ts_slot_name"><?php echo esc_html( $key ); ?></span></td>
+                                            <td data-th="<?php esc_attr_e( 'Slot Time', 'booking-and-rental-manager-for-woocommerce' ); ?>"><span class="rbfw_ts_time_pill"><?php echo rbfw_inv_icon( 'clock' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php echo esc_html( wp_strip_all_tags( $value ) ); ?></span></td>
+                                            <td class="rbfw_ts_td_action" data-th="<?php esc_attr_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                                <a href="#" class="rbfw_ts_action rbfw_ts_action_edit rbfw_time_slot_edit_btn" data-label="<?php echo esc_attr( $key ); ?>"><?php echo rbfw_inv_icon( 'pencil' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <span><?php esc_html_e( 'Edit', 'booking-and-rental-manager-for-woocommerce' ); ?></span></a>
+                                                <a href="#" class="rbfw_ts_action rbfw_ts_action_del rbfw_time_slot_remove_btn" data-time="<?php echo esc_attr( $value ); ?>" data-label="<?php echo esc_attr( $key ); ?>" aria-label="<?php esc_attr_e( 'Delete', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'trash' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                                            </td>
+                                        </tr>
+										<?php
+									}
+								} else {
+									?>
+                                    <tr class="rbfw_ts_empty_tr">
+                                        <td colspan="3" class="rbfw_ts_empty"><?php esc_html_e( 'No time slots yet — add your first one above.', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
+                                    </tr>
+									<?php
+								}
+							?>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="rbfw_time_slot_edit_form_group">
-                        <button class="rbfw_time_slot_edit_form_save"><?php esc_html_e( 'Save', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
-                        <input type="hidden" class="rbfw_time_slot_edit_slot_label_current_value"/>
+                </div>
+
+                <div class="rbfw_time_slot_edit_form">
+                    <div class="rbfw_ts_modal_head">
+                        <div class="rbfw_ts_modal_icon"><?php echo rbfw_inv_icon( 'pencil' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                        <div class="rbfw_ts_modal_title_wrap">
+                            <div class="rbfw_ts_modal_title"><?php esc_html_e( 'Edit Time Slot', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                            <div class="rbfw_ts_modal_sub"><?php esc_html_e( 'Rename this slot label', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                        </div>
+                        <a href="#" class="rbfw_ts_modal_close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+                    </div>
+                    <div class="rbfw_ts_modal_body">
+                        <div class="rbfw_ts_field">
+                            <label><?php esc_html_e( 'Slot Label', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                            <input type="text" class="rbfw_time_slot_edit_slot_label"/>
+                        </div>
+                        <div class="rbfw_ts_modal_footer">
+                            <button type="button" class="rbfw_ts_btn rbfw_ts_btn_primary rbfw_time_slot_edit_form_save"><?php echo rbfw_inv_icon( 'check' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Save Changes', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                            <input type="hidden" class="rbfw_time_slot_edit_slot_label_current_value"/>
+                        </div>
                     </div>
                 </div>
 				<?php
@@ -299,10 +320,22 @@
                             jQuery('.rbfw_time_slot_edit_slot_label').val(ts_label);
                             jQuery('.rbfw_time_slot_edit_slot_label_current_value').val(ts_label);
                             jQuery(".rbfw_time_slot_edit_form").mage_modal({
-                                escapeClose: false,
-                                clickClose: false,
-                                showClose: true
+                                escapeClose: true,
+                                clickClose: true,
+                                showClose: false
                             });
+                        });
+                        function rbfwTsCloseModal() {
+                            if (jQuery.mage_modal && typeof jQuery.mage_modal.isActive === 'function' && jQuery.mage_modal.isActive()) {
+                                jQuery.mage_modal.close();
+                            }
+                        }
+                        jQuery(document).on('click', '.rbfw_ts_modal_close', function (e) {
+                            e.preventDefault();
+                            rbfwTsCloseModal();
+                        });
+                        jQuery(document).on('click', '.mage_blocker', function (e) {
+                            if (e.target === this) { rbfwTsCloseModal(); }
                         });
                         jQuery('.rbfw_time_slot_edit_form_save').click(function (e) {
                             e.preventDefault();

--- a/templates/forms/multi-day-registration.php
+++ b/templates/forms/multi-day-registration.php
@@ -646,6 +646,7 @@ $rbfw_buffer_time = get_post_meta( $rbfw_id, 'rbfw_buffer_time', true ) ? maybe_
                                                             </div>
                                                             <div class="title"><?php echo wp_kses(wc_price($service['price']),rbfw_allowed_html()); ?></div>
                                                             <span class="day-time-wise"><?php echo (isset($service['service_price_type']) && $service['service_price_type'] === 'day_wise') ? esc_html__('Day Wise', 'booking-and-rental-manager-for-woocommerce') : esc_html__('One Time', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+                                                            <span class="rbfw_service_day_calc" style="display:none;"></span>
                                                         </td>
                                                         <td class="rbfw_service_quantity item_<?php echo esc_attr($cat . $serkey); ?>">
                                                             <div class="rbfw_qty_input">


### PR DESCRIPTION
…nagement & day-wise fixes

ORDER LIST PAGE (edit.php?post_type=rbfw_item&page=rbfw_order)
- Full modern redesign scoped under .rbfw_ol (admin/css/rbfw_order.css, admin/js/rbfw_order.js): header + order-count badge, 5 status stat cards (Total/Cancelled/Completed/Pending/Refunded with amounts), client-side search + pagination, animated inline order-detail panel.
- Dependency-free inline-SVG icon system via rbfw_inv_icon() (the bundled Font Awesome referenced ../webfonts which do not ship, so no icon font rendered). Full glyph set added in inc/rbfw_inventory_functions.php.
- Retired the legacy admin/css/rbfw-order-list-modern.css (it centered the page in a max-width card -> left/right gaps, and shipped a global */body reset that leaked into the rest of wp-admin). The list is now full width.

ORDER MANAGEMENT (Order List actions)
- Status edit popup: change a WooCommerce order status via AJAX with a live badge update (rbfw_update_order_status).
- Delete popup (Move to Trash): trashes the booking (rbfw_order) and its linked WooCommerce order together (HPOS-safe via the WC API) and live- recalculates the stat cards (rbfw_delete_order, rbfw_calculate_order_list_stats).
- Full "Edit Order" modal (rbfw_get_order_edit_form / rbfw_save_order_edit):
    * Booking dates + times, service add-on quantities (catalog-driven; add or remove), Duration / Fee / Discount / Security Deposit, full WooCommerce billing details, and Pro attendee/registration (rbfw_regf_info) values.
    * Prices recomputed server-side from the item catalog (tamper-proof) with live in-modal totals; syncs the WooCommerce order total + billing and adds an order note.
    * Closes only via the x / Cancel buttons (no accidental outside-click/Esc close that would lose edits).
- Edit propagation / data consistency: an order edit now updates ALL THREE copies of the booking so the detail panel, the Reports dashboard and the PDF all reflect the change -- the rbfw_order CPT ticket meta, the WC line-item _rbfw_ticket_info (panel + PDF), and the rbfw_order_meta attendee posts (Reports) via rbfw_sync_attendee_meta_from_edit().

FILTERS (Order List)
- Modern filter bar: "Filter by" Item / Name / Order / Phone / Email + Status
  + booking-date range + Reset, applied live on the in-page rows (data-name/order/phone/email/item/status/start attributes).
- Custom themed dropdowns for the selects (native option lists cannot be styled) and flatpickr calendars for the From/To range.

DATE / TIME PICKERS
- flatpickr enqueued on the order page; modern accent-themed calendar.
- Edit Order modal uses flatpickr date pickers + time pickers with static positioning (the default body-append mispositions inside the position:fixed modal on a scrolled page).

ORDER DETAIL PANEL
- Render category-wise "Service Information" for multi-day/dress orders, grouped into modern cards and hidden entirely when empty; the multi_items "Optional Add-ons" block is hidden when empty too.
- Fixed "Room Information" rendering an empty value (now shows an em dash), and corrected eye/action icon alignment.

DAY-WISE CATEGORY SERVICE FIX (multi-day rentals)
- Frontend/RBFW_Woocommerse.php: the multi-day add-to-cart branch checked a non-existent [main_cat_name] key, so day-wise category services were silently dropped from cart/checkout and the order. Now keyed off [name] with quantity/price guards, so the resource cost flows into the cart, checkout review and order, and the line item / detail display.
- Frontend product page shows the day-wise breakdown as a small badge, e.g. "500.00 x 5 Days = 2,500.00" (templates/forms/multi-day-registration.php, assets/mp_script/md_script.js, css/rbfw_style.css).

INVENTORY PAGE
- Modern redesign with stat cards, stock pills, detail modal, inline SVG icons and full mobile responsiveness (admin/css/rbfw_inventory.css, admin/js/rbfw_inventory.js, inc/rbfw_inventory_functions.php).

TIME SLOTS PAGE
- Modern light redesign using both primary and secondary colors, fixed action column + right-side gap (admin/css/rbfw_timeslots.css, lib/classes/class-time-slots-page.php).

SUPPORTING CHANGES
- inc/RBFW_Dependencies.php: per-page asset enqueues (Plus Jakarta Sans font, flatpickr CSS/JS, page CSS/JS) plus AJAX nonces and the currency symbol for the new order-management endpoints.
- inc/rbfw_functions.php: rbfw_allowed_html() now allows thead/tfoot and td colspan/data-th for the new table markup.
- lib/classes/class-admin-menu.php: order-list markup (filter bar, stat cards, modals, row data attributes) and the new AJAX wiring.