### PR TITLE
Add Order List CSV/PDF export + fix variation "Undefined array key" notices

### DIFF
--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -736,15 +736,21 @@ if (!class_exists('RBFW_Woocommerce')) {
                 }
                 $variation_data = get_post_meta( $rbfw_id, 'rbfw_variations_data', true );
                 $variation_info = [];
-                if ( ! empty( $variation_data ) ) {
+                if ( ! empty( $variation_data ) && is_array( $variation_data ) ) {
                     $i = 0;
                     foreach ( $variation_data as $level_one_arr ) {
-                        $selected_field_value = ! empty( $sd_input_data_sabitized[ $level_one_arr['field_id'] ] ) ? $sd_input_data_sabitized[ $level_one_arr['field_id'] ] : [];
-                        $level_two_arr        = $level_one_arr['value'];
-                        foreach ( $level_two_arr as $level_two_arr_value ) {
-                            if ( $selected_field_value == $level_two_arr_value['name'] ) {
-                                $field_label                         = $level_one_arr['field_label'];
-                                $field_id                            = $level_one_arr['field_id'];
+                        // Skip incomplete/legacy variation rows (missing id or values)
+                        // so they cannot raise "Undefined array key" notices here.
+                        if ( ! is_array( $level_one_arr ) || empty( $level_one_arr['field_id'] ) || empty( $level_one_arr['value'] ) || ! is_array( $level_one_arr['value'] ) ) {
+                            $i ++;
+                            continue;
+                        }
+                        $field_id             = $level_one_arr['field_id'];
+                        $field_label          = isset( $level_one_arr['field_label'] ) ? $level_one_arr['field_label'] : '';
+                        $selected_field_value = ! empty( $sd_input_data_sabitized[ $field_id ] ) ? $sd_input_data_sabitized[ $field_id ] : [];
+                        foreach ( $level_one_arr['value'] as $level_two_arr_value ) {
+                            $level_two_name = isset( $level_two_arr_value['name'] ) ? $level_two_arr_value['name'] : '';
+                            if ( $selected_field_value == $level_two_name ) {
                                 $variation_info[ $i ]['field_id']    = $field_id;
                                 $variation_info[ $i ]['field_label'] = $field_label;
                                 $variation_info[ $i ]['field_value'] = $selected_field_value;
@@ -1635,8 +1641,8 @@ if (!class_exists('RBFW_Woocommerce')) {
                     $variation_content .= '<table style="border:1px solid #f5f5f5;margin:0;width: 100%;">';
                     foreach ( $variation_info as $key => $value ) {
                         $variation_content .= '<tr>';
-                        $variation_content .= '<td style="border:1px solid #f5f5f5;"><strong>' . esc_html( $value['field_label'] ) . '</strong></td>';
-                        $variation_content .= '<td style="border:1px solid #f5f5f5;">' . esc_html( $value['field_value'] ) . '</td>';
+                        $variation_content .= '<td style="border:1px solid #f5f5f5;"><strong>' . esc_html( $value['field_label'] ?? '' ) . '</strong></td>';
+                        $variation_content .= '<td style="border:1px solid #f5f5f5;">' . esc_html( $value['field_value'] ?? '' ) . '</td>';
                         $variation_content .= '</tr>';
                     }
                     $variation_content .= '</table>';

--- a/admin/RBFW_Modern_Editor.php
+++ b/admin/RBFW_Modern_Editor.php
@@ -646,7 +646,7 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 
 			$rbfw_variations_data = [];
 			if ( isset( $_POST['rbfw_variations_data'] ) && is_array( $_POST['rbfw_variations_data'] ) ) {
-				$rbfw_variations_data = RBFW_Function::data_sanitize( wp_unslash( $_POST['rbfw_variations_data'] ) );
+				$rbfw_variations_data = rbfw_clean_variations_data( RBFW_Function::data_sanitize( wp_unslash( $_POST['rbfw_variations_data'] ) ) );
 			}
 			update_post_meta( $post_id, 'rbfw_variations_data', $rbfw_variations_data );
 

--- a/admin/css/rbfw_order.css
+++ b/admin/css/rbfw_order.css
@@ -622,3 +622,96 @@ span.flatpickr-weekday { color: #8896B0; font-weight: 700; font-size: 11px; }
 .rbfw_ol_edit_modal .flatpickr-wrapper { display: block; width: 100%; }
 .rbfw_ol_edit_modal .flatpickr-calendar.static,
 .rbfw_ol_edit_modal .flatpickr-calendar.static.open { z-index: 100070; }
+
+/* =========================================================================
+   Export (CSV / PDF) — header button + modal
+   ========================================================================= */
+.rbfw_ol_header_actions { margin-left: auto; display: flex; align-items: center; gap: 10px; }
+.rbfw_ol .rbfw_ol_export_btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: inherit; font-size: 13px; font-weight: 700; cursor: pointer;
+    padding: 10px 18px; border-radius: var(--rbfw-radius-sm); border: 1px solid var(--rbfw-accent);
+    background: linear-gradient(90deg, var(--rbfw-accent) 0%, var(--rbfw-purple) 100%);
+    color: #fff; transition: filter .15s, box-shadow .15s, transform .05s;
+    box-shadow: 0 2px 6px rgba(79,110,247,.28);
+}
+.rbfw_ol .rbfw_ol_export_btn:hover { filter: brightness(1.05); box-shadow: 0 4px 12px rgba(79,110,247,.36); }
+.rbfw_ol .rbfw_ol_export_btn:active { transform: translateY(1px); }
+.rbfw_ol .rbfw_ol_export_btn svg.rbfw_inv_ic { width: 17px; height: 17px; }
+
+/* Export modal */
+.rbfw_ol_export_box {
+    max-width: 480px;
+    max-height: calc(100vh - 40px);
+    display: flex; flex-direction: column;
+}
+.rbfw_ol_export_box .rbfw_ol_status_modal_head,
+.rbfw_ol_export_box .rbfw_ol_status_modal_foot { flex: 0 0 auto; }
+.rbfw_ol_export_body { padding: 20px 18px 10px; overflow-y: auto; flex: 1 1 auto; }
+.rbfw_ol_export_label {
+    display: block; font-size: 12px; font-weight: 700; color: var(--rbfw-text-2);
+    margin: 0 0 8px; text-transform: uppercase; letter-spacing: .4px;
+}
+.rbfw_ol_export_label:not(:first-child) { margin-top: 18px; }
+.rbfw_ol_export_hint { text-transform: none; letter-spacing: 0; font-weight: 600; color: var(--rbfw-text-3); font-size: 11px; }
+
+/* Format cards */
+.rbfw_ol_export_formats { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.rbfw_ol_export_fmt {
+    display: flex; align-items: center; gap: 10px; cursor: pointer; margin: 0;
+    padding: 12px; border: 1.5px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    background: var(--rbfw-surface); transition: border-color .15s, background .15s, box-shadow .15s;
+}
+.rbfw_ol_export_fmt:hover { border-color: #C7D0E8; }
+.rbfw_ol_export_fmt.is-active { border-color: var(--rbfw-accent); background: var(--rbfw-accent-lt); box-shadow: 0 0 0 3px rgba(79,110,247,.1); }
+.rbfw_ol_export_fmt input { position: absolute; opacity: 0; width: 0; height: 0; }
+.rbfw_ol_export_fmt_ic {
+    display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto;
+    width: 36px; height: 36px; border-radius: 9px; background: var(--rbfw-bg); color: var(--rbfw-accent);
+}
+.rbfw_ol_export_fmt.is-active .rbfw_ol_export_fmt_ic { background: #fff; }
+.rbfw_ol_export_fmt_ic svg.rbfw_inv_ic { width: 20px; height: 20px; }
+.rbfw_ol_export_fmt_txt { display: flex; flex-direction: column; gap: 2px; line-height: 1.2; }
+.rbfw_ol_export_fmt_title { font-size: 14px; font-weight: 700; color: var(--rbfw-text-1); }
+.rbfw_ol_export_fmt_sub { font-size: 10.5px; color: var(--rbfw-text-3); }
+
+/* Selects + month inputs reuse the status-select look */
+.rbfw_ol_status_modal .rbfw_ol_export_select {
+    width: 100%; height: 42px; padding: 0 36px 0 12px; margin: 0;
+    border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    background-color: var(--rbfw-surface); color: var(--rbfw-text-1); font-size: 14px; font-weight: 600;
+    box-shadow: none; outline: none; line-height: normal; transition: border-color .15s, box-shadow .15s;
+    -webkit-appearance: none; -moz-appearance: none; appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%238896B0' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right 12px center; background-size: 14px 14px; cursor: pointer;
+}
+.rbfw_ol_status_modal .rbfw_ol_export_select:focus { border-color: var(--rbfw-accent); box-shadow: 0 0 0 3px rgba(79,110,247,.12); }
+
+.rbfw_ol_export_months { display: flex; align-items: center; gap: 10px; }
+.rbfw_ol_status_modal .rbfw_ol_export_month {
+    flex: 1; min-width: 0; height: 42px; padding: 0 12px; margin: 0;
+    border: 1px solid var(--rbfw-border); border-radius: var(--rbfw-radius-sm);
+    background-color: var(--rbfw-surface); color: var(--rbfw-text-1);
+    font-size: 14px; font-weight: 600; font-family: inherit; outline: none; box-shadow: none;
+    transition: border-color .15s, box-shadow .15s;
+}
+.rbfw_ol_status_modal .rbfw_ol_export_month:focus { border-color: var(--rbfw-accent); box-shadow: 0 0 0 3px rgba(79,110,247,.12); }
+.rbfw_ol_export_month_sep { color: var(--rbfw-text-3); font-weight: 700; }
+.rbfw_ol_export_note { margin: 8px 0 0; font-size: 11.5px; color: var(--rbfw-text-3); }
+
+/* Download button */
+.rbfw_ol_export_do {
+    display: inline-flex; align-items: center; gap: 7px;
+    background: var(--rbfw-accent); border: 1px solid var(--rbfw-accent); color: #fff; min-width: 140px; justify-content: center;
+}
+.rbfw_ol_export_do:hover { background: #3B5BE0; border-color: #3B5BE0; }
+.rbfw_ol_export_do svg.rbfw_inv_ic { width: 16px; height: 16px; }
+
+@media (max-width: 600px) {
+    .rbfw_ol_header_actions { margin-left: 0; width: 100%; }
+    .rbfw_ol .rbfw_ol_export_btn { width: 100%; justify-content: center; }
+    .rbfw_ol_export_modal.rbfw_ol_status_modal { padding: 12px; }
+    .rbfw_ol_export_box { max-height: calc(100vh - 24px); }
+    .rbfw_ol_export_formats { grid-template-columns: 1fr; }
+    .rbfw_ol_export_months { flex-wrap: nowrap; }
+}

--- a/admin/js/rbfw_order.js
+++ b/admin/js/rbfw_order.js
@@ -816,6 +816,97 @@
             }
         });
 
+        /* ----------------------------------------------------------------- *
+         *  Export (CSV / PDF) — item-wise + month-range download.
+         * ----------------------------------------------------------------- */
+        (function initExport() {
+            var exportBtn   = document.getElementById('rbfw_ol_export_btn');
+            var exportModal = document.getElementById('rbfw_ol_export_modal');
+            if (!exportBtn || !exportModal) { return; }
+
+            var itemSel   = document.getElementById('rbfw_ol_export_item');
+            var statusSelE = document.getElementById('rbfw_ol_export_status');
+            var fromMonth = document.getElementById('rbfw_ol_export_from');
+            var toMonth   = document.getElementById('rbfw_ol_export_to');
+
+            function openExport() {
+                // Pre-fill from the currently applied on-page filters as a convenience.
+                if (itemSel && fbItem) { itemSel.value = fbItem; }
+                if (statusSelE && statusFilter) { statusSelE.value = statusFilter; }
+                // Use flex (not block) so the shared .rbfw_ol_status_modal
+                // centering (align/justify center) applies — same as the other modals.
+                exportModal.style.display = 'flex';
+                exportModal.setAttribute('aria-hidden', 'false');
+                document.body.classList.add('rbfw_ol_modal_open');
+            }
+
+            function closeExport() {
+                exportModal.style.display = 'none';
+                exportModal.setAttribute('aria-hidden', 'true');
+                document.body.classList.remove('rbfw_ol_modal_open');
+            }
+
+            exportBtn.addEventListener('click', function (e) { e.preventDefault(); openExport(); });
+
+            exportModal.addEventListener('click', function (e) {
+                if (!e.target) { return; }
+                if (e.target.closest('.rbfw_ol_export_close') ||
+                    e.target.closest('.rbfw_ol_export_cancel') ||
+                    e.target.classList.contains('rbfw_ol_status_modal_overlay')) {
+                    e.preventDefault();
+                    closeExport();
+                    return;
+                }
+                // Active-state styling for the format cards.
+                var fmt = e.target.closest('.rbfw_ol_export_fmt');
+                if (fmt) {
+                    var radio = fmt.querySelector('input[type="radio"]');
+                    if (radio) { radio.checked = true; }
+                    exportModal.querySelectorAll('.rbfw_ol_export_fmt').forEach(function (c) {
+                        c.classList.toggle('is-active', c === fmt);
+                    });
+                    return;
+                }
+                // Trigger the download.
+                if (e.target.closest('.rbfw_ol_export_do')) {
+                    e.preventDefault();
+                    doExport();
+                }
+            });
+
+            // Keep card highlight in sync if the radio itself receives focus/change.
+            exportModal.querySelectorAll('input[name="rbfw_ol_export_format"]').forEach(function (r) {
+                r.addEventListener('change', function () {
+                    exportModal.querySelectorAll('.rbfw_ol_export_fmt').forEach(function (c) {
+                        c.classList.toggle('is-active', c.contains(r) && r.checked);
+                    });
+                });
+            });
+
+            function doExport() {
+                if (typeof rbfw_ajax_admin === 'undefined' || !rbfw_ajax_admin.admin_post_url) { return; }
+                var fmtEl = exportModal.querySelector('input[name="rbfw_ol_export_format"]:checked');
+                var params = {
+                    action: 'rbfw_export_orders',
+                    format: fmtEl ? fmtEl.value : 'csv',
+                    item_id: itemSel ? itemSel.value : '0',
+                    status: statusSelE ? statusSelE.value : '',
+                    from_month: fromMonth ? fromMonth.value : '',
+                    to_month: toMonth ? toMonth.value : '',
+                    _wpnonce: rbfw_ajax_admin.nonce_export_orders || ''
+                };
+                var qs = Object.keys(params).map(function (k) {
+                    return encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);
+                }).join('&');
+
+                // Navigate to the download endpoint. The server streams a file
+                // (CSV/PDF) with a Content-Disposition: attachment header, so the
+                // current admin page is not replaced.
+                window.location.href = rbfw_ajax_admin.admin_post_url + '?' + qs;
+                closeExport();
+            }
+        })();
+
         render();
     });
 })();

--- a/admin/settings/Inventory.php
+++ b/admin/settings/Inventory.php
@@ -326,7 +326,7 @@
 					$rbfw_item_stock_quantity = isset( $_POST['rbfw_item_stock_quantity'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_item_stock_quantity'] ) ) : '';
 					$stock_manage_on_return_date = isset( $_POST['stock_manage_on_return_date'] ) ? sanitize_text_field( wp_unslash( $_POST['stock_manage_on_return_date'] ) ) : '';
 					$rbfw_enable_md_type_item_qty = isset( $_POST['rbfw_enable_md_type_item_qty'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_enable_md_type_item_qty'] ) ) : 'no';
-					$rbfw_variations_data = isset( $_POST['rbfw_variations_data'] ) ? RBFW_Function::data_sanitize( $_POST['rbfw_variations_data'] ) : [];
+					$rbfw_variations_data = isset( $_POST['rbfw_variations_data'] ) ? rbfw_clean_variations_data( RBFW_Function::data_sanitize( $_POST['rbfw_variations_data'] ) ) : [];
 
                     $rbfw_item_stock_quantity = ($rbfw_item_stock_quantity)?$rbfw_item_stock_quantity:1000;
 

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -156,7 +156,9 @@ if (! class_exists('RBFW_Dependencies')) {
 
 			wp_localize_script('jquery', 'rbfw_ajax_admin', array(
 				'rbfw_ajaxurl' => admin_url('admin-ajax.php'),
+				'admin_post_url' => admin_url('admin-post.php'),
 				'currency_symbol' => function_exists('get_woocommerce_currency_symbol') ? html_entity_decode( get_woocommerce_currency_symbol() ) : '',
+				'nonce_export_orders'        => wp_create_nonce('rbfw_export_orders_action'),
 				'nonce_time_slot'        => wp_create_nonce('rbfw_time_slot_action'),
 				'nonce_duration_form'        => wp_create_nonce('rbfw_duration_form_action'),
 				'nonce_room_types_with_sd_price'        => wp_create_nonce('rbfw_room_types_with_sd_price_action'),

--- a/inc/class-bike-car-md-function.php
+++ b/inc/class-bike-car-md-function.php
@@ -424,9 +424,9 @@ if ( ! class_exists( 'RBFW_BikeCarMd_Function' ) ) {
                     $c = 0;
                     foreach ($variation_info as $key => $value):
 
-                        $main_array[0]['rbfw_variation_info'][$c]['field_id'] = $value['field_id'];
-                        $main_array[0]['rbfw_variation_info'][$c]['field_label'] = $value['field_label'];
-                        $main_array[0]['rbfw_variation_info'][$c]['field_value'] = $value['field_value'];
+                        $main_array[0]['rbfw_variation_info'][$c]['field_id'] = $value['field_id'] ?? '';
+                        $main_array[0]['rbfw_variation_info'][$c]['field_label'] = $value['field_label'] ?? '';
+                        $main_array[0]['rbfw_variation_info'][$c]['field_value'] = $value['field_value'] ?? '';
                         $c++;
                     endforeach;
                 }

--- a/inc/rbfw_file_include.php
+++ b/inc/rbfw_file_include.php
@@ -28,6 +28,7 @@ require_once RBFW_PLUGIN_DIR . '/inc/class-bike-car-sd-function.php';
 
 
 require_once RBFW_PLUGIN_DIR . '/inc/rbfw_order_meta.php';
+require_once RBFW_PLUGIN_DIR . '/inc/rbfw_order_export.php';
 require_once RBFW_PLUGIN_DIR . '/inc/class-bike-car-md-function.php';
 require_once RBFW_PLUGIN_DIR . '/lib/classes/class-thankyou-page.php';
 require_once RBFW_PLUGIN_DIR . '/lib/classes/class-search-page.php';

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -3994,3 +3994,46 @@ function rbfw_enqueue_reset_orders_assets( $hook ) {
 		)
 	) );
 }
+
+if ( ! function_exists( 'rbfw_clean_variations_data' ) ) {
+	/**
+	 * Normalise saved product-variation rows before they are persisted.
+	 *
+	 * The variations repeater can submit blank or partial rows — an untouched
+	 * "add new" row, or a row whose label was cleared. Persisting those leads to
+	 * "Undefined array key 'field_label'" notices wherever the data is rendered
+	 * later (single-item form, cart, checkout, thank-you page, order meta). This
+	 * drops any row without a usable label and strips value entries that have no
+	 * name, fixing the problem at the source.
+	 *
+	 * @param mixed $rows raw (already sanitised) variations data.
+	 * @return array cleaned, re-indexed rows.
+	 */
+	function rbfw_clean_variations_data( $rows ) {
+		if ( empty( $rows ) || ! is_array( $rows ) ) {
+			return array();
+		}
+		$clean = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$label = isset( $row['field_label'] ) ? trim( (string) $row['field_label'] ) : '';
+			if ( '' === $label ) {
+				continue; // No label -> unusable, skip it.
+			}
+			// Keep only value entries that actually carry a name.
+			$values = array();
+			if ( ! empty( $row['value'] ) && is_array( $row['value'] ) ) {
+				foreach ( $row['value'] as $val ) {
+					if ( is_array( $val ) && isset( $val['name'] ) && '' !== trim( (string) $val['name'] ) ) {
+						$values[] = $val;
+					}
+				}
+			}
+			$row['value'] = $values;
+			$clean[]      = $row;
+		}
+		return $clean;
+	}
+}

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -416,10 +416,10 @@ function rbfw_get_multiple_date_available_qty($post_id, $start_date, $end_date, 
     if(($rbfw_enable_variations=='yes') && !empty($rbfw_variations_data)){
         $variant_q = [];
         foreach($rbfw_variations_data as $key=>$item1){
-            $field_label = $item1['field_label'];
-            if($field_label){
+            $field_label = isset($item1['field_label']) ? $item1['field_label'] : '';
+            if($field_label && !empty($item1['value']) && is_array($item1['value'])){
                 foreach ($item1['value'] as $key1=>$single){
-                    if($single['name']){
+                    if(!empty($single['name'])){
                         foreach($date_range as $date){
                             $variant_q[] = array('date'=>$date,$single['name']=>total_variant_quantity($field_label,$single['name'],$date,$rbfw_inventory,$inventory_based_on_return));
                         }
@@ -680,10 +680,10 @@ function rbfw_day_wise_sold_out_check_by_month($post_id, $year,  $month, $total_
         if(($rbfw_enable_variations=='yes') && !empty($rbfw_variations_data)){
             $variant_q = [];
             foreach($rbfw_variations_data as $key=>$item1){
-                $field_label = $item1['field_label'];
-                if($field_label){
+                $field_label = isset($item1['field_label']) ? $item1['field_label'] : '';
+                if($field_label && !empty($item1['value']) && is_array($item1['value'])){
                     foreach ($item1['value'] as $key1=>$single){
-                        if($single['name']){
+                        if(!empty($single['name'])){
                             foreach($date_range as $date1){
                                 $variant_q[] = array('date'=>$date1,$single['name']=>total_variant_quantity($field_label,$single['name'],$date,$rbfw_inventory,$inventory_based_on_return));
                             }
@@ -912,6 +912,9 @@ function rbfw_inv_icon( $name, $extra_class = '' ) {
         'calendar' => '<rect x="4" y="5" width="16" height="16" rx="2"/><path d="M4 10h16"/><path d="M8 3v4"/><path d="M16 3v4"/>',
         'receipt'  => '<path d="M6 3h12v18l-2.2-1.5L13.5 21 12 19.5 10.5 21 8.2 19.5 6 21z"/><path d="M9 8h6"/><path d="M9 12h6"/>',
         'calculator' => '<rect x="5" y="3" width="14" height="18" rx="2"/><path d="M9 7h6"/><path d="M8.5 12h.01"/><path d="M12 12h.01"/><path d="M15.5 12h.01"/><path d="M8.5 16h.01"/><path d="M12 16h.01"/><path d="M15.5 16h.01"/>',
+        'download' => '<path d="M12 4v11"/><path d="M7 11l5 5 5-5"/><path d="M5 20h14"/>',
+        'file_csv' => '<path d="M14 3v5h5"/><path d="M14 3H6.5A1.5 1.5 0 0 0 5 4.5v15A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V8z"/><path d="M8.5 14h2"/><path d="M13.5 14h2"/><path d="M8.5 17h2"/><path d="M13.5 17h2"/>',
+        'file_pdf' => '<path d="M14 3v5h5"/><path d="M14 3H6.5A1.5 1.5 0 0 0 5 4.5v15A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V8z"/><path d="M8.5 13v4"/><path d="M8.5 13h1.2a1.2 1.2 0 0 1 0 2.4H8.5"/><path d="M13 13v4h1a1.5 1.5 0 0 0 1.5-1.5v-1A1.5 1.5 0 0 0 14 13z"/>',
     );
 
     if ( ! isset( $paths[ $name ] ) ) {
@@ -1480,21 +1483,21 @@ function rbfw_get_stock_details(){
                                 $sold_item_qty += $rbfw_item_quantity;
                                 $f = 0;
                                 foreach ($rbfw_variations_data_closing as $key => $v_data) {
-                                    $field_id = $rbfw_variations_data_closing[$f]['field_id'];
-                                    $field_label = $rbfw_variations_data_closing[$f]['field_label'];
-                                    $field_value = $rbfw_variations_data_closing[$f]['value'];
+                                    $field_id = isset($rbfw_variations_data_closing[$f]['field_id']) ? $rbfw_variations_data_closing[$f]['field_id'] : '';
+                                    $field_label = isset($rbfw_variations_data_closing[$f]['field_label']) ? $rbfw_variations_data_closing[$f]['field_label'] : '';
+                                    $field_value = ( isset($rbfw_variations_data_closing[$f]['value']) && is_array($rbfw_variations_data_closing[$f]['value']) ) ? $rbfw_variations_data_closing[$f]['value'] : array();
 
                                     if(!empty($rbfw_variation_info)){
                                         foreach ($rbfw_variation_info as $key => $v_info) {
-                                            $s_field_id = $v_info['field_id'];
-                                            $s_field_label = $v_info['field_label'];
-                                            $s_field_value = $v_info['field_value'];
+                                            $s_field_id = $v_info['field_id'] ?? '';
+                                            $s_field_label = $v_info['field_label'] ?? '';
+                                            $s_field_value = $v_info['field_value'] ?? '';
                                             if($s_field_id == $field_id){
                                                 $g = 0;
                                                 foreach ($field_value as $key => $f_value) {
 
-                                                    $fv_name = $f_value['name'];
-                                                    $fv_qty = $f_value['quantity'];
+                                                    $fv_name = $f_value['name'] ?? '';
+                                                    $fv_qty = $f_value['quantity'] ?? '';
 
                                                     if ($s_field_value == $fv_name) {
                                                         $rbfw_variations_data_closing[$f]['value'][$g]['quantity'] = $fv_qty - $rbfw_item_quantity;
@@ -1593,7 +1596,7 @@ function rbfw_get_stock_details(){
                     <?php if($rbfw_enable_variations == 'yes' && !empty($rbfw_variations_data) && $rent_type != 'resort' && $rent_type != 'bike_car_sd' && $rent_type != 'appointment'){ ?>
                         <?php foreach ($rbfw_variations_data as $_variations_data) { ?>
                         <div class="rbfw_inv_modal_section">
-                            <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('clone'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php echo esc_html( $_variations_data['field_label'] ); ?></div>
+                            <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('clone'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php echo esc_html( $_variations_data['field_label'] ?? '' ); ?></div>
                             <?php if(!empty($_variations_data['value'])){ ?>
                             <table class="rbfw_inv_mini_table">
                                 <thead><tr><th><?php esc_html_e('Name','booking-and-rental-manager-for-woocommerce'); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e('Available Qty','booking-and-rental-manager-for-woocommerce'); ?></th></tr></thead>

--- a/inc/rbfw_order_export.php
+++ b/inc/rbfw_order_export.php
@@ -1,0 +1,712 @@
+<?php
+/**
+ * RBFW Order List — Export (CSV / PDF)
+ *
+ * Streams the rental order data shown on the Order List page as either a CSV
+ * spreadsheet or a PDF document. Supports item-wise and month-range filtering.
+ *
+ * A real PDF is produced with mPDF when the bundled "magepeople-pdf-support"
+ * companion plugin is active (same library the Pro PDF tickets use). When that
+ * library is not available the handler degrades gracefully to a print-optimised
+ * HTML page that the browser can "Save as PDF", so the free plugin keeps working
+ * stand-alone.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'admin_post_rbfw_export_orders', 'rbfw_export_orders_handler' );
+
+/**
+ * Entry point for the export download request.
+ *
+ * Security: verifies the dedicated nonce and the manage_options capability
+ * before reading any data. All output is plain text / library-rendered PDF, so
+ * there is no HTML echoed into wp-admin from user input.
+ */
+function rbfw_export_orders_handler() {
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You are not allowed to export orders.', 'booking-and-rental-manager-for-woocommerce' ), 403 );
+	}
+
+	$nonce = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+	if ( ! wp_verify_nonce( $nonce, 'rbfw_export_orders_action' ) ) {
+		wp_die( esc_html__( 'Security check failed. Please reload the Order List page and try again.', 'booking-and-rental-manager-for-woocommerce' ), 403 );
+	}
+
+	// --- Sanitise filter inputs -------------------------------------------------
+	$format = isset( $_GET['format'] ) ? sanitize_key( wp_unslash( $_GET['format'] ) ) : 'csv';
+	if ( ! in_array( $format, array( 'csv', 'pdf' ), true ) ) {
+		$format = 'csv';
+	}
+
+	$item_id    = isset( $_GET['item_id'] ) ? absint( wp_unslash( $_GET['item_id'] ) ) : 0;
+	$status     = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : '';
+	$from_month = isset( $_GET['from_month'] ) ? sanitize_text_field( wp_unslash( $_GET['from_month'] ) ) : '';
+	$to_month   = isset( $_GET['to_month'] ) ? sanitize_text_field( wp_unslash( $_GET['to_month'] ) ) : '';
+
+	// Normalise the YYYY-MM month inputs; ignore anything that is not a valid month.
+	$from_month = preg_match( '/^\d{4}-\d{2}$/', $from_month ) ? $from_month : '';
+	$to_month   = preg_match( '/^\d{4}-\d{2}$/', $to_month ) ? $to_month : '';
+	// Allow the user to enter the range either way round.
+	if ( $from_month && $to_month && $from_month > $to_month ) {
+		$tmp        = $from_month;
+		$from_month = $to_month;
+		$to_month   = $tmp;
+	}
+
+	$filters = array(
+		'item_id'    => $item_id,
+		'status'     => $status,
+		'from_month' => $from_month,
+		'to_month'   => $to_month,
+	);
+
+	$rows = rbfw_collect_export_rows( $filters );
+
+	if ( 'pdf' === $format ) {
+		rbfw_export_orders_pdf( $rows, $filters );
+	} else {
+		rbfw_export_orders_csv( $rows, $filters );
+	}
+	exit;
+}
+
+/**
+ * Column definitions for the export — single source of truth for both CSV and PDF.
+ *
+ * @return array<string,string> machine key => human label.
+ */
+function rbfw_export_columns() {
+	return array(
+		'order_no'         => __( 'Order #', 'booking-and-rental-manager-for-woocommerce' ),
+		'booking_id'       => __( 'Booking ID', 'booking-and-rental-manager-for-woocommerce' ),
+		'customer'         => __( 'Customer', 'booking-and-rental-manager-for-woocommerce' ),
+		'email'            => __( 'Email', 'booking-and-rental-manager-for-woocommerce' ),
+		'phone'            => __( 'Phone', 'booking-and-rental-manager-for-woocommerce' ),
+		'item'             => __( 'Item', 'booking-and-rental-manager-for-woocommerce' ),
+		'item_type'        => __( 'Item Type', 'booking-and-rental-manager-for-woocommerce' ),
+		'qty'              => __( 'Qty', 'booking-and-rental-manager-for-woocommerce' ),
+		'booking_start'    => __( 'Booking Start', 'booking-and-rental-manager-for-woocommerce' ),
+		'booking_end'      => __( 'Booking End', 'booking-and-rental-manager-for-woocommerce' ),
+		'total_days'       => __( 'Days', 'booking-and-rental-manager-for-woocommerce' ),
+		'duration_cost'    => __( 'Duration Cost', 'booking-and-rental-manager-for-woocommerce' ),
+		'service_cost'     => __( 'Service Cost', 'booking-and-rental-manager-for-woocommerce' ),
+		'discount'         => __( 'Discount', 'booking-and-rental-manager-for-woocommerce' ),
+		'security_deposit' => __( 'Security Deposit', 'booking-and-rental-manager-for-woocommerce' ),
+		'status'           => __( 'Status', 'booking-and-rental-manager-for-woocommerce' ),
+		'order_total'      => __( 'Order Total', 'booking-and-rental-manager-for-woocommerce' ),
+		'order_created'    => __( 'Order Created', 'booking-and-rental-manager-for-woocommerce' ),
+	);
+}
+
+/**
+ * Build the export dataset — one row per booking line item (ticket).
+ *
+ * Producing a row per ticket (rather than per order) is what makes the
+ * item-wise filter meaningful: a multi-item order yields one row per item,
+ * each carrying its parent order number so rows can still be grouped.
+ *
+ * @param array $filters item_id, status, from_month, to_month.
+ * @return array list of associative rows keyed by rbfw_export_columns().
+ */
+function rbfw_collect_export_rows( $filters ) {
+	$rows = array();
+
+	$query = new WP_Query(
+		array(
+			'post_type'      => 'rbfw_order',
+			'order'          => 'DESC',
+			'posts_per_page' => -1,
+			'post_status'    => array( 'publish', 'private', 'draft', 'pending', 'future', 'inherit' ),
+			'no_found_rows'  => true,
+		)
+	);
+
+	if ( ! $query->have_posts() ) {
+		return $rows;
+	}
+
+	$item_id    = isset( $filters['item_id'] ) ? (int) $filters['item_id'] : 0;
+	$status     = isset( $filters['status'] ) ? $filters['status'] : '';
+	$from_month = isset( $filters['from_month'] ) ? $filters['from_month'] : '';
+	$to_month   = isset( $filters['to_month'] ) ? $filters['to_month'] : '';
+
+	while ( $query->have_posts() ) {
+		$query->the_post();
+		$post_id     = get_the_ID();
+		$wc_order_id = get_post_meta( $post_id, 'rbfw_order_id', true );
+		$order       = $wc_order_id ? wc_get_order( $wc_order_id ) : false;
+
+		if ( ! $order ) {
+			continue;
+		}
+
+		$order_status = $order->get_status();
+		if ( 'trash' === $order_status || 'wc-trash' === $order_status ) {
+			continue;
+		}
+
+		// Status filter (statuses are stored without the wc- prefix in the UI).
+		if ( '' !== $status && str_replace( 'wc-', '', $order_status ) !== $status ) {
+			continue;
+		}
+
+		$order_created = get_the_date( 'Y-m-d H:i', $post_id );
+		$order_total   = (float) $order->get_total();
+		$billing_name  = get_post_meta( $post_id, 'rbfw_billing_name', true );
+		if ( '' === $billing_name ) {
+			$billing_name = trim( $order->get_formatted_billing_full_name() );
+		}
+		$billing_phone = $order->get_billing_phone();
+		$billing_email = $order->get_billing_email();
+
+		$ticket_info_array = maybe_unserialize( get_post_meta( $post_id, 'rbfw_ticket_info', true ) );
+		if ( empty( $ticket_info_array ) || ! is_array( $ticket_info_array ) ) {
+			continue;
+		}
+
+		// Re-index in case the meta is an associative/nested structure.
+		if ( isset( $ticket_info_array['rbfw_id'] ) ) {
+			$ticket_info_array = array( $ticket_info_array );
+		}
+
+		$first_ticket_row_for_order = true;
+
+		foreach ( $ticket_info_array as $ticket ) {
+			if ( ! is_array( $ticket ) ) {
+				continue;
+			}
+
+			$ticket_item_id = isset( $ticket['rbfw_id'] ) ? (int) $ticket['rbfw_id'] : 0;
+
+			// Item-wise filter.
+			if ( $item_id > 0 && $ticket_item_id !== $item_id ) {
+				continue;
+			}
+
+			$start_raw = isset( $ticket['rbfw_start_datetime'] ) ? $ticket['rbfw_start_datetime'] : '';
+			$end_raw   = isset( $ticket['rbfw_end_datetime'] ) ? $ticket['rbfw_end_datetime'] : '';
+
+			// Month-range filter on booking start, falling back to order-created
+			// date when the booking has no start (keeps every record placeable).
+			$range_basis = $start_raw ? strtotime( $start_raw ) : strtotime( $order_created );
+			if ( ( $from_month || $to_month ) && $range_basis ) {
+				$row_month = gmdate( 'Y-m', $range_basis );
+				if ( $from_month && $row_month < $from_month ) {
+					continue;
+				}
+				if ( $to_month && $row_month > $to_month ) {
+					continue;
+				}
+			}
+
+			$qty = 1;
+			if ( ! empty( $ticket['rbfw_item_quantity'] ) ) {
+				$qty = (int) $ticket['rbfw_item_quantity'];
+			} elseif ( ! empty( $ticket['ticket_qty'] ) ) {
+				$qty = (int) $ticket['ticket_qty'];
+			}
+
+			$rows[] = array(
+				'order_no'         => $wc_order_id,
+				'booking_id'       => $post_id,
+				'customer'         => html_entity_decode( (string) $billing_name, ENT_QUOTES, 'UTF-8' ),
+				'email'            => $billing_email,
+				'phone'            => $billing_phone,
+				'item'             => isset( $ticket['ticket_name'] ) ? html_entity_decode( (string) $ticket['ticket_name'], ENT_QUOTES, 'UTF-8' ) : '',
+				'item_type'        => isset( $ticket['rbfw_rent_type'] ) ? rbfw_export_type_label( $ticket['rbfw_rent_type'] ) : '',
+				'qty'              => $qty,
+				'booking_start'    => rbfw_export_format_datetime( $start_raw ),
+				'booking_end'      => rbfw_export_format_datetime( $end_raw ),
+				'total_days'       => isset( $ticket['total_days'] ) && $ticket['total_days'] ? (int) $ticket['total_days'] : '',
+				'duration_cost'    => isset( $ticket['duration_cost'] ) ? (float) $ticket['duration_cost'] : 0,
+				'service_cost'     => isset( $ticket['service_cost'] ) ? (float) $ticket['service_cost'] : 0,
+				'discount'         => isset( $ticket['discount_amount'] ) ? (float) $ticket['discount_amount'] : 0,
+				'security_deposit' => isset( $ticket['security_deposit_amount'] ) ? (float) $ticket['security_deposit_amount'] : 0,
+				'status'           => ucfirst( str_replace( 'wc-', '', $order_status ) ),
+				// The WC order total belongs to the whole order; only attribute it
+				// to the first line so the column never double-counts a multi-item
+				// order when summed in a spreadsheet.
+				'order_total'      => $first_ticket_row_for_order ? $order_total : '',
+				'order_created'    => $order_created,
+			);
+
+			$first_ticket_row_for_order = false;
+		}
+	}
+
+	wp_reset_postdata();
+
+	return $rows;
+}
+
+/**
+ * Resolve a rent-type slug to its human label, reusing the plugin helper when present.
+ *
+ * @param string $type rent type slug.
+ * @return string
+ */
+function rbfw_export_type_label( $type ) {
+	if ( function_exists( 'rbfw_get_type_label' ) ) {
+		$label = rbfw_get_type_label( $type );
+		if ( $label ) {
+			return $label;
+		}
+	}
+	return ucwords( str_replace( array( '_', '-' ), ' ', (string) $type ) );
+}
+
+/**
+ * Format a stored booking datetime string to a stable, sortable export value.
+ *
+ * @param string $value raw datetime string from ticket meta.
+ * @return string formatted "Y-m-d H:i" or empty string.
+ */
+function rbfw_export_format_datetime( $value ) {
+	if ( empty( $value ) ) {
+		return '';
+	}
+	$ts = strtotime( $value );
+	return $ts ? gmdate( 'Y-m-d H:i', $ts ) : (string) $value;
+}
+
+/**
+ * Plain-text money formatter (no HTML) for the PDF report.
+ *
+ * The PDF is rendered with mPDF's default Latin font (DejaVu / FreeSans), which
+ * covers ASCII, the Latin-1 currency characters and the Unicode "Currency
+ * Symbols" block (€, ₹, ₦ …) but NOT script-specific symbols such as the
+ * Bengali Taka sign ৳ (U+09F3) — those render as empty "tofu" boxes. So we keep
+ * the currency symbol when every character is in a font-safe range, and fall
+ * back to the ISO currency code (e.g. "BDT") otherwise, which always renders.
+ *
+ * @param float $amount value.
+ * @return string e.g. "$1,250.00" or "BDT 1,250.00".
+ */
+function rbfw_export_money( $amount ) {
+	$decimals   = function_exists( 'wc_get_price_decimals' ) ? wc_get_price_decimals() : 2;
+	$symbol     = function_exists( 'get_woocommerce_currency_symbol' ) ? html_entity_decode( get_woocommerce_currency_symbol(), ENT_QUOTES, 'UTF-8' ) : '';
+	$amount_str = number_format( (float) $amount, $decimals, '.', ',' );
+
+	if ( '' !== $symbol && rbfw_export_symbol_is_font_safe( $symbol ) ) {
+		// Most currency symbols sit before the amount; this matches WooCommerce defaults closely enough for a report.
+		return $symbol . $amount_str;
+	}
+
+	$code = function_exists( 'get_woocommerce_currency' ) ? get_woocommerce_currency() : '';
+	return ( $code ? $code . ' ' : '' ) . $amount_str;
+}
+
+/**
+ * Whether a currency symbol is renderable by the PDF's default Latin font.
+ *
+ * Font-safe ranges (all covered by DejaVu / FreeSans): ASCII (0x20–0x7E),
+ * Latin-1 Supplement + Latin Extended-A/B (0xA0–0x24F, covers ¢ £ ¥ and symbols
+ * built from Latin letters such as zł, Kč) and the Currency Symbols block
+ * (0x20A0–0x20BF, covers € ₹ ₦ …). Anything outside — e.g. Bengali ৳ (U+09F3) or
+ * Thai ฿ (U+0E3F) — is treated as unsafe so we fall back to the ISO code.
+ *
+ * @param string $symbol currency symbol.
+ * @return bool
+ */
+function rbfw_export_symbol_is_font_safe( $symbol ) {
+	$len = function_exists( 'mb_strlen' ) ? mb_strlen( $symbol, 'UTF-8' ) : strlen( $symbol );
+	for ( $i = 0; $i < $len; $i++ ) {
+		$char = function_exists( 'mb_substr' ) ? mb_substr( $symbol, $i, 1, 'UTF-8' ) : substr( $symbol, $i, 1 );
+		$cp   = rbfw_export_uniord( $char );
+		$safe = ( $cp >= 0x20 && $cp <= 0x7E )
+			|| ( $cp >= 0xA0 && $cp <= 0x24F )
+			|| ( $cp >= 0x20A0 && $cp <= 0x20BF );
+		if ( ! $safe ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Unicode code point of a single (possibly multibyte) UTF-8 character.
+ *
+ * @param string $char one character.
+ * @return int code point, or 0 on failure.
+ */
+function rbfw_export_uniord( $char ) {
+	if ( function_exists( 'mb_convert_encoding' ) ) {
+		$encoded = mb_convert_encoding( $char, 'UTF-32BE', 'UTF-8' );
+		if ( false !== $encoded && strlen( $encoded ) >= 4 ) {
+			$parsed = unpack( 'N', $encoded );
+			return $parsed ? (int) $parsed[1] : 0;
+		}
+	}
+	return ord( $char[0] );
+}
+
+/**
+ * Neutralise CSV formula injection.
+ *
+ * A spreadsheet treats a cell beginning with = + - @ (or a leading tab/CR) as a
+ * formula, so an attacker-controlled value such as "=HYPERLINK(...)" could run
+ * on open. We prefix such values with an apostrophe to force text — but only
+ * when the value is not a genuine number, so formatted amounts and numeric
+ * phone fields keep parsing correctly.
+ *
+ * @param mixed $value cell value.
+ * @return string
+ */
+function rbfw_export_csv_safe( $value ) {
+	$value = (string) $value;
+	if ( '' === $value ) {
+		return $value;
+	}
+	$first = $value[0];
+	if ( in_array( $first, array( '=', '+', '-', '@' ), true ) && ! is_numeric( $value ) ) {
+		return "'" . $value;
+	}
+	if ( "\t" === $first || "\r" === $first ) {
+		return "'" . $value;
+	}
+	return $value;
+}
+
+/**
+ * Raw numeric money for CSV (no symbol, no thousands separator) so spreadsheets parse it.
+ *
+ * @param float $amount value.
+ * @return string
+ */
+function rbfw_export_money_raw( $amount ) {
+	$decimals = function_exists( 'wc_get_price_decimals' ) ? wc_get_price_decimals() : 2;
+	return number_format( (float) $amount, $decimals, '.', '' );
+}
+
+/**
+ * Human-readable summary of the applied filters, for the file body / PDF header.
+ *
+ * @param array $filters applied filters.
+ * @return string
+ */
+function rbfw_export_filter_summary( $filters ) {
+	$parts = array();
+
+	if ( ! empty( $filters['item_id'] ) ) {
+		$title   = get_the_title( (int) $filters['item_id'] );
+		$parts[] = __( 'Item', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . ( $title ? $title : '#' . (int) $filters['item_id'] );
+	} else {
+		$parts[] = __( 'Item', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . __( 'All Items', 'booking-and-rental-manager-for-woocommerce' );
+	}
+
+	if ( ! empty( $filters['status'] ) ) {
+		$parts[] = __( 'Status', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . ucfirst( $filters['status'] );
+	}
+
+	if ( ! empty( $filters['from_month'] ) || ! empty( $filters['to_month'] ) ) {
+		$from    = ! empty( $filters['from_month'] ) ? date_i18n( 'M Y', strtotime( $filters['from_month'] . '-01' ) ) : __( 'Beginning', 'booking-and-rental-manager-for-woocommerce' );
+		$to      = ! empty( $filters['to_month'] ) ? date_i18n( 'M Y', strtotime( $filters['to_month'] . '-01' ) ) : __( 'Now', 'booking-and-rental-manager-for-woocommerce' );
+		$parts[] = __( 'Period', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . $from . ' – ' . $to;
+	} else {
+		$parts[] = __( 'Period', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . __( 'All time', 'booking-and-rental-manager-for-woocommerce' );
+	}
+
+	return implode( '   |   ', $parts );
+}
+
+/**
+ * Sum of distinct order totals in the dataset (avoids double-counting multi-item orders).
+ *
+ * @param array $rows export rows.
+ * @return float
+ */
+function rbfw_export_grand_total( $rows ) {
+	$total = 0;
+	foreach ( $rows as $row ) {
+		if ( '' !== $row['order_total'] ) {
+			$total += (float) $row['order_total'];
+		}
+	}
+	return $total;
+}
+
+/**
+ * Build the export filename stem (without extension).
+ *
+ * @return string
+ */
+function rbfw_export_filename_stem() {
+	return 'rbfw-orders-export-' . gmdate( 'Ymd-His' );
+}
+
+/**
+ * Stream the dataset as a CSV download.
+ *
+ * @param array $rows    export rows.
+ * @param array $filters applied filters.
+ */
+function rbfw_export_orders_csv( $rows, $filters ) {
+	$columns  = rbfw_export_columns();
+	$filename = rbfw_export_filename_stem() . '.csv';
+
+	nocache_headers();
+	header( 'Content-Type: text/csv; charset=utf-8' );
+	header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+
+	$out = fopen( 'php://output', 'w' );
+
+	// UTF-8 BOM so Excel renders accented characters and the currency symbol correctly.
+	fprintf( $out, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
+
+	// Context lines so the file is self-describing.
+	fputcsv( $out, array( get_bloginfo( 'name' ) . ' — ' . __( 'Orders Export', 'booking-and-rental-manager-for-woocommerce' ) ) );
+	fputcsv( $out, array( rbfw_export_filter_summary( $filters ) ) );
+	fputcsv( $out, array( __( 'Generated', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . date_i18n( 'Y-m-d H:i' ) ) );
+	fputcsv( $out, array() );
+
+	// Header row.
+	fputcsv( $out, array_values( $columns ) );
+
+	$money_keys = array( 'duration_cost', 'service_cost', 'discount', 'security_deposit', 'order_total' );
+
+	foreach ( $rows as $row ) {
+		$line = array();
+		foreach ( $columns as $key => $label ) {
+			$value = isset( $row[ $key ] ) ? $row[ $key ] : '';
+			if ( in_array( $key, $money_keys, true ) && '' !== $value ) {
+				$value = rbfw_export_money_raw( $value );
+			}
+			$line[] = rbfw_export_csv_safe( $value );
+		}
+		fputcsv( $out, $line );
+	}
+
+	// Totals line.
+	fputcsv( $out, array() );
+	fputcsv(
+		$out,
+		array(
+			__( 'Total Orders', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . rbfw_export_count_orders( $rows ),
+			__( 'Total Line Items', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . count( $rows ),
+			__( 'Grand Total', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . rbfw_export_money_raw( rbfw_export_grand_total( $rows ) ),
+		)
+	);
+
+	fclose( $out );
+}
+
+/**
+ * Count distinct orders represented in the dataset.
+ *
+ * @param array $rows export rows.
+ * @return int
+ */
+function rbfw_export_count_orders( $rows ) {
+	$ids = array();
+	foreach ( $rows as $row ) {
+		$ids[ (string) $row['order_no'] ] = true;
+	}
+	return count( $ids );
+}
+
+/**
+ * Render the dataset as a PDF (mPDF) download, or an auto-print HTML fallback.
+ *
+ * @param array $rows    export rows.
+ * @param array $filters applied filters.
+ */
+function rbfw_export_orders_pdf( $rows, $filters ) {
+	$body_html = rbfw_export_pdf_body_html( $rows, $filters );
+
+	// Use mPDF when the companion PDF plugin is active (true downloadable PDF).
+	if ( class_exists( '\Mpdf\Mpdf' ) ) {
+		try {
+			$upload  = wp_upload_dir();
+			$tmp_dir = ( isset( $upload['basedir'] ) ? $upload['basedir'] : sys_get_temp_dir() ) . '/rbfw-mpdf-tmp';
+			if ( ! file_exists( $tmp_dir ) ) {
+				wp_mkdir_p( $tmp_dir );
+			}
+
+			$mpdf = new \Mpdf\Mpdf(
+				array(
+					'mode'          => 'utf-8',
+					'format'        => 'A4-L',
+					'margin_top'    => 30,
+					'margin_bottom' => 16,
+					'margin_left'   => 8,
+					'margin_right'  => 8,
+					'tempDir'       => is_writable( $tmp_dir ) ? $tmp_dir : null,
+				)
+			);
+			$mpdf->SetTitle( get_bloginfo( 'name' ) . ' — ' . __( 'Orders Export', 'booking-and-rental-manager-for-woocommerce' ) );
+			$mpdf->SetHTMLHeader( rbfw_export_pdf_header_html( $filters ) );
+			$mpdf->SetHTMLFooter( rbfw_export_pdf_footer_html() );
+			$mpdf->WriteHTML( $body_html );
+			$mpdf->Output( rbfw_export_filename_stem() . '.pdf', 'D' );
+			return;
+		} catch ( \Exception $e ) {
+			// Fall through to the print fallback on any rendering error.
+			$body_html .= '';
+		}
+	}
+
+	// Fallback: a print-optimised HTML page that the browser can "Save as PDF".
+	rbfw_export_pdf_print_fallback( $rows, $filters );
+}
+
+/**
+ * Shared inline CSS for the PDF table (mPDF supports a CSS subset).
+ *
+ * @return string
+ */
+function rbfw_export_pdf_css() {
+	return '
+		body { font-family: sans-serif; color: #1f2430; font-size: 8.5px; }
+		.rbfw_exp_meta { color: #5a6072; font-size: 9px; margin: 0 0 6px; }
+		table.rbfw_exp { width: 100%; border-collapse: collapse; }
+		table.rbfw_exp th { background: #4F6EF7; color: #fff; font-size: 8px; text-align: left; padding: 5px 4px; }
+		table.rbfw_exp td { border-bottom: 0.5px solid #e3e7ef; padding: 4px; font-size: 8px; vertical-align: top; }
+		table.rbfw_exp tr:nth-child(even) td { background: #f6f8fc; }
+		.rbfw_exp_num { text-align: right; }
+		.rbfw_exp_tot td { font-weight: bold; background: #eef2ff; border-top: 1px solid #4F6EF7; }
+		.rbfw_exp_empty { padding: 16px; text-align: center; color: #8a90a2; }
+	';
+}
+
+/**
+ * mPDF running page header.
+ *
+ * @param array $filters applied filters.
+ * @return string
+ */
+function rbfw_export_pdf_header_html( $filters ) {
+	$title   = esc_html( get_bloginfo( 'name' ) ) . ' — ' . esc_html__( 'Orders Export', 'booking-and-rental-manager-for-woocommerce' );
+	$summary = esc_html( rbfw_export_filter_summary( $filters ) );
+	$gen     = esc_html__( 'Generated', 'booking-and-rental-manager-for-woocommerce' ) . ': ' . esc_html( date_i18n( 'Y-m-d H:i' ) );
+
+	// A two-cell table keeps the title (left) and the generated date (right)
+	// reliably separated in mPDF, where CSS float in a page header is flaky.
+	return '<table style="width:100%;font-family:sans-serif;border-bottom:1px solid #4F6EF7;">'
+		. '<tr>'
+		. '<td style="font-size:12px;font-weight:bold;color:#1f2430;padding:0 12px 5px 0;vertical-align:bottom;">' . $title . '</td>'
+		. '<td style="font-size:8px;color:#5a6072;text-align:right;padding:0 0 5px 12px;vertical-align:bottom;white-space:nowrap;">' . $gen . '</td>'
+		. '</tr>'
+		. '<tr><td colspan="2" style="font-size:8px;color:#5a6072;padding:0 0 5px;">' . $summary . '</td></tr>'
+		. '</table>';
+}
+
+/**
+ * mPDF running page footer with page numbers.
+ *
+ * @return string
+ */
+function rbfw_export_pdf_footer_html() {
+	return '<div style="font-family:sans-serif;font-size:7.5px;color:#8a90a2;border-top:0.5px solid #e3e7ef;padding-top:3px;text-align:right;">'
+		. esc_html__( 'Page', 'booking-and-rental-manager-for-woocommerce' ) . ' {PAGENO} / {nbpg}</div>';
+}
+
+/**
+ * Build the PDF body table HTML.
+ *
+ * @param array $rows    export rows.
+ * @param array $filters applied filters.
+ * @return string
+ */
+function rbfw_export_pdf_body_html( $rows, $filters ) {
+	$columns    = rbfw_export_columns();
+	$money_keys = array( 'duration_cost', 'service_cost', 'discount', 'security_deposit', 'order_total' );
+	$num_keys   = array( 'qty', 'total_days' );
+
+	$html  = '<style>' . rbfw_export_pdf_css() . '</style>';
+	$html .= '<table class="rbfw_exp"><thead><tr>';
+	foreach ( $columns as $label ) {
+		$html .= '<th>' . esc_html( $label ) . '</th>';
+	}
+	$html .= '</tr></thead><tbody>';
+
+	if ( empty( $rows ) ) {
+		$html .= '<tr><td class="rbfw_exp_empty" colspan="' . count( $columns ) . '">'
+			. esc_html__( 'No orders match the selected filters.', 'booking-and-rental-manager-for-woocommerce' )
+			. '</td></tr>';
+	} else {
+		foreach ( $rows as $row ) {
+			$html .= '<tr>';
+			foreach ( $columns as $key => $label ) {
+				$value = isset( $row[ $key ] ) ? $row[ $key ] : '';
+				$class = '';
+				if ( in_array( $key, $money_keys, true ) ) {
+					$value = ( '' === $value ) ? '' : rbfw_export_money( $value );
+					$class = ' class="rbfw_exp_num"';
+				} elseif ( in_array( $key, $num_keys, true ) ) {
+					$class = ' class="rbfw_exp_num"';
+				}
+				$html .= '<td' . $class . '>' . esc_html( $value ) . '</td>';
+			}
+			$html .= '</tr>';
+		}
+
+		// Totals row spanning to the order-total column.
+		$keys      = array_keys( $columns );
+		$total_pos = array_search( 'order_total', $keys, true );
+		$lead_span = false === $total_pos ? count( $columns ) : $total_pos;
+		$html     .= '<tr class="rbfw_exp_tot"><td colspan="' . $lead_span . '">'
+			. esc_html__( 'Grand Total', 'booking-and-rental-manager-for-woocommerce' )
+			. ' (' . esc_html( rbfw_export_count_orders( $rows ) ) . ' '
+			. esc_html__( 'orders', 'booking-and-rental-manager-for-woocommerce' ) . ')</td>'
+			. '<td class="rbfw_exp_num">' . esc_html( rbfw_export_money( rbfw_export_grand_total( $rows ) ) ) . '</td>'
+			. '<td></td></tr>';
+	}
+
+	$html .= '</tbody></table>';
+
+	return $html;
+}
+
+/**
+ * Print-optimised HTML page used when mPDF is not available.
+ *
+ * Sends a normal HTML document that triggers window.print() on load, letting the
+ * user choose "Save as PDF". This keeps the PDF option functional in the free
+ * plugin without bundling a PDF library.
+ *
+ * @param array $rows    export rows.
+ * @param array $filters applied filters.
+ */
+function rbfw_export_pdf_print_fallback( $rows, $filters ) {
+	nocache_headers();
+	header( 'Content-Type: text/html; charset=utf-8' );
+
+	$title = get_bloginfo( 'name' ) . ' — ' . __( 'Orders Export', 'booking-and-rental-manager-for-woocommerce' );
+
+	echo '<!doctype html><html><head><meta charset="utf-8"><title>' . esc_html( $title ) . '</title>';
+	echo '<style>'
+		. 'body{font-family:Arial,Helvetica,sans-serif;color:#1f2430;margin:20px;}'
+		. 'h1{font-size:18px;margin:0 0 4px;}'
+		. '.rbfw_exp_meta{color:#5a6072;font-size:12px;margin:0 0 14px;}'
+		. 'table{width:100%;border-collapse:collapse;font-size:11px;}'
+		. 'th{background:#4F6EF7;color:#fff;text-align:left;padding:6px 5px;}'
+		. 'td{border-bottom:1px solid #e3e7ef;padding:5px;}'
+		. 'tr:nth-child(even) td{background:#f6f8fc;}'
+		. '.rbfw_exp_num{text-align:right;}'
+		. '.rbfw_exp_tot td{font-weight:bold;background:#eef2ff;}'
+		. '@media print{.rbfw_exp_noprint{display:none;}}'
+		. '.rbfw_exp_btn{display:inline-block;margin:0 0 16px;padding:8px 16px;background:#4F6EF7;color:#fff;border:0;border-radius:6px;cursor:pointer;font-size:13px;}'
+		. rbfw_export_pdf_css() // Static, trusted CSS string — not user input.
+		. '</style></head><body>';
+
+	echo '<button class="rbfw_exp_btn rbfw_exp_noprint" onclick="window.print()">'
+		. esc_html__( 'Print / Save as PDF', 'booking-and-rental-manager-for-woocommerce' ) . '</button>';
+	echo '<h1>' . esc_html( $title ) . '</h1>';
+	echo '<p class="rbfw_exp_meta">' . esc_html( rbfw_export_filter_summary( $filters ) )
+		. '<br>' . esc_html__( 'Generated', 'booking-and-rental-manager-for-woocommerce' ) . ': '
+		. esc_html( date_i18n( 'Y-m-d H:i' ) ) . '</p>';
+
+	// Reuse the same table markup as the mPDF body. Every dynamic value inside
+	// rbfw_export_pdf_body_html() is passed through esc_html(); the surrounding
+	// markup is static, so this builder output is safe to emit directly.
+	echo rbfw_export_pdf_body_html( $rows, $filters ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped builder output.
+
+	echo '<script>window.addEventListener("load",function(){setTimeout(function(){window.print();},250);});</script>';
+	echo '</body></html>';
+}

--- a/inc/rbfw_order_meta.php
+++ b/inc/rbfw_order_meta.php
@@ -1220,8 +1220,8 @@ function fetch_order_details_callback() {
                             foreach ( $variation_info as $key => $value ) {
                                 ?>
                                 <tr>
-                                    <td><strong><?php echo esc_html( $value['field_label'] ); ?></strong></td>
-                                    <td><?php echo esc_html( $value['field_value'] ); ?></td>
+                                    <td><strong><?php echo esc_html( $value['field_label'] ?? '' ); ?></strong></td>
+                                    <td><?php echo esc_html( $value['field_value'] ?? '' ); ?></td>
                                 </tr>
                             <?php }
                         } ?>
@@ -1789,8 +1789,8 @@ function rbfw_order_meta_box_callback() {
                         foreach ( $variation_info as $key => $value ) {
                             ?>
                             <tr>
-                                <td><strong><?php echo esc_html( $value['field_label'] ); ?></strong></td>
-                                <td><?php echo esc_html( $value['field_value'] ); ?></td>
+                                <td><strong><?php echo esc_html( $value['field_label'] ?? '' ); ?></strong></td>
+                                <td><?php echo esc_html( $value['field_value'] ?? '' ); ?></td>
                             </tr>
                         <?php }
                     } ?>

--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -142,6 +142,14 @@
                                 echo esc_html( sprintf( _n( '%s Order', '%s Orders', $total_orders, 'booking-and-rental-manager-for-woocommerce' ), number_format_i18n( $total_orders ) ) );
                             ?></span>
                         </div>
+                        <?php if ( function_exists( 'rbfw_pro_tab_menu_list' ) ) { ?>
+                        <div class="rbfw_ol_header_actions">
+                            <button type="button" id="rbfw_ol_export_btn" class="rbfw_ol_export_btn">
+                                <?php echo rbfw_inv_icon( 'download' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                                <span><?php esc_html_e( 'Export', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                            </button>
+                        </div>
+                        <?php } ?>
                     </div>
                     <hr class="wp-header-end">
 
@@ -388,6 +396,74 @@
                                 <div class="rbfw_ol_status_modal_foot">
                                     <button type="button" class="rbfw_ol_status_cancel rbfw_ol_edit_cancel"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
                                     <button type="button" class="rbfw_ol_edit_save"><?php esc_html_e( 'Save Changes', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Export modal -->
+                        <div id="rbfw_ol_export_modal" class="rbfw_ol_status_modal rbfw_ol_export_modal" style="display:none;" aria-hidden="true">
+                            <div class="rbfw_ol_status_modal_overlay"></div>
+                            <div class="rbfw_ol_status_modal_box rbfw_ol_export_box" role="dialog" aria-modal="true" aria-labelledby="rbfw_ol_export_modal_title">
+                                <div class="rbfw_ol_status_modal_head">
+                                    <span class="rbfw_ol_status_modal_ic"><?php echo rbfw_inv_icon( 'download' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                                    <h2 id="rbfw_ol_export_modal_title"><?php esc_html_e( 'Export Orders', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+                                    <button type="button" class="rbfw_ol_status_modal_close rbfw_ol_export_close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></button>
+                                </div>
+                                <div class="rbfw_ol_status_modal_body rbfw_ol_export_body">
+                                    <label class="rbfw_ol_export_label"><?php esc_html_e( 'Export format', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                                    <div class="rbfw_ol_export_formats">
+                                        <label class="rbfw_ol_export_fmt is-active">
+                                            <input type="radio" name="rbfw_ol_export_format" value="csv" checked>
+                                            <span class="rbfw_ol_export_fmt_ic"><?php echo rbfw_inv_icon( 'file_csv' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                                            <span class="rbfw_ol_export_fmt_txt">
+                                                <span class="rbfw_ol_export_fmt_title"><?php esc_html_e( 'CSV', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                                <span class="rbfw_ol_export_fmt_sub"><?php esc_html_e( 'Spreadsheet (Excel, Sheets)', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                            </span>
+                                        </label>
+                                        <label class="rbfw_ol_export_fmt">
+                                            <input type="radio" name="rbfw_ol_export_format" value="pdf">
+                                            <span class="rbfw_ol_export_fmt_ic"><?php echo rbfw_inv_icon( 'file_pdf' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                                            <span class="rbfw_ol_export_fmt_txt">
+                                                <span class="rbfw_ol_export_fmt_title"><?php esc_html_e( 'PDF', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                                <span class="rbfw_ol_export_fmt_sub"><?php esc_html_e( 'Printable document', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                            </span>
+                                        </label>
+                                    </div>
+
+                                    <label class="rbfw_ol_export_label" for="rbfw_ol_export_item"><?php esc_html_e( 'Item', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                                    <select id="rbfw_ol_export_item" class="rbfw_ol_export_select">
+                                        <option value="0"><?php esc_html_e( 'All Items', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                        <?php
+                                        $rbfw_export_items = get_posts( array( 'post_type' => 'rbfw_item', 'numberposts' => -1, 'orderby' => 'title', 'order' => 'ASC', 'post_status' => 'publish' ) );
+                                        foreach ( $rbfw_export_items as $rbfw_export_item ) : ?>
+                                            <option value="<?php echo esc_attr( $rbfw_export_item->ID ); ?>"><?php echo esc_html( get_the_title( $rbfw_export_item->ID ) ); ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+
+                                    <label class="rbfw_ol_export_label" for="rbfw_ol_export_status"><?php esc_html_e( 'Status', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                                    <select id="rbfw_ol_export_status" class="rbfw_ol_export_select">
+                                        <option value=""><?php esc_html_e( 'All Statuses', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+                                        <?php if ( function_exists( 'wc_get_order_statuses' ) ) :
+                                            foreach ( wc_get_order_statuses() as $rbfw_es_key => $rbfw_es_label ) : ?>
+                                                <option value="<?php echo esc_attr( str_replace( 'wc-', '', $rbfw_es_key ) ); ?>"><?php echo esc_html( $rbfw_es_label ); ?></option>
+                                            <?php endforeach;
+                                        endif; ?>
+                                    </select>
+
+                                    <label class="rbfw_ol_export_label"><?php esc_html_e( 'Month range', 'booking-and-rental-manager-for-woocommerce' ); ?> <span class="rbfw_ol_export_hint">(<?php esc_html_e( 'optional', 'booking-and-rental-manager-for-woocommerce' ); ?>)</span></label>
+                                    <div class="rbfw_ol_export_months">
+                                        <input type="month" id="rbfw_ol_export_from" class="rbfw_ol_export_month" aria-label="<?php esc_attr_e( 'From month', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                        <span class="rbfw_ol_export_month_sep">&ndash;</span>
+                                        <input type="month" id="rbfw_ol_export_to" class="rbfw_ol_export_month" aria-label="<?php esc_attr_e( 'To month', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                                    </div>
+                                    <p class="rbfw_ol_export_note"><?php esc_html_e( 'Filters by booking start date. Leave blank to export all dates.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+                                </div>
+                                <div class="rbfw_ol_status_modal_foot">
+                                    <button type="button" class="rbfw_ol_status_cancel rbfw_ol_export_cancel"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                    <button type="button" class="rbfw_ol_export_do">
+                                        <?php echo rbfw_inv_icon( 'download' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?>
+                                        <span><?php esc_html_e( 'Download', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/lib/classes/class-thankyou-page.php
+++ b/lib/classes/class-thankyou-page.php
@@ -367,8 +367,8 @@
 										foreach ( $variation_info as $key => $value ) {
 											?>
                                             <tr>
-                                                <td><strong><?php echo esc_html( $value['field_label'] ); ?></strong></td>
-                                                <td><?php echo esc_html( $value['field_value'] ); ?></td>
+                                                <td><strong><?php echo esc_html( $value['field_label'] ?? '' ); ?></strong></td>
+                                                <td><?php echo esc_html( $value['field_value'] ?? '' ); ?></td>
                                             </tr>
 										<?php }
 									} ?>
@@ -671,8 +671,8 @@
 								foreach ( $variation_info as $key => $value ) {
 									?>
                                     <tr>
-                                        <td><strong><?php echo esc_html( $value['field_label'] ); ?></strong></td>
-                                        <td><?php echo esc_html( $value['field_value'] ); ?></td>
+                                        <td><strong><?php echo esc_html( $value['field_label'] ?? '' ); ?></strong></td>
+                                        <td><?php echo esc_html( $value['field_value'] ?? '' ); ?></td>
                                     </tr>
 								<?php }
 							} ?>

--- a/templates/cart_page.php
+++ b/templates/cart_page.php
@@ -674,8 +674,8 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
         <?php if(!empty($variation_info)){ ?>
             <?php foreach ($variation_info as $key => $value) { ?>
                 <tr>
-                    <th><?php echo esc_html($value['field_label']);  ?></th>
-                    <td><?php echo esc_html($value['field_value']); ?></td>
+                    <th><?php echo esc_html($value['field_label'] ?? '');  ?></th>
+                    <td><?php echo esc_html($value['field_value'] ?? ''); ?></td>
                 </tr>
             <?php } ?>
         <?php }  ?>

--- a/templates/forms/multi-day-registration.php
+++ b/templates/forms/multi-day-registration.php
@@ -572,18 +572,25 @@ $rbfw_buffer_time = get_post_meta( $rbfw_id, 'rbfw_buffer_time', true ) ? maybe_
                     <?php if($rbfw_enable_variations == 'yes' && !empty($rbfw_variations_data)){ ?>
                         <div class="rbfw-variations-content-wrapper">
                             <?php foreach ($rbfw_variations_data as $data_arr_one) {
+                                // Some saved/legacy variation rows may omit one or more keys; default
+                                // them so the template never raises "Undefined array key" notices.
+                                $field_label    = isset($data_arr_one['field_label']) ? $data_arr_one['field_label'] : '';
+                                $field_id       = isset($data_arr_one['field_id']) ? $data_arr_one['field_id'] : '';
+                                $field_values   = !empty($data_arr_one['value']) && is_array($data_arr_one['value']) ? $data_arr_one['value'] : array();
                                 $selected_value = !empty($data_arr_one['selected_value']) ? $data_arr_one['selected_value'] : '';
                                 ?>
                                 <div class="item">
-                                    <div class="rbfw-single-right-heading"><?php echo esc_html($data_arr_one['field_label']); ?></div>
+                                    <div class="rbfw-single-right-heading"><?php echo esc_html($field_label); ?></div>
                                     <div class="item-content rbfw-p-relative">
-                                        <?php if(!empty($data_arr_one['value'])){  ?>
-                                            <select class="rbfw-select rbfw_variation_field" required name="<?php echo esc_attr($data_arr_one['field_id']); ?>" id="<?php echo esc_attr($data_arr_one['field_id']); ?>" data-field="<?php echo esc_attr($data_arr_one['field_label']); ?>">
+                                        <?php if(!empty($field_values)){  ?>
+                                            <select class="rbfw-select rbfw_variation_field" required name="<?php echo esc_attr($field_id); ?>" id="<?php echo esc_attr($field_id); ?>" data-field="<?php echo esc_attr($field_label); ?>">
                                                 <?php if(empty($selected_value)){ ?>
-                                                    <option value=""><?php echo esc_html(__('Choose','booking-and-rental-manager-for-woocommerce').' '.$data_arr_one['field_label']); ?></option>
+                                                    <option value=""><?php echo esc_html(__('Choose','booking-and-rental-manager-for-woocommerce').' '.$field_label); ?></option>
                                                 <?php } ?>
-                                                <?php foreach ($data_arr_one['value'] as $data_arr_two) { ?>
-                                                    <option class="rbfw_variant" value="<?php echo esc_attr($data_arr_two['name']); ?>" <?php if($data_arr_two['name'] == $selected_value){ echo 'selected'; } ?> ><?php echo esc_html($data_arr_two['name']); ?></option>
+                                                <?php foreach ($field_values as $data_arr_two) {
+                                                    $variant_name = isset($data_arr_two['name']) ? $data_arr_two['name'] : '';
+                                                    ?>
+                                                    <option class="rbfw_variant" value="<?php echo esc_attr($variant_name); ?>" <?php if($variant_name !== '' && $variant_name == $selected_value){ echo 'selected'; } ?> ><?php echo esc_html($variant_name); ?></option>
                                                 <?php } ?>
                                             </select>
                                         <?php } ?>


### PR DESCRIPTION


ORDER LIST EXPORT (CSV / PDF)
New export feature on the Order List page (edit.php?post_type=rbfw_item&page=rbfw_order): a header "Export" button opens a modern, centered, mobile-responsive modal to download the orders as CSV or PDF, with item-wise and month-range filtering.

- inc/rbfw_order_export.php (new): admin_post_rbfw_export_orders download handler.
    * Security: manage_options capability check + dedicated nonce (rbfw_export_orders_action); all inputs sanitised (absint, sanitize_key, ^\d{4}-\d{2}$ month regex).
    * Dataset is one row per booking line item (so the item-wise filter is meaningful for multi-item orders); each row carries its parent order number. Filters: item, status, and month range on the booking start date (falls back to order-created date when a booking has no start).
    * CSV: streamed with a UTF-8 BOM (Excel-friendly), raw numeric amounts, a self-describing header block + grand-total line, and CSV formula-injection protection (values beginning = + - @ that are not numbers are neutralised).
    * PDF: rendered with mPDF when the magepeople-pdf-support companion plugin is active (true downloadable PDF, landscape A4, running header/footer, totals), with a graceful auto-print HTML fallback when mPDF is unavailable so the free plugin keeps working stand-alone.
    * Currency in the PDF is font-safe: the symbol is kept when the PDF font covers it (ASCII, Latin-1/Extended, the Unicode Currency-Symbols block -> $, EUR, GBP, ₹, ₦, zł, Kč) and falls back to the ISO code for script-specific symbols such as the Bengali Taka ৳ (U+09F3), which would otherwise render as empty "tofu".
- inc/rbfw_file_include.php: register the new export module.
- inc/RBFW_Dependencies.php: localise admin_post_url + nonce_export_orders on the order page.
- lib/classes/class-admin-menu.php: header Export button + Export modal markup (format cards, item select, status select, month from/to, download/cancel).
- admin/js/rbfw_order.js: export controller — opens the modal with display:flex so it centers like the other modals, pre-fills from the active on-page filters, toggles the format cards, and builds the admin-post download URL.
- admin/css/rbfw_order.css: export button, modal, format cards, month inputs; the export box is scrollable (max-height) and collapses cleanly on mobile.
- inc/rbfw_inventory_functions.php: new download / file_csv / file_pdf inline-SVG icons for the export UI.

FIX: "Undefined array key 'field_label'" notices from incomplete variation rows The product-variations repeater can persist blank/partial rows (an untouched "add new" row, or a row whose label was cleared). That malformed meta then raised PHP notices wherever it was read — the single-item form, cart, checkout review, thank-you page, WC line-item meta, the admin order detail panel and the inventory screens. Fixed at four layers so one deploy resolves it everywhere:

- Root cause (save time): new rbfw_clean_variations_data() in inc/rbfw_functions.php drops rows without a usable label and prunes value entries that have no name. It is applied in both save paths — admin/settings/Inventory.php (classic editor) and admin/RBFW_Modern_Editor.php (modern editor) — so newly saved items never store malformed rows.
- Builder hardening: the $variation_info builder in Frontend/RBFW_Woocommerse.php now skips incomplete rows and guards field_id / value / field_label / name, so existing bad data no longer warns during add-to-cart.
- Defensive guards on every reader (for legacy data already in the database): templates/forms/multi-day-registration.php, templates/cart_page.php, lib/classes/class-thankyou-page.php (both blocks), Frontend/RBFW_Woocommerse.php (line-item meta), inc/rbfw_order_meta.php (both order-detail blocks), inc/class-bike-car-md-function.php (order builder) and inc/rbfw_inventory_functions.php (stock engine + inventory modal).

Behaviour is unchanged for valid data; only blank/partial variation rows are dropped. Sanitisation is preserved (RBFW_Function::data_sanitize still runs first; the cleaner only filters the already-sanitised result).