### PR TITLE
feat(order-list): add revenue summary dashboard and remove redundant ……Reports submenu

### DIFF
--- a/admin/css/rbfw_order.css
+++ b/admin/css/rbfw_order.css
@@ -58,6 +58,52 @@
     font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 20px;
 }
 
+/* ── Revenue summary card ── */
+.rbfw_ol_revenue {
+    display: flex; align-items: center; gap: 22px; flex-wrap: wrap;
+    background: linear-gradient(120deg, var(--rbfw-accent) 0%, var(--rbfw-purple) 100%);
+    border-radius: var(--rbfw-radius); padding: 20px 24px; margin-bottom: 16px;
+    box-shadow: 0 8px 24px rgba(79,110,247,.25); color: #fff;
+}
+.rbfw_ol_rev_main { display: flex; align-items: center; gap: 16px; flex: 0 0 auto; }
+.rbfw_ol_rev_ic {
+    width: 54px; height: 54px; border-radius: 14px; flex-shrink: 0;
+    display: grid; place-items: center; background: rgba(255,255,255,.18);
+}
+.rbfw_ol_rev_ic svg.rbfw_inv_ic { width: 26px; height: 26px; }
+.rbfw_ol_rev_main_txt { min-width: 0; }
+.rbfw_ol_rev_label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .6px; opacity: .85; }
+.rbfw_ol_rev_value { font-size: 30px; font-weight: 800; line-height: 1.15; margin-top: 2px; }
+.rbfw_ol_rev_value .woocommerce-Price-amount,
+.rbfw_ol_rev_value bdi { color: #fff; }
+.rbfw_ol_rev_sub { font-size: 11.5px; font-weight: 500; opacity: .8; margin-top: 3px; }
+
+.rbfw_ol_rev_breakdown {
+    display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr));
+    gap: 10px; flex: 1 1 360px;
+}
+.rbfw_ol_rev_chip {
+    background: rgba(255,255,255,.14); border: 1px solid rgba(255,255,255,.18);
+    border-radius: 10px; padding: 10px 12px; display: flex; flex-direction: column; gap: 5px;
+}
+.rbfw_ol_rev_chip_lbl {
+    font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: .4px;
+    opacity: .9; display: inline-flex; align-items: center; gap: 5px;
+}
+.rbfw_ol_rev_chip_lbl svg.rbfw_inv_ic { width: 13px; height: 13px; }
+.rbfw_ol_rev_chip_val { font-size: 16px; font-weight: 700; }
+.rbfw_ol_rev_chip_val .woocommerce-Price-amount,
+.rbfw_ol_rev_chip_val bdi { color: #fff; }
+
+@media (max-width: 1100px) {
+    .rbfw_ol_rev_breakdown { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+    .rbfw_ol_revenue { padding: 16px; gap: 16px; }
+    .rbfw_ol_rev_value { font-size: 26px; }
+    .rbfw_ol_rev_breakdown { grid-template-columns: 1fr 1fr; flex-basis: 100%; }
+}
+
 /* ── Stat cards ── */
 .rbfw_ol_stats {
     display: grid; grid-template-columns: repeat(5, 1fr);

--- a/admin/js/rbfw_order.js
+++ b/admin/js/rbfw_order.js
@@ -433,7 +433,7 @@
             deleteCtx.row = deleteCtx.postId = null;
         }
 
-        function applyStats(stats, headerText) {
+        function applyStats(stats, headerText, revenue) {
             if (stats) {
                 Object.keys(stats).forEach(function (key) {
                     var card = root.querySelector('[data-stat="' + key + '"]');
@@ -445,6 +445,12 @@
                         amt.innerHTML = stats[key].amount;
                         amt.className = 'rbfw_ol_stat_amt ' + (stats[key].pos ? 'pos' : 'zero');
                     }
+                });
+            }
+            if (revenue) {
+                Object.keys(revenue).forEach(function (rk) {
+                    var el = root.querySelector('[data-rev="' + rk + '"]');
+                    if (el) { el.innerHTML = revenue[rk]; }
                 });
             }
             var headBadge = root.querySelector('.rbfw_ol_badge_count');
@@ -479,7 +485,7 @@
                     if (deleteCtx.row) { deleteCtx.row.parentNode.removeChild(deleteCtx.row); }
                     var detail = document.getElementById('order-details-' + pid);
                     if (detail) { detail.parentNode.removeChild(detail); }
-                    applyStats(res.data.stats, res.data.header);
+                    applyStats(res.data.stats, res.data.header, res.data.revenue);
                     closeDeleteModal();
                     render();
                 })

--- a/inc/rbfw_order_meta.php
+++ b/inc/rbfw_order_meta.php
@@ -104,16 +104,24 @@ function rbfw_update_order_status_callback() {
  */
 function rbfw_calculate_order_list_stats() {
     $stats = array(
-        'total_orders'     => 0, 'total_amount'     => 0,
-        'completed_orders' => 0, 'completed_amount' => 0,
-        'cancelled_orders' => 0, 'cancelled_amount' => 0,
-        'pending_orders'   => 0, 'pending_amount'   => 0,
-        'refunded_orders'  => 0, 'refunded_amount'  => 0,
+        'total_orders'      => 0, 'total_amount'      => 0,
+        'completed_orders'  => 0, 'completed_amount'  => 0,
+        'cancelled_orders'  => 0, 'cancelled_amount'  => 0,
+        'pending_orders'    => 0, 'pending_amount'    => 0,
+        'refunded_orders'   => 0, 'refunded_amount'   => 0,
+        // Revenue summary ( "earned" money = completed + processing ).
+        'processing_orders' => 0, 'processing_amount' => 0,
+        'paid_orders'       => 0,
+        'net_revenue'       => 0,
+        'this_month_revenue'=> 0,
+        'avg_order_value'   => 0,
     );
 
     if ( ! function_exists( 'wc_get_order' ) ) {
         return $stats;
     }
+
+    $this_ym = function_exists( 'current_time' ) ? current_time( 'Y-m' ) : gmdate( 'Y-m' );
 
     $query = new WP_Query( array(
         'post_type'      => 'rbfw_order',
@@ -137,7 +145,9 @@ function rbfw_calculate_order_list_stats() {
         $stats['total_orders']++;
         $stats['total_amount'] += $order_total;
 
-        switch ( str_replace( 'wc-', '', $status ) ) {
+        $norm = str_replace( 'wc-', '', $status );
+
+        switch ( $norm ) {
             case 'completed':
                 $stats['completed_orders']++;
                 $stats['completed_amount'] += $order_total;
@@ -159,8 +169,24 @@ function rbfw_calculate_order_list_stats() {
                 $stats['pending_amount'] += $order_total;
                 break;
         }
+
+        // Revenue: count completed + processing as earned/collected money.
+        if ( 'completed' === $norm || 'processing' === $norm ) {
+            $stats['net_revenue'] += $order_total;
+            $stats['paid_orders']++;
+            if ( 'processing' === $norm ) {
+                $stats['processing_orders']++;
+                $stats['processing_amount'] += $order_total;
+            }
+            $created = $order->get_date_created();
+            if ( $created && $created->date( 'Y-m' ) === $this_ym ) {
+                $stats['this_month_revenue'] += $order_total;
+            }
+        }
     }
     wp_reset_postdata();
+
+    $stats['avg_order_value'] = $stats['paid_orders'] > 0 ? ( $stats['net_revenue'] / $stats['paid_orders'] ) : 0;
 
     return $stats;
 }
@@ -219,6 +245,18 @@ function rbfw_delete_order_callback() {
             'completed' => $fmt( $stats['completed_orders'], $stats['completed_amount'] ),
             'pending'   => $fmt( $stats['pending_orders'], $stats['pending_amount'] ),
             'refunded'  => $fmt( $stats['refunded_orders'], $stats['refunded_amount'] ),
+        ),
+        'revenue' => array(
+            'net'        => wc_price( $stats['net_revenue'] ),
+            'completed'  => wc_price( $stats['completed_amount'] ),
+            'processing' => wc_price( $stats['processing_amount'] ),
+            'month'      => wc_price( $stats['this_month_revenue'] ),
+            'avg'        => wc_price( $stats['avg_order_value'] ),
+            'paid_label' => esc_html( sprintf(
+                /* translators: %s: number of paid (completed + processing) orders. */
+                _n( 'From %s paid order', 'From %s paid orders', $stats['paid_orders'], 'booking-and-rental-manager-for-woocommerce' ),
+                number_format_i18n( $stats['paid_orders'] )
+            ) ),
         ),
     ) );
 }

--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -17,6 +17,9 @@
 				add_action( 'add_meta_boxes', array( $this, 'add_meta_box_func' ) );
 				add_action( 'admin_init', array( $this, 'admin_init' ) );
 				add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+				// Hide the Pro "Reports" submenu — its data now lives in the Order List.
+				// Runs late ( priority 999 ) so it removes the entry after Pro registers it.
+				add_action( 'admin_menu', array( $this, 'rbfw_remove_reports_submenu' ), 999 );
 				add_action( 'admin_enqueue_scripts', array( $this, 'rbfw_admin_enqueue_scripts' ) );
 				/* WooCommerce Action and Filter */
 				add_filter( 'woocommerce_order_status_changed', array( $this, 'rbfw_wc_status_update' ), 10, 4 );
@@ -44,6 +47,19 @@
 				// End PRO plugin is activated
 			}
 
+			/**
+			 * Remove the Pro "Reports" submenu.
+			 *
+			 * The Reports (attendee/customer) dashboard has been superseded by the
+			 * Order List page — booking details, status management, filtering,
+			 * export and the revenue summary all live there now — so the duplicate
+			 * submenu is hidden. Runs at admin_menu priority 999, after the Pro
+			 * plugin has registered it on rbfw_admin_menu_after_inventory.
+			 */
+			public function rbfw_remove_reports_submenu() {
+				remove_submenu_page( 'edit.php?post_type=rbfw_item', 'reports' );
+			}
+
 			public function rbfw_admin_enqueue_scripts( $hook ) {
 				// The Order List page is fully styled by the modern admin/css/rbfw_order.css
 				// (scoped under .rbfw_ol). The legacy rbfw-order-list-modern.css was retired:
@@ -68,69 +84,26 @@
 					'post_status'    => array('publish', 'private', 'draft', 'pending', 'future', 'inherit')
 				);
 				$query                = new WP_Query( $args );
-				
-				// Calculate stats
-				$total_orders = 0;
-				$completed_orders = 0;
-				$cancelled_orders = 0;
-				$pending_orders = 0;
-				$refunded_orders = 0;
-				$total_amount = 0;
-				$completed_amount = 0;
-				$cancelled_amount = 0;
-				$pending_amount = 0;
-				$refunded_amount = 0;
-				
-				if ( $query->have_posts() ) {
-					while ( $query->have_posts() ) {
-						$query->the_post();
-						global $post;
-						$post_id = $post->ID;
-						$wc_order_id = get_post_meta( $post_id, 'rbfw_order_id', true );
-						$order = wc_get_order($wc_order_id);
-						
-						if ($order) {
-							$status = $order->get_status();
-							
-							// Skip orders with trash status
-							if ($status === 'trash' || $status === 'wc-trash') {
-								continue;
-							}
-							
-							$total_orders++;
-							$order_total = $order->get_total();
-							$total_amount += $order_total;
-							
-							// Normalize status by removing 'wc-' prefix if present
-							$normalized_status = str_replace('wc-', '', $status);
-							
-							// Count orders and amounts by normalized status
-							switch($normalized_status) {
-								case 'completed':
-									$completed_orders++;
-									$completed_amount += $order_total;
-									break;
-								case 'cancelled':
-								case 'canceled':
-								case 'failed':
-									$cancelled_orders++;
-									$cancelled_amount += $order_total;
-									break;
-								case 'refunded':
-									$refunded_orders++;
-									$refunded_amount += $order_total;
-									break;
-								case 'pending':
-								case 'on-hold':
-								case 'processing':
-									$pending_orders++;
-									$pending_amount += $order_total;
-									break;
-							}
-						}
-					}
-					wp_reset_postdata();
-				}
+
+				// Dashboard stats ( status counts/amounts + revenue summary ) come from
+				// the shared calculator so the page load and the post-delete AJAX update
+				// stay in sync.
+				$stats            = function_exists( 'rbfw_calculate_order_list_stats' ) ? rbfw_calculate_order_list_stats() : array();
+				$total_orders     = isset( $stats['total_orders'] ) ? $stats['total_orders'] : 0;
+				$total_amount     = isset( $stats['total_amount'] ) ? $stats['total_amount'] : 0;
+				$completed_orders = isset( $stats['completed_orders'] ) ? $stats['completed_orders'] : 0;
+				$completed_amount = isset( $stats['completed_amount'] ) ? $stats['completed_amount'] : 0;
+				$cancelled_orders = isset( $stats['cancelled_orders'] ) ? $stats['cancelled_orders'] : 0;
+				$cancelled_amount = isset( $stats['cancelled_amount'] ) ? $stats['cancelled_amount'] : 0;
+				$pending_orders   = isset( $stats['pending_orders'] ) ? $stats['pending_orders'] : 0;
+				$pending_amount   = isset( $stats['pending_amount'] ) ? $stats['pending_amount'] : 0;
+				$refunded_orders  = isset( $stats['refunded_orders'] ) ? $stats['refunded_orders'] : 0;
+				$refunded_amount  = isset( $stats['refunded_amount'] ) ? $stats['refunded_amount'] : 0;
+				$processing_amount  = isset( $stats['processing_amount'] ) ? $stats['processing_amount'] : 0;
+				$net_revenue        = isset( $stats['net_revenue'] ) ? $stats['net_revenue'] : 0;
+				$this_month_revenue = isset( $stats['this_month_revenue'] ) ? $stats['this_month_revenue'] : 0;
+				$avg_order_value    = isset( $stats['avg_order_value'] ) ? $stats['avg_order_value'] : 0;
+				$paid_orders        = isset( $stats['paid_orders'] ) ? $stats['paid_orders'] : 0;
 				?>
                 <div class="rbfw_ol rental-order-list-dashboard wrap">
                     <div class="rbfw_ol_header">
@@ -152,6 +125,41 @@
                         <?php } ?>
                     </div>
                     <hr class="wp-header-end">
+
+                    <!-- Revenue summary card -->
+                    <div class="rbfw_ol_revenue">
+                        <div class="rbfw_ol_rev_main">
+                            <div class="rbfw_ol_rev_ic"><?php echo rbfw_inv_icon( 'tag' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_ol_rev_main_txt">
+                                <div class="rbfw_ol_rev_label"><?php esc_html_e( 'Net Revenue', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_ol_rev_value" data-rev="net"><?php echo wp_kses_post( wc_price( $net_revenue ) ); ?></div>
+                                <div class="rbfw_ol_rev_sub" data-rev="paid_label">
+                                    <?php
+                                    /* translators: %s: number of paid (completed + processing) orders. */
+                                    echo esc_html( sprintf( _n( 'From %s paid order', 'From %s paid orders', $paid_orders, 'booking-and-rental-manager-for-woocommerce' ), number_format_i18n( $paid_orders ) ) );
+                                    ?>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="rbfw_ol_rev_breakdown">
+                            <div class="rbfw_ol_rev_chip">
+                                <span class="rbfw_ol_rev_chip_lbl"><?php echo rbfw_inv_icon( 'check' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Completed', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                <span class="rbfw_ol_rev_chip_val" data-rev="completed"><?php echo wp_kses_post( wc_price( $completed_amount ) ); ?></span>
+                            </div>
+                            <div class="rbfw_ol_rev_chip">
+                                <span class="rbfw_ol_rev_chip_lbl"><?php echo rbfw_inv_icon( 'clock' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Processing', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                <span class="rbfw_ol_rev_chip_val" data-rev="processing"><?php echo wp_kses_post( wc_price( $processing_amount ) ); ?></span>
+                            </div>
+                            <div class="rbfw_ol_rev_chip">
+                                <span class="rbfw_ol_rev_chip_lbl"><?php echo rbfw_inv_icon( 'calendar' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'This Month', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                <span class="rbfw_ol_rev_chip_val" data-rev="month"><?php echo wp_kses_post( wc_price( $this_month_revenue ) ); ?></span>
+                            </div>
+                            <div class="rbfw_ol_rev_chip">
+                                <span class="rbfw_ol_rev_chip_lbl"><?php echo rbfw_inv_icon( 'calculator' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Avg. Order', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                <span class="rbfw_ol_rev_chip_val" data-rev="avg"><?php echo wp_kses_post( wc_price( $avg_order_value ) ); ?></span>
+                            </div>
+                        </div>
+                    </div>
 
                     <!-- Stat cards -->
                     <div class="rbfw_ol_stats">


### PR DESCRIPTION


Add a gradient "Revenue Summary" card to the Order List dashboard and unify stat calculation around the existing shared helper so the page render and the post-delete AJAX refresh stay perfectly in sync. Also hide the legacy Pro "Reports" submenu now that the Order List page covers the same data.

Dashboard UI (lib/classes/class-admin-menu.php)
- Render a new revenue card above the existing stat cards showing:
  - Net Revenue (completed + processing totals) with a "From N paid orders" caption
  - Breakdown chips for Completed, Processing, This Month, and Avg. Order value
- Replace the inline, duplicated stat loop with a call to rbfw_calculate_order_list_stats() so page load and AJAX use one source of truth

Stats calculator (inc/rbfw_order_meta.php)
- Extend rbfw_calculate_order_list_stats() with revenue metrics: processing_orders/amount, paid_orders, net_revenue, this_month_revenue, avg_order_value
- Treat completed + processing as earned revenue; track month-to-date using current_time('Y-m') with a gmdate() fallback
- Include a "revenue" payload in rbfw_delete_order_callback() so the card updates live after an order is deleted

Styling (admin/css/rbfw_order.css)
- Add .rbfw_ol_revenue card styles: gradient background, responsive 4-column breakdown grid, white WooCommerce price overrides, and 1100px/600px breakpoints

Interactivity (admin/js/rbfw_order.js)
- Extend applyStats() to accept a revenue map and update [data-rev] elements
- Pass res.data.revenue through from the delete-order AJAX handler

Admin menu cleanup
- Register rbfw_remove_reports_submenu() at admin_menu priority 999 to remove the Pro "Reports" submenu under edit.php?post_type=rbfw_item, since booking details, status management, filtering, export, and the revenue summary now all live on the Order List page