### PR TITLE
feat(order-list): move Report Settings into Order List as Export Settings accordion

### DIFF
--- a/admin/css/rbfw_order.css
+++ b/admin/css/rbfw_order.css
@@ -761,3 +761,78 @@ span.flatpickr-weekday { color: #8896B0; font-weight: 700; font-size: 11px; }
     .rbfw_ol_export_formats { grid-template-columns: 1fr; }
     .rbfw_ol_export_months { flex-wrap: nowrap; }
 }
+
+/* =========================================================================
+   Export Settings accordion (column toggles for CSV / PDF)
+   ========================================================================= */
+.rbfw_ol_exs {
+    background: var(--rbfw-surface); border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius); box-shadow: var(--rbfw-shadow-sm);
+    margin-bottom: 18px; overflow: hidden;
+}
+.rbfw_ol_exs_head {
+    width: 100%; display: flex; align-items: center; gap: 14px;
+    padding: 14px 18px; background: transparent; border: 0; cursor: pointer;
+    font-family: inherit; text-align: left;
+}
+.rbfw_ol_exs_head:hover { background: var(--rbfw-bg); }
+.rbfw_ol_exs_head_ic {
+    width: 40px; height: 40px; border-radius: 10px; flex-shrink: 0;
+    display: grid; place-items: center; background: var(--rbfw-accent-lt); color: var(--rbfw-accent);
+}
+.rbfw_ol_exs_head_ic svg.rbfw_inv_ic { width: 20px; height: 20px; }
+.rbfw_ol_exs_head_txt { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.rbfw_ol_exs_title { font-size: 14px; font-weight: 700; color: var(--rbfw-text-1); }
+.rbfw_ol_exs_sub { font-size: 11.5px; color: var(--rbfw-text-3); }
+.rbfw_ol_exs_chev { color: var(--rbfw-text-3); display: inline-flex; transition: transform .2s ease; flex-shrink: 0; }
+.rbfw_ol_exs_chev svg.rbfw_inv_ic { width: 20px; height: 20px; }
+.rbfw_ol_exs.is-open .rbfw_ol_exs_chev { transform: rotate(180deg); color: var(--rbfw-accent); }
+
+.rbfw_ol_exs_body { padding: 4px 18px 18px; border-top: 1px solid var(--rbfw-border); }
+.rbfw_ol_exs_groups {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px 22px; padding-top: 16px;
+}
+.rbfw_ol_exs_group_title {
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+    color: var(--rbfw-accent); margin-bottom: 10px; padding-bottom: 7px;
+    border-bottom: 1px solid var(--rbfw-border);
+}
+.rbfw_ol_exs_cols { display: flex; flex-direction: column; gap: 9px; }
+.rbfw_ol_exs_toggle { display: flex; align-items: center; gap: 10px; cursor: pointer; margin: 0; }
+.rbfw_ol_exs_cb { position: absolute; opacity: 0; width: 0; height: 0; }
+.rbfw_ol_exs_switch {
+    position: relative; flex-shrink: 0; width: 36px; height: 20px; border-radius: 999px;
+    background: #CBD3E1; transition: background .18s ease;
+}
+.rbfw_ol_exs_switch::after {
+    content: ''; position: absolute; top: 2px; left: 2px; width: 16px; height: 16px;
+    border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.25); transition: transform .18s ease;
+}
+.rbfw_ol_exs_cb:checked + .rbfw_ol_exs_switch { background: var(--rbfw-accent); }
+.rbfw_ol_exs_cb:checked + .rbfw_ol_exs_switch::after { transform: translateX(16px); }
+.rbfw_ol_exs_cb:focus-visible + .rbfw_ol_exs_switch { box-shadow: 0 0 0 3px rgba(79,110,247,.25); }
+.rbfw_ol_exs_label { font-size: 13px; font-weight: 600; color: var(--rbfw-text-2); }
+
+.rbfw_ol_exs_foot {
+    display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--rbfw-border);
+}
+.rbfw_ol_exs_quick { display: flex; align-items: center; gap: 8px; }
+.rbfw_ol_exs_all, .rbfw_ol_exs_none {
+    background: none; border: 0; padding: 0; cursor: pointer; font-family: inherit;
+    font-size: 12.5px; font-weight: 700; color: var(--rbfw-accent);
+}
+.rbfw_ol_exs_all:hover, .rbfw_ol_exs_none:hover { text-decoration: underline; }
+.rbfw_ol_exs_dot { color: var(--rbfw-text-3); }
+.rbfw_ol_exs_hint { margin-left: auto; font-size: 12px; font-weight: 500; color: var(--rbfw-text-3); }
+.rbfw_ol_exs_msg { margin-left: 10px; font-size: 12.5px; font-weight: 600; padding: 6px 12px; border-radius: var(--rbfw-radius-sm); }
+.rbfw_ol_exs_msg.is_success { background: var(--rbfw-green-lt); color: #065F46; }
+.rbfw_ol_exs_msg.is_error { background: var(--rbfw-red-lt); color: #991B1B; }
+
+@media (max-width: 1100px) { .rbfw_ol_exs_groups { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 600px) {
+    .rbfw_ol_exs_groups { grid-template-columns: 1fr; }
+    .rbfw_ol_exs_foot { flex-wrap: wrap; }
+    .rbfw_ol_exs_hint { margin-left: 0; }
+    .rbfw_ol_exs_msg { margin-left: 0; }
+}

--- a/admin/js/rbfw_order.js
+++ b/admin/js/rbfw_order.js
@@ -913,6 +913,75 @@
             }
         })();
 
