### PR TITLE
feat(editor): add inline rent type popup for classic and modern editors

### DIFF
--- a/admin/RBFW_Modern_Editor.php
+++ b/admin/RBFW_Modern_Editor.php
@@ -782,7 +782,7 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 
 			/* Categories (taxonomy) */
 			if ( isset( $_POST['rbfw_categories'] ) ) {
-				$cats = RBFW_Function::data_sanitize( wp_unslash( $_POST['rbfw_categories'] ) );
+				$cats = rbfw_sanitize_rent_type_categories( wp_unslash( $_POST['rbfw_categories'] ) );
 				wp_set_object_terms( $post_id, $cats, 'rbfw_item_caregory' );
 				update_post_meta( $post_id, 'rbfw_categories', $cats );
 			}

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -1312,6 +1312,45 @@
             $cb.closest('.rbfw-me-checkbox-label').toggleClass('is-checked', $cb.is(':checked'));
         }
 
+        function rtEsc(s) { return $('<div>').text(s == null ? '' : String(s)).html(); }
+
+        function rebuildRentTypes(rentTypes, selectName) {
+            rentTypes = rentTypes || [];
+            var current = ($wrap.find('.rbfw-me-cats-hidden').val() || '').split(',').filter(Boolean);
+            if (selectName) {
+                var selectLower = String(selectName).toLowerCase().trim();
+                var has = current.some(function (n) { return String(n).toLowerCase().trim() === selectLower; });
+                if (!has) {
+                    current.push(selectName);
+                }
+            }
+            var $grid = $wrap.find('.rbfw-me-checkbox-grid').empty();
+            rentTypes.forEach(function (rt) {
+                var nameLower = String(rt.name).toLowerCase().trim();
+                var checked = current.some(function (n) { return String(n).toLowerCase().trim() === nameLower; });
+                var checkedAttr = checked ? ' checked' : '';
+                $grid.append(
+                    '<label class="rbfw-me-checkbox-label' + (checked ? ' is-checked' : '') + '">' +
+                        '<input type="checkbox" class="rbfw-me-cat-checkbox" data-name="' + rtEsc(rt.name) + '"' + checkedAttr + ' />' +
+                        '<span>' + rtEsc(rt.name.charAt(0).toUpperCase() + rt.name.slice(1)) + '</span>' +
+                    '</label>'
+                );
+            });
+            $wrap.find('.rbfw-me-cats-hidden').val(current.join(','));
+            $wrap.find('.rbfw-me-rent-type-empty').toggleClass('rbfw-me-hidden', rentTypes.length > 0);
+        }
+
+        function openRentTypeModal() {
+            var $modal = $wrap.find('#rbfw-me-rent-type-modal');
+            $modal.find('#rbfw-me-rent-type-modal-input').val('');
+            $modal.addClass('is-open');
+            setTimeout(function () { $modal.find('#rbfw-me-rent-type-modal-input').trigger('focus'); }, 50);
+        }
+
+        function closeRentTypeModal() {
+            $wrap.find('#rbfw-me-rent-type-modal').removeClass('is-open');
+        }
+
         // Set initial pill state for pre-checked boxes
         $wrap.find('.rbfw-me-cat-checkbox').each(function () {
             syncPill($(this));
@@ -1324,6 +1363,38 @@
                 selected.push($(this).data('name'));
             });
             $wrap.find('.rbfw-me-cats-hidden').val(selected.join(','));
+        });
+
+        $wrap.on('click', '.rbfw-rent-type-add-trigger', function (e) {
+            e.preventDefault();
+            openRentTypeModal();
+        });
+
+        $wrap.on('click', '#rbfw-me-rent-type-modal .rbfw-me-faq-modal__close, #rbfw-me-rent-type-modal .rbfw-me-faq-modal__backdrop, .rbfw-me-rent-type-modal-cancel', function () {
+            closeRentTypeModal();
+        });
+
+        $wrap.on('click', '#rbfw-me-rent-type-modal-save', function () {
+            var $card  = $wrap.find('.rbfw-me-rent-type-card');
+            var $input = $wrap.find('#rbfw-me-rent-type-modal-input');
+            var name   = $.trim($input.val());
+            if (!name) { $input.trigger('focus'); return; }
+            $.post(window.ajaxurl, {
+                action: 'rbfw_rent_type_add',
+                nonce:  $card.data('nonce'),
+                name:   name
+            }, function (resp) {
+                if (resp && resp.success) {
+                    rebuildRentTypes(resp.data.rent_types, resp.data.added_name);
+                    closeRentTypeModal();
+                } else {
+                    window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                }
+            }).fail(function () { window.alert('Request failed.'); });
+        });
+
+        $wrap.on('keypress', '#rbfw-me-rent-type-modal-input', function (e) {
+            if (e.which === 13) { e.preventDefault(); $wrap.find('#rbfw-me-rent-type-modal-save').trigger('click'); }
         });
     }
 

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -1379,6 +1379,7 @@
             var $input = $wrap.find('#rbfw-me-rent-type-modal-input');
             var name   = $.trim($input.val());
             if (!name) { $input.trigger('focus'); return; }
+            if (name.length > 200) { name = name.substring(0, 200); }
             $.post(window.ajaxurl, {
                 action: 'rbfw_rent_type_add',
                 nonce:  $card.data('nonce'),

--- a/admin/settings/General_Info.php
+++ b/admin/settings/General_Info.php
@@ -44,12 +44,16 @@
 			public function ajax_rent_type_add() {
 				$this->rbfw_rent_type_crud_guard();
 				$name = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+				$name = trim( $name );
 				if ( '' === $name ) {
 					wp_send_json_error( array( 'message' => esc_html__( 'Please enter a rent type name.', 'booking-and-rental-manager-for-woocommerce' ) ) );
 				}
+				if ( mb_strlen( $name ) > 200 ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Rent type name must be 200 characters or fewer.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
 				$res = wp_insert_term( $name, 'rbfw_item_caregory' );
 				if ( is_wp_error( $res ) ) {
-					wp_send_json_error( array( 'message' => $res->get_error_message() ) );
+					wp_send_json_error( array( 'message' => sanitize_text_field( $res->get_error_message() ) ) );
 				}
 				wp_send_json_success( array(
 					'rent_types' => $this->rbfw_get_rent_type_list(),
@@ -101,7 +105,9 @@
                         </label>
                         <p>
                             <?php echo esc_html__( "Here you can manage rent type.",'booking-and-rental-manager-for-woocommerce'); ?>
+                            <?php if ( current_user_can( 'manage_categories' ) ) : ?>
                             <a href="#" class="rbfw-rent-type-add-trigger"><?php echo esc_html__( "Add new ",'booking-and-rental-manager-for-woocommerce'); ?></a><?php echo esc_html__( "rent type",'booking-and-rental-manager-for-woocommerce'); ?>
+                            <?php endif; ?>
                         </p>
                     </div>
                 </section>
@@ -125,7 +131,7 @@
                         </div>
                         <div class="rbfw-rent-type-modal__body">
                             <label for="rbfw-rent-type-modal-input"><strong><?php esc_html_e( 'Rent type name', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></label>
-                            <input type="text" id="rbfw-rent-type-modal-input" class="widefat" style="margin-top:6px;" placeholder="<?php esc_attr_e( 'e.g. Bike, Car, Equipment…', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                            <input type="text" id="rbfw-rent-type-modal-input" class="widefat" style="margin-top:6px;" maxlength="200" placeholder="<?php esc_attr_e( 'e.g. Bike, Car, Equipment…', 'booking-and-rental-manager-for-woocommerce' ); ?>">
                         </div>
                         <div class="rbfw-rent-type-modal__foot">
                             <button type="button" class="button button-primary" id="rbfw-rent-type-modal-save"><?php esc_html_e( 'Add Rent Type', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
@@ -179,6 +185,7 @@
                         jQuery(document).on('click', '#rbfw-rent-type-modal-save', function () {
                             var name = jQuery.trim(jQuery('#rbfw-rent-type-modal-input').val());
                             if (!name) { jQuery('#rbfw-rent-type-modal-input').trigger('focus'); return; }
+                            if (name.length > 200) { name = name.substring(0, 200); }
                             jQuery.post(ajaxurl, {
                                 action: 'rbfw_rent_type_add',
                                 nonce: rtNonce(),
@@ -495,7 +502,9 @@
 					return;
 				}
 				if ( get_post_type( $post_id ) == 'rbfw_item' ) {
-					$rbfw_categories = isset( $_POST['rbfw_categories'] ) ? RBFW_Function::data_sanitize( wp_unslash( $_POST['rbfw_categories'] ) ) : [];
+					$rbfw_categories = isset( $_POST['rbfw_categories'] )
+						? rbfw_sanitize_rent_type_categories( wp_unslash( $_POST['rbfw_categories'] ) )
+						: array();
 					wp_set_object_terms( $post_id, $rbfw_categories, 'rbfw_item_caregory' );
 					$feature_category_input = isset( $_POST['rbfw_feature_category'] ) ? wp_unslash( $_POST['rbfw_feature_category'] ) : array();
 					$feature_category = rbfw_prepare_feature_category_meta_value( $feature_category_input );

--- a/admin/settings/General_Info.php
+++ b/admin/settings/General_Info.php
@@ -11,6 +11,50 @@
 				add_action( 'rbfw_meta_box_tab_name', [ $this, 'add_tab_menu' ] );
 				add_action( 'rbfw_meta_box_tab_content', [ $this, 'add_tabs_content' ] );
 				add_action( 'save_post', array( $this, 'settings_save' ), 99, 1 );
+				add_action( 'wp_ajax_rbfw_rent_type_add', [ $this, 'ajax_rent_type_add' ] );
+			}
+
+			/**
+			 * @return array[] List of [ term_id, name ].
+			 */
+			public function rbfw_get_rent_type_list() {
+				$terms = get_terms( array(
+					'taxonomy'   => 'rbfw_item_caregory',
+					'hide_empty' => false,
+				) );
+				$out   = array();
+				if ( ! is_wp_error( $terms ) ) {
+					foreach ( $terms as $term ) {
+						$out[] = array(
+							'term_id' => (int) $term->term_id,
+							'name'    => $term->name,
+						);
+					}
+				}
+				return $out;
+			}
+
+			private function rbfw_rent_type_crud_guard() {
+				check_ajax_referer( 'rbfw_rent_type_crud', 'nonce' );
+				if ( ! current_user_can( 'manage_categories' ) ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+				}
+			}
+
+			public function ajax_rent_type_add() {
+				$this->rbfw_rent_type_crud_guard();
+				$name = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+				if ( '' === $name ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Please enter a rent type name.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$res = wp_insert_term( $name, 'rbfw_item_caregory' );
+				if ( is_wp_error( $res ) ) {
+					wp_send_json_error( array( 'message' => $res->get_error_message() ) );
+				}
+				wp_send_json_success( array(
+					'rent_types' => $this->rbfw_get_rent_type_list(),
+					'added_name' => $name,
+				) );
 			}
 
 			public function add_tab_menu() {
@@ -57,11 +101,11 @@
                         </label>
                         <p>
                             <?php echo esc_html__( "Here you can manage rent type.",'booking-and-rental-manager-for-woocommerce'); ?>
-                            <a href="edit-tags.php?taxonomy=rbfw_item_caregory&post_type=rbfw_item"><?php echo esc_html__( "Add new ",'booking-and-rental-manager-for-woocommerce'); ?></a><?php echo esc_html__( "rent type",'booking-and-rental-manager-for-woocommerce'); ?>
+                            <a href="#" class="rbfw-rent-type-add-trigger"><?php echo esc_html__( "Add new ",'booking-and-rental-manager-for-woocommerce'); ?></a><?php echo esc_html__( "rent type",'booking-and-rental-manager-for-woocommerce'); ?>
                         </p>
                     </div>
                 </section>
-                <section class="rbfw_off_days justify-content-center">
+                <section class="rbfw_off_days justify-content-center rbfw-rent-type-checkboxes" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_rent_type_crud' ) ); ?>">
                     <div class="groupCheckBox">
                         <input type="hidden" name="rbfw_categories[]" value="<?php echo esc_attr( $rbfw_categories_items ); ?>">
                         <?php foreach ( $terms as $key => $value ) { ?>
@@ -72,6 +116,98 @@
                         <?php } ?>
                     </div>
                 </section>
+                <div class="rbfw-rent-type-modal" id="rbfw-rent-type-modal">
+                    <div class="rbfw-rent-type-modal__backdrop"></div>
+                    <div class="rbfw-rent-type-modal__box">
+                        <div class="rbfw-rent-type-modal__head">
+                            <h3><?php esc_html_e( 'Add New Rent Type', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+                            <button type="button" class="rbfw-rent-type-modal__close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>">&times;</button>
+                        </div>
+                        <div class="rbfw-rent-type-modal__body">
+                            <label for="rbfw-rent-type-modal-input"><strong><?php esc_html_e( 'Rent type name', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></label>
+                            <input type="text" id="rbfw-rent-type-modal-input" class="widefat" style="margin-top:6px;" placeholder="<?php esc_attr_e( 'e.g. Bike, Car, Equipment…', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+                        </div>
+                        <div class="rbfw-rent-type-modal__foot">
+                            <button type="button" class="button button-primary" id="rbfw-rent-type-modal-save"><?php esc_html_e( 'Add Rent Type', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                            <button type="button" class="button rbfw-rent-type-modal__close"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                        </div>
+                    </div>
+                </div>
+                <script>
+                    (function () {
+                        function rtEsc(s) { return jQuery('<div>').text(s == null ? '' : String(s)).html(); }
+                        function rtNonce() { return jQuery('.rbfw-rent-type-checkboxes').data('nonce'); }
+
+                        function rtRebuild(rentTypes, selectName) {
+                            rentTypes = rentTypes || [];
+                            var $section = jQuery('.rbfw-rent-type-checkboxes');
+                            var $group   = $section.find('.groupCheckBox');
+                            var current  = ($group.find('input[type="hidden"]').val() || '').split(',').filter(Boolean);
+                            if (selectName && current.indexOf(selectName) === -1) {
+                                current.push(selectName);
+                            }
+                            $group.find('label.customCheckboxLabel').remove();
+                            rentTypes.forEach(function (rt) {
+                                var checked = current.indexOf(rt.name) !== -1 ? ' checked' : '';
+                                $group.append(
+                                    '<label class="customCheckboxLabel">' +
+                                        '<input type="checkbox"' + checked + ' data-checked="' + rtEsc(rt.name) + '">' +
+                                        '<span class="customCheckbox">' + rtEsc(rt.name.charAt(0).toUpperCase() + rt.name.slice(1)) + '</span>' +
+                                    '</label>'
+                                );
+                            });
+                            $group.find('input[type="hidden"]').val(current.join(','));
+                        }
+
+                        function rtOpenModal() {
+                            jQuery('#rbfw-rent-type-modal-input').val('');
+                            jQuery('#rbfw-rent-type-modal').addClass('is-open');
+                            setTimeout(function () { jQuery('#rbfw-rent-type-modal-input').trigger('focus'); }, 50);
+                        }
+
+                        function rtCloseModal() {
+                            jQuery('#rbfw-rent-type-modal').removeClass('is-open');
+                        }
+
+                        jQuery(document).on('click', '.rbfw-rent-type-add-trigger', function (e) {
+                            e.preventDefault();
+                            rtOpenModal();
+                        });
+                        jQuery(document).on('click', '.rbfw-rent-type-modal__close, .rbfw-rent-type-modal__backdrop', function () {
+                            rtCloseModal();
+                        });
+                        jQuery(document).on('click', '#rbfw-rent-type-modal-save', function () {
+                            var name = jQuery.trim(jQuery('#rbfw-rent-type-modal-input').val());
+                            if (!name) { jQuery('#rbfw-rent-type-modal-input').trigger('focus'); return; }
+                            jQuery.post(ajaxurl, {
+                                action: 'rbfw_rent_type_add',
+                                nonce: rtNonce(),
+                                name: name
+                            }, function (resp) {
+                                if (resp && resp.success) {
+                                    rtRebuild(resp.data.rent_types, resp.data.added_name);
+                                    rtCloseModal();
+                                } else {
+                                    window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                                }
+                            }).fail(function () { window.alert('Request failed.'); });
+                        });
+                        jQuery(document).on('keypress', '#rbfw-rent-type-modal-input', function (e) {
+                            if (e.which === 13) { e.preventDefault(); jQuery('#rbfw-rent-type-modal-save').trigger('click'); }
+                        });
+                    })();
+                </script>
+                <style>
+                    .rbfw-rent-type-modal { position: fixed; inset: 0; z-index: 100000; display: none; }
+                    .rbfw-rent-type-modal.is-open { display: block; }
+                    .rbfw-rent-type-modal__backdrop { position: absolute; inset: 0; background: rgba(0,0,0,.5); }
+                    .rbfw-rent-type-modal__box { position: relative; max-width: 440px; margin: 12vh auto 0; background: #fff; border-radius: 8px; box-shadow: 0 10px 40px rgba(0,0,0,.25); overflow: hidden; }
+                    .rbfw-rent-type-modal__head { display: flex; align-items: center; justify-content: space-between; padding: 14px 18px; border-bottom: 1px solid #e2e6ee; }
+                    .rbfw-rent-type-modal__head h3 { margin: 0; font-size: 15px; }
+                    .rbfw-rent-type-modal__close { background: none; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: #6b7280; }
+                    .rbfw-rent-type-modal__body { padding: 18px; }
+                    .rbfw-rent-type-modal__foot { padding: 14px 18px; border-top: 1px solid #e2e6ee; display: flex; gap: 8px; }
+                </style>
 				<?php
 			}
 

--- a/admin/taxonomy_register.php
+++ b/admin/taxonomy_register.php
@@ -25,6 +25,10 @@ function rbfw_taxonomy_register(){
         'show_admin_column'     => false,
         'update_count_callback' => '_update_post_term_count',
         'query_var'             => true,
+        // Rent types are managed inline in the rental-item editor
+        // (General ▸ Category Settings), so the auto-generated taxonomy
+        // submenu is hidden from the admin sidebar.
+        'show_in_menu'          => false,
         'rewrite'               => array( 'slug' => 'rbfw_caregory' ),
         'show_in_rest'          => false,
         'meta_box_cb'           => false,

--- a/admin/views/rbfw-modern-editor.php
+++ b/admin/views/rbfw-modern-editor.php
@@ -149,7 +149,9 @@
 						<h2><?php esc_html_e( 'Category Settings', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
 						<p>
 							<?php esc_html_e( 'Here you can manage rent type.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+							<?php if ( current_user_can( 'manage_categories' ) ) : ?>
 							<a href="#" class="rbfw-rent-type-add-trigger"><?php esc_html_e( 'Add new rent type', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
+							<?php endif; ?>
 						</p>
 					</div>
 					<div class="rbfw-me-card__body">
@@ -175,7 +177,9 @@
 						<?php if ( empty( $all_cat_terms ) ) : ?>
 							<p class="rbfw-me-field__help rbfw-me-rent-type-empty">
 								<?php esc_html_e( 'No rent types found.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+								<?php if ( current_user_can( 'manage_categories' ) ) : ?>
 								<a href="#" class="rbfw-rent-type-add-trigger"><?php esc_html_e( 'Create one', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
+								<?php endif; ?>
 							</p>
 						<?php endif; ?>
 					</div>
@@ -190,7 +194,7 @@
 							<div class="rbfw-me-faq-modal__body">
 								<div class="rbfw-me-field">
 									<label class="rbfw-me-field__label" for="rbfw-me-rent-type-modal-input"><?php esc_html_e( 'Rent type name', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
-									<input class="rbfw-me-input" type="text" id="rbfw-me-rent-type-modal-input" placeholder="<?php esc_attr_e( 'e.g. Bike, Car, Equipment…', 'booking-and-rental-manager-for-woocommerce' ); ?>" />
+									<input class="rbfw-me-input" type="text" id="rbfw-me-rent-type-modal-input" maxlength="200" placeholder="<?php esc_attr_e( 'e.g. Bike, Car, Equipment…', 'booking-and-rental-manager-for-woocommerce' ); ?>" />
 								</div>
 							</div>
 							<div class="rbfw-me-faq-modal__foot">

--- a/admin/views/rbfw-modern-editor.php
+++ b/admin/views/rbfw-modern-editor.php
@@ -144,14 +144,12 @@
 				</div>
 
 				<!-- Category Settings ───────────────────────────────── -->
-				<div class="rbfw-me-card">
+				<div class="rbfw-me-card rbfw-me-rent-type-card" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_rent_type_crud' ) ); ?>">
 					<div class="rbfw-me-card__head">
 						<h2><?php esc_html_e( 'Category Settings', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
 						<p>
 							<?php esc_html_e( 'Here you can manage rent type.', 'booking-and-rental-manager-for-woocommerce' ); ?>
-							<a href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=rbfw_item_caregory&post_type=rbfw_item' ) ); ?>" target="_blank">
-								<?php esc_html_e( 'Add new rent type', 'booking-and-rental-manager-for-woocommerce' ); ?>
-							</a>
+							<a href="#" class="rbfw-rent-type-add-trigger"><?php esc_html_e( 'Add new rent type', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
 						</p>
 					</div>
 					<div class="rbfw-me-card__body">
@@ -175,11 +173,31 @@
 							<?php endforeach; ?>
 						</div>
 						<?php if ( empty( $all_cat_terms ) ) : ?>
-							<p class="rbfw-me-field__help">
-								<?php esc_html_e( 'No categories found.', 'booking-and-rental-manager-for-woocommerce' ); ?>
-								<a href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=rbfw_item_caregory&post_type=rbfw_item' ) ); ?>" target="_blank"><?php esc_html_e( 'Create one', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
+							<p class="rbfw-me-field__help rbfw-me-rent-type-empty">
+								<?php esc_html_e( 'No rent types found.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+								<a href="#" class="rbfw-rent-type-add-trigger"><?php esc_html_e( 'Create one', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
 							</p>
 						<?php endif; ?>
+					</div>
+
+					<div class="rbfw-me-faq-modal" id="rbfw-me-rent-type-modal">
+						<div class="rbfw-me-faq-modal__backdrop"></div>
+						<div class="rbfw-me-faq-modal__box">
+							<div class="rbfw-me-faq-modal__head">
+								<h3><?php esc_html_e( 'Add New Rent Type', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+								<button type="button" class="rbfw-me-faq-modal__close"><span class="dashicons dashicons-no-alt"></span></button>
+							</div>
+							<div class="rbfw-me-faq-modal__body">
+								<div class="rbfw-me-field">
+									<label class="rbfw-me-field__label" for="rbfw-me-rent-type-modal-input"><?php esc_html_e( 'Rent type name', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+									<input class="rbfw-me-input" type="text" id="rbfw-me-rent-type-modal-input" placeholder="<?php esc_attr_e( 'e.g. Bike, Car, Equipment…', 'booking-and-rental-manager-for-woocommerce' ); ?>" />
+								</div>
+							</div>
+							<div class="rbfw-me-faq-modal__foot">
+								<button type="button" id="rbfw-me-rent-type-modal-save" class="rbfw-me-btn rbfw-me-btn--primary"><?php esc_html_e( 'Add Rent Type', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+								<button type="button" class="rbfw-me-btn rbfw-me-btn--secondary rbfw-me-rent-type-modal-cancel"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+							</div>
+						</div>
 					</div>
 				</div>
 

--- a/functions.php
+++ b/functions.php
@@ -169,6 +169,89 @@ function rbfw_prepare_feature_category_meta_value( $value ) {
 }
 
 /**
+ * Flatten posted rent-type values into a list of names.
+ *
+ * @param mixed $raw Posted rbfw_categories value (array or string).
+ * @return string[]
+ */
+function rbfw_normalize_rent_type_input( $raw ) {
+    $names = array();
+
+    if ( is_string( $raw ) ) {
+        $raw = array( $raw );
+    }
+
+    if ( ! is_array( $raw ) ) {
+        return array();
+    }
+
+    foreach ( $raw as $item ) {
+        if ( is_array( $item ) ) {
+            $names = array_merge( $names, rbfw_normalize_rent_type_input( $item ) );
+            continue;
+        }
+
+        $item = sanitize_text_field( (string) $item );
+        if ( '' === $item ) {
+            continue;
+        }
+
+        foreach ( explode( ',', $item ) as $part ) {
+            $part = trim( $part );
+            if ( '' !== $part ) {
+                $names[] = $part;
+            }
+        }
+    }
+
+    return $names;
+}
+
+/**
+ * Map of lowercase rent-type name => canonical taxonomy term name.
+ *
+ * @return array<string, string>
+ */
+function rbfw_get_valid_rent_type_names() {
+    $terms = get_terms(
+        array(
+            'taxonomy'   => 'rbfw_item_caregory',
+            'hide_empty' => false,
+        )
+    );
+
+    $valid = array();
+    if ( ! is_wp_error( $terms ) ) {
+        foreach ( $terms as $term ) {
+            $valid[ strtolower( $term->name ) ] = $term->name;
+        }
+    }
+
+    return $valid;
+}
+
+/**
+ * Keep only rent types that exist in rbfw_item_caregory.
+ *
+ * @param mixed $raw Posted rbfw_categories value.
+ * @return string[]
+ */
+function rbfw_sanitize_rent_type_categories( $raw ) {
+    $names = rbfw_normalize_rent_type_input( $raw );
+    $valid = rbfw_get_valid_rent_type_names();
+    $out   = array();
+
+    foreach ( $names as $name ) {
+        $key = strtolower( $name );
+        if ( isset( $valid[ $key ] ) ) {
+            $out[] = $valid[ $key ];
+        }
+    }
+
+    return array_values( array_unique( $out ) );
+}
+
+/**
  * Helper to fetch the sanitized feature category meta.
  *
  * @param int $post_id

--- a/inc/rbfw_shortcodes.php
+++ b/inc/rbfw_shortcodes.php
@@ -58,7 +58,13 @@ function rbfw_rent_list_get_category_filter_names( $category ) {
                 $category_names[] = $term->name;
             }
         } else {
-            $category_names[] = $category_value;
+            $term = get_term_by( 'name', $category_value, 'rbfw_item_caregory' );
+            if ( ! $term ) {
+                $term = get_term_by( 'slug', sanitize_title( $category_value ), 'rbfw_item_caregory' );
+            }
+            if ( $term && ! is_wp_error( $term ) ) {
+                $category_names[] = $term->name;
+            }
         }
     }
 
@@ -256,13 +262,14 @@ function rbfw_rent_list_shortcode_func($atts = null) {
         );
 
 
-        if( !empty( $rbfw_search_type ) ) {
-            $search_category_name = $rbfw_search_type;
-            $args['meta_query'][] = array(
-                    'key' => 'rbfw_categories',
-                'value' => $search_category_name,
-                'compare' => 'LIKE'
+        if ( ! empty( $rbfw_search_type ) ) {
+            $validated_types = rbfw_sanitize_rent_type_categories(
+                array( sanitize_text_field( (string) $rbfw_search_type ) )
             );
+            $category_clause = rbfw_build_categories_meta_clause( $validated_types );
+            if ( ! empty( $category_clause ) ) {
+                $args['meta_query'][] = $category_clause;
+            }
         }
 
 

--- a/templates/rental_lists.php
+++ b/templates/rental_lists.php
@@ -100,11 +100,10 @@ function render_mep_events_by_status( $posts ) {
 function fount_post_number_by_category(){
 
     global $wpdb;
-    $results = $wpdb->get_results("
-    SELECT post_id, meta_value 
-    FROM {$wpdb->prefix}postmeta 
-    WHERE meta_key = 'rbfw_categories'
-");
+    $results = $wpdb->get_results( $wpdb->prepare(
+        "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s",
+        'rbfw_categories'
+    ) );
 
     $category_counts = [];
 


### PR DESCRIPTION
Replace the external edit-tags.php link with in-editor modals so rent types can be created without leaving the rental item editor.

Problem:
- "Add new rent type" opened edit-tags.php?taxonomy=rbfw_item_caregory in a new tab, forcing admins out of the classic or modern editor workflow.
- The separate taxonomy submenu duplicated management already needed on the item edit screen.

Solution:
- Classic editor (General Info tab):
  - "Add new rent type" opens a WordPress-style modal popup.
  - Modal collects the rent type name and saves via AJAX.
  - Checkbox list rebuilds after save; the new type is auto-selected.
- Modern editor (Category Settings card):
  - Same flow using the existing rbfw-me-faq-modal component.
  - Pill checkbox grid rebuilds and auto-selects the newly added type.
- Shared backend:
  - New wp_ajax_rbfw_rent_type_add handler in RBFW_General_Info.
  - Nonce-protected (rbfw_rent_type_crud), requires manage_categories.
  - Creates rbfw_item_caregory taxonomy terms via wp_insert_term().
- Taxonomy admin:
  - Set show_in_menu => false on rbfw_item_caregory (same pattern as rbfw_item_location) so rent types are managed inline only.

Files changed:
- admin/settings/General_Info.php — AJAX handler, classic modal markup/JS/CSS
- admin/views/rbfw-modern-editor.php — modern modal markup and trigger links
- admin/js/rbfw-modern-editor.js — modal open/close, AJAX save, grid rebuild
- admin/taxonomy_register.php — hide taxonomy submenu from admin sidebar

Test plan:
- Classic editor: open rbfw_item, General Info, click "Add new rent type", create a type, confirm modal closes and checkbox appears checked.
- Modern editor: same on Category Settings step; confirm pill appears selected.
- Verify duplicate name shows an error from wp_insert_term.
- Confirm Rent Type submenu no longer appears under Rental Items in wp-admin.