+        /* ----------------------------------------------------------------- *
+         *  Export Settings accordion — toggle export columns (CSV / PDF).
+         * ----------------------------------------------------------------- */
+        (function initExportSettings() {
+            var exs = document.getElementById('rbfw_ol_exs');
+            if (!exs) { return; }
+            var head    = exs.querySelector('.rbfw_ol_exs_head');
+            var body    = document.getElementById('rbfw_ol_exs_body');
+            var allBtn  = exs.querySelector('.rbfw_ol_exs_all');
+            var noneBtn = exs.querySelector('.rbfw_ol_exs_none');
+            var msg     = document.getElementById('rbfw_ol_exs_msg');
+
+            function checks() { return Array.prototype.slice.call(exs.querySelectorAll('.rbfw_ol_exs_cb')); }
+
+            function setOpen(open) {
+                body.hidden = !open;
+                exs.classList.toggle('is-open', open);
+                if (head) { head.setAttribute('aria-expanded', open ? 'true' : 'false'); }
+            }
+            if (head) { head.addEventListener('click', function () { setOpen(body.hidden); }); }
+
+            function showMsg(text, ok) {
+                if (!msg) { return; }
+                msg.textContent = text;
+                msg.className = 'rbfw_ol_exs_msg ' + (ok ? 'is_success' : 'is_error');
+                msg.style.display = 'inline-block';
+            }
+
+            function doSave() {
+                if (typeof rbfw_ajax_admin === 'undefined' || !rbfw_ajax_admin.nonce_save_export_settings) {
+                    // Stale page / missing localisation — make the failure visible
+                    // instead of silently doing nothing.
+                    showMsg('Could not save — please reload the page and try again.', false);
+                    return;
+                }
+                var parts = [
+                    'action=rbfw_save_export_settings',
+                    'nonce=' + encodeURIComponent(rbfw_ajax_admin.nonce_save_export_settings)
+                ];
+                checks().forEach(function (c) {
+                    parts.push('columns[' + encodeURIComponent(c.getAttribute('data-col')) + ']=' + (c.checked ? '1' : '0'));
+                });
+                showMsg('Saving…', true);
+                fetch(rbfw_ajax_admin.rbfw_ajaxurl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: parts.join('&')
+                }).then(function (r) { return r.json(); }).then(function (res) {
+                    if (res && res.success) { showMsg((res.data && res.data.message) || 'Export settings saved.', true); }
+                    else { showMsg((res && res.data && res.data.message) || 'Could not save.', false); }
+                }).catch(function () {
+                    showMsg('Network error. Please try again.', false);
+                });
+            }
+
+            // Debounced auto-save: toggling a column persists automatically so the
+            // next CSV / PDF export always reflects the current selection.
+            var saveTimer = null;
+            function scheduleSave() {
+                if (saveTimer) { clearTimeout(saveTimer); }
+                saveTimer = setTimeout(doSave, 500);
+            }
+
+            checks().forEach(function (c) { c.addEventListener('change', scheduleSave); });
+
+            if (allBtn) { allBtn.addEventListener('click', function () { checks().forEach(function (c) { c.checked = true; }); scheduleSave(); }); }
+            if (noneBtn) { noneBtn.addEventListener('click', function () { checks().forEach(function (c) { c.checked = false; }); scheduleSave(); }); }
+        })();
+
         render();
     });
 })();

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -159,6 +159,7 @@ if (! class_exists('RBFW_Dependencies')) {
 				'admin_post_url' => admin_url('admin-post.php'),
 				'currency_symbol' => function_exists('get_woocommerce_currency_symbol') ? html_entity_decode( get_woocommerce_currency_symbol() ) : '',
 				'nonce_export_orders'        => wp_create_nonce('rbfw_export_orders_action'),
+				'nonce_save_export_settings'        => wp_create_nonce('rbfw_save_export_settings_action'),
 				'nonce_time_slot'        => wp_create_nonce('rbfw_time_slot_action'),
 				'nonce_duration_form'        => wp_create_nonce('rbfw_duration_form_action'),
 				'nonce_room_types_with_sd_price'        => wp_create_nonce('rbfw_room_types_with_sd_price_action'),

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -915,6 +915,8 @@ function rbfw_inv_icon( $name, $extra_class = '' ) {
         'download' => '<path d="M12 4v11"/><path d="M7 11l5 5 5-5"/><path d="M5 20h14"/>',
         'file_csv' => '<path d="M14 3v5h5"/><path d="M14 3H6.5A1.5 1.5 0 0 0 5 4.5v15A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V8z"/><path d="M8.5 14h2"/><path d="M13.5 14h2"/><path d="M8.5 17h2"/><path d="M13.5 17h2"/>',
         'file_pdf' => '<path d="M14 3v5h5"/><path d="M14 3H6.5A1.5 1.5 0 0 0 5 4.5v15A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V8z"/><path d="M8.5 13v4"/><path d="M8.5 13h1.2a1.2 1.2 0 0 1 0 2.4H8.5"/><path d="M13 13v4h1a1.5 1.5 0 0 0 1.5-1.5v-1A1.5 1.5 0 0 0 14 13z"/>',
+        'sliders'  => '<path d="M4 6h10"/><path d="M18 6h2"/><circle cx="16" cy="6" r="2"/><path d="M4 12h2"/><path d="M10 12h10"/><circle cx="8" cy="12" r="2"/><path d="M4 18h10"/><path d="M18 18h2"/><circle cx="16" cy="18" r="2"/>',
+        'chevron_down' => '<path d="M6 9l6 6 6-6"/>',
     );
 
     if ( ! isset( $paths[ $name ] ) ) {

--- a/inc/rbfw_order_export.php
+++ b/inc/rbfw_order_export.php
@@ -105,6 +105,105 @@ function rbfw_export_columns() {
 }
 
 /**
+ * Export columns arranged into accordion groups for the settings UI.
+ *
+ * @return array<string,array{label:string,columns:string[]}>
+ */
+function rbfw_export_column_groups() {
+	return array(
+		'order'    => array(
+			'label'   => __( 'Order', 'booking-and-rental-manager-for-woocommerce' ),
+			'columns' => array( 'order_no', 'booking_id', 'status', 'order_total', 'order_created' ),
+		),
+		'customer' => array(
+			'label'   => __( 'Customer', 'booking-and-rental-manager-for-woocommerce' ),
+			'columns' => array( 'customer', 'email', 'phone' ),
+		),
+		'booking'  => array(
+			'label'   => __( 'Booking', 'booking-and-rental-manager-for-woocommerce' ),
+			'columns' => array( 'item', 'item_type', 'qty', 'booking_start', 'booking_end', 'total_days' ),
+		),
+		'pricing'  => array(
+			'label'   => __( 'Pricing', 'booking-and-rental-manager-for-woocommerce' ),
+			'columns' => array( 'duration_cost', 'service_cost', 'discount', 'security_deposit' ),
+		),
+	);
+}
+
+/**
+ * Option name holding the per-column export toggles.
+ *
+ * @return string
+ */
+function rbfw_export_settings_option_name() {
+	return 'rbfw_order_export_settings';
+}
+
+/**
+ * Enabled/disabled map for every export column.
+ *
+ * Columns default to ON — a column is only hidden when it has an explicit 'off'
+ * saved — so the export is unchanged until the admin customises it.
+ *
+ * @return array<string,bool>
+ */
+function rbfw_export_column_enabled_map() {
+	$saved = get_option( rbfw_export_settings_option_name(), array() );
+	if ( ! is_array( $saved ) ) {
+		$saved = array();
+	}
+	$map = array();
+	foreach ( rbfw_export_columns() as $key => $label ) {
+		$map[ $key ] = ! ( isset( $saved[ $key ] ) && 'off' === $saved[ $key ] );
+	}
+	return $map;
+}
+
+/**
+ * The export columns that are currently enabled, in display order.
+ *
+ * Falls back to all columns if every toggle was switched off, so the export
+ * file is never completely empty of columns.
+ *
+ * @return array<string,string> key => label.
+ */
+function rbfw_export_enabled_columns() {
+	$all     = rbfw_export_columns();
+	$map     = rbfw_export_column_enabled_map();
+	$enabled = array();
+	foreach ( $all as $key => $label ) {
+		if ( ! empty( $map[ $key ] ) ) {
+			$enabled[ $key ] = $label;
+		}
+	}
+	return $enabled ? $enabled : $all;
+}
+
+add_action( 'wp_ajax_rbfw_save_export_settings', 'rbfw_save_export_settings_callback' );
+/**
+ * AJAX: persist the export column toggles from the Order List accordion.
+ */
+function rbfw_save_export_settings_callback() {
+	check_ajax_referer( 'rbfw_save_export_settings_action', 'nonce' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+	}
+
+	$posted = ( isset( $_POST['columns'] ) && is_array( $_POST['columns'] ) ) ? wp_unslash( $_POST['columns'] ) : array();
+
+	$settings = array();
+	foreach ( rbfw_export_columns() as $key => $label ) {
+		$val               = isset( $posted[ $key ] ) ? sanitize_text_field( $posted[ $key ] ) : '0';
+		$settings[ $key ]  = in_array( $val, array( '1', 'on', 'true' ), true ) ? 'on' : 'off';
+	}
+
+	update_option( rbfw_export_settings_option_name(), $settings );
+
+	wp_send_json_success( array( 'message' => esc_html__( 'Export settings saved.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+}
+
+/**
  * Build the export dataset — one row per booking line item (ticket).
  *
  * Producing a row per ticket (rather than per order) is what makes the
@@ -447,7 +546,7 @@ function rbfw_export_filename_stem() {
  * @param array $filters applied filters.
  */
 function rbfw_export_orders_csv( $rows, $filters ) {
-	$columns  = rbfw_export_columns();
+	$columns  = rbfw_export_enabled_columns();
 	$filename = rbfw_export_filename_stem() . '.csv';
 
 	nocache_headers();
@@ -614,7 +713,7 @@ function rbfw_export_pdf_footer_html() {
  * @return string
  */
 function rbfw_export_pdf_body_html( $rows, $filters ) {
-	$columns    = rbfw_export_columns();
+	$columns    = rbfw_export_enabled_columns();
 	$money_keys = array( 'duration_cost', 'service_cost', 'discount', 'security_deposit', 'order_total' );
 	$num_keys   = array( 'qty', 'total_days' );
 
@@ -646,16 +745,39 @@ function rbfw_export_pdf_body_html( $rows, $filters ) {
 			$html .= '</tr>';
 		}
 
-		// Totals row spanning to the order-total column.
+		// Totals row — aligned to the order-total column when it is shown, and
+		// robust to that column being toggled off or positioned first/last.
 		$keys      = array_keys( $columns );
+		$col_count = count( $columns );
 		$total_pos = array_search( 'order_total', $keys, true );
-		$lead_span = false === $total_pos ? count( $columns ) : $total_pos;
-		$html     .= '<tr class="rbfw_exp_tot"><td colspan="' . $lead_span . '">'
-			. esc_html__( 'Grand Total', 'booking-and-rental-manager-for-woocommerce' )
+		$label     = esc_html__( 'Grand Total', 'booking-and-rental-manager-for-woocommerce' )
 			. ' (' . esc_html( rbfw_export_count_orders( $rows ) ) . ' '
-			. esc_html__( 'orders', 'booking-and-rental-manager-for-woocommerce' ) . ')</td>'
-			. '<td class="rbfw_exp_num">' . esc_html( rbfw_export_money( rbfw_export_grand_total( $rows ) ) ) . '</td>'
-			. '<td></td></tr>';
+			. esc_html__( 'orders', 'booking-and-rental-manager-for-woocommerce' ) . ')';
+		$amount    = esc_html( rbfw_export_money( rbfw_export_grand_total( $rows ) ) );
+
+		$html .= '<tr class="rbfw_exp_tot">';
+		if ( false === $total_pos ) {
+			// No order-total column: a single full-width labelled row.
+			$html .= '<td colspan="' . $col_count . '">' . $label . '</td>';
+		} else {
+			$lead  = (int) $total_pos;                 // cells before the total column.
+			$trail = $col_count - $total_pos - 1;       // cells after it.
+			if ( $lead > 0 ) {
+				$html .= '<td colspan="' . $lead . '">' . $label . '</td>';
+				$html .= '<td class="rbfw_exp_num">' . $amount . '</td>';
+			} else {
+				// order_total is the first column.
+				$html .= '<td class="rbfw_exp_num">' . $amount . '</td>';
+			}
+			if ( $trail > 0 ) {
+				$cell = ( 0 === $lead ) ? $label : '';
+				$html .= '<td colspan="' . $trail . '">' . $cell . '</td>';
+			} elseif ( 0 === $lead ) {
+				// Total is first and only-ish: ensure the label is still shown.
+				$html .= '<td>' . $label . '</td>';
+			}
+		}
+		$html .= '</tr>';
 	}
 
 	$html .= '</tbody></table>';

--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -21,6 +21,10 @@
 				// Runs late ( priority 999 ) so it removes the entry after Pro registers it.
 				add_action( 'admin_menu', array( $this, 'rbfw_remove_reports_submenu' ), 999 );
 				add_action( 'admin_enqueue_scripts', array( $this, 'rbfw_admin_enqueue_scripts' ) );
+				// The Pro "Report Settings" tab has moved to the Order List page as the
+				// "Export Settings" accordion, so remove it from the global Settings.
+				add_filter( 'rbfw_settings_sec_reg', array( $this, 'rbfw_remove_report_settings_section' ), 200 );
+				add_filter( 'rbfw_settings_sec_fields', array( $this, 'rbfw_remove_report_settings_fields' ), 200 );
 				/* WooCommerce Action and Filter */
 				add_filter( 'woocommerce_order_status_changed', array( $this, 'rbfw_wc_status_update' ), 10, 4 );
 				/* End WooCommerce Action and Filter */
@@ -58,6 +62,40 @@
 			 */
 			public function rbfw_remove_reports_submenu() {
 				remove_submenu_page( 'edit.php?post_type=rbfw_item', 'reports' );
+			}
+
+			/**
+			 * Remove the "Report Settings" section from the global Settings tabs.
+			 *
+			 * Its purpose ( choosing which columns the report/export shows ) now lives
+			 * on the Order List page as the "Export Settings" accordion.
+			 *
+			 * @param array $sections registered settings sections.
+			 * @return array
+			 */
+			public function rbfw_remove_report_settings_section( $sections ) {
+				if ( ! is_array( $sections ) ) {
+					return $sections;
+				}
+				foreach ( $sections as $index => $section ) {
+					if ( isset( $section['id'] ) && 'rbfw_basic_purchase_list_settings' === $section['id'] ) {
+						unset( $sections[ $index ] );
+					}
+				}
+				return array_values( $sections );
+			}
+
+			/**
+			 * Remove the "Report Settings" fields that belong to the moved section.
+			 *
+			 * @param array $fields registered settings fields keyed by section id.
+			 * @return array
+			 */
+			public function rbfw_remove_report_settings_fields( $fields ) {
+				if ( is_array( $fields ) && isset( $fields['rbfw_basic_purchase_list_settings'] ) ) {
+					unset( $fields['rbfw_basic_purchase_list_settings'] );
+				}
+				return $fields;
 			}
 
 			public function rbfw_admin_enqueue_scripts( $hook ) {
@@ -254,6 +292,53 @@
                             <span><?php esc_html_e( 'Reset', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
                         </button>
                     </div>
+
+                    <?php if ( function_exists( 'rbfw_pro_tab_menu_list' ) && function_exists( 'rbfw_export_column_groups' ) ) :
+                        $rbfw_exs_labels  = rbfw_export_columns();
+                        $rbfw_exs_enabled = rbfw_export_column_enabled_map();
+                        ?>
+                        <!-- Export Settings accordion -->
+                        <div class="rbfw_ol_exs" id="rbfw_ol_exs">
+                            <button type="button" class="rbfw_ol_exs_head" aria-expanded="false" aria-controls="rbfw_ol_exs_body">
+                                <span class="rbfw_ol_exs_head_ic"><?php echo rbfw_inv_icon( 'sliders' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                                <span class="rbfw_ol_exs_head_txt">
+                                    <span class="rbfw_ol_exs_title"><?php esc_html_e( 'Export Settings', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                    <span class="rbfw_ol_exs_sub"><?php esc_html_e( 'Choose which columns are included in the CSV / PDF export', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                </span>
+                                <span class="rbfw_ol_exs_chev"><?php echo rbfw_inv_icon( 'chevron_down' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                            </button>
+                            <div class="rbfw_ol_exs_body" id="rbfw_ol_exs_body" hidden>
+                                <div class="rbfw_ol_exs_groups">
+                                    <?php foreach ( rbfw_export_column_groups() as $rbfw_exs_gkey => $rbfw_exs_group ) : ?>
+                                        <div class="rbfw_ol_exs_group">
+                                            <div class="rbfw_ol_exs_group_title"><?php echo esc_html( $rbfw_exs_group['label'] ); ?></div>
+                                            <div class="rbfw_ol_exs_cols">
+                                                <?php foreach ( $rbfw_exs_group['columns'] as $rbfw_exs_col ) :
+                                                    if ( ! isset( $rbfw_exs_labels[ $rbfw_exs_col ] ) ) { continue; }
+                                                    $rbfw_exs_on = ! empty( $rbfw_exs_enabled[ $rbfw_exs_col ] );
+                                                    ?>
+                                                    <label class="rbfw_ol_exs_toggle">
+                                                        <input type="checkbox" class="rbfw_ol_exs_cb" data-col="<?php echo esc_attr( $rbfw_exs_col ); ?>" <?php checked( $rbfw_exs_on ); ?>>
+                                                        <span class="rbfw_ol_exs_switch"></span>
+                                                        <span class="rbfw_ol_exs_label"><?php echo esc_html( $rbfw_exs_labels[ $rbfw_exs_col ] ); ?></span>
+                                                    </label>
+                                                <?php endforeach; ?>
+                                            </div>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </div>
+                                <div class="rbfw_ol_exs_foot">
+                                    <div class="rbfw_ol_exs_quick">
+                                        <button type="button" class="rbfw_ol_exs_all"><?php esc_html_e( 'Select all', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                        <span class="rbfw_ol_exs_dot">&middot;</span>
+                                        <button type="button" class="rbfw_ol_exs_none"><?php esc_html_e( 'Clear all', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                                    </div>
+                                    <span class="rbfw_ol_exs_hint"><?php esc_html_e( 'Changes are saved automatically.', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+                                    <span class="rbfw_ol_exs_msg" id="rbfw_ol_exs_msg" style="display:none;"></span>
+                                </div>
+                            </div>
+                        </div>
+                    <?php endif; ?>
 
                     <!-- Table -->
                     <div class="rbfw_ol_card">


### PR DESCRIPTION


Relocate the Pro "Report Settings" (the per-column toggles that decide which fields appear in reports/exports) out of the global Settings page and onto the Order List page as a modern, collapsible "Export Settings" accordion. The CSV / PDF export now honours those toggles, so the export is driven by settings.

EXPORT SETTINGS ACCORDION (Order List)
- New collapsible card below the filter bar with a slide-down body. Every export column has a modern toggle switch, grouped into Order / Customer / Booking / Pricing. All columns default to ON, so the export is unchanged until the admin customises it.
- Auto-save: toggling a column (and Select all / Clear all) persists immediately via AJAX with an inline "Saving… / Export settings saved." status — no separate Save button. A missing/stale localisation surfaces a visible error instead of failing silently.
- Pro-gated (function_exists('rbfw_pro_tab_menu_list')), consistent with the Export button and order actions.

SETTING-WISE CSV / PDF EXPORT
- inc/rbfw_order_export.php: new rbfw_export_column_groups(), rbfw_export_column_enabled_map() and rbfw_export_enabled_columns() (reads the rbfw_order_export_settings option; default ON; never returns an empty set), plus the rbfw_save_export_settings AJAX handler (manage_options + nonce + sanitised per-column on/off).
- Both the CSV writer and the PDF body now render only the enabled columns. The PDF grand-total row was made robust to the Order Total column being toggled off or positioned first/last.

REPORT SETTINGS TAB REMOVED FROM GLOBAL SETTINGS
- lib/classes/class-admin-menu.php: rbfw_remove_report_settings_section() and rbfw_remove_report_settings_fields() unregister the Pro rbfw_basic_purchase_list_settings section + fields via the rbfw_settings_sec_reg / rbfw_settings_sec_fields filters (priority 200). The Pro plugin is left untouched; PDF / Email / Review settings tabs remain intact.

SUPPORTING CHANGES
- inc/RBFW_Dependencies.php: localise nonce_save_export_settings on the order page.
- inc/rbfw_inventory_functions.php: add 'sliders' and 'chevron_down' inline-SVG icons for the accordion header.
- admin/css/rbfw_order.css: accordion, toggle switches, grouped column grid and responsive layout.

Verified: with columns toggled off the saved option persists and both the CSV header and the PDF columns drop them (e.g. 18 -> 15); toggling Order Total off still renders a valid grand-total row; the Report Settings tab and its fields are gone while the other settings tabs remain.