### PR TITLE
Fix: mobile layout for default single-rental detail page

### DIFF
--- a/assets/mp_script/rbfw_script.js
+++ b/assets/mp_script/rbfw_script.js
@@ -693,3 +693,62 @@ function fee_management(sub_total_price,total_days=1,quantity=1){
 }
 
 
+/*
+ * Mobile layout reorder for the default single-rental template.
+ *
+ * Desktop: .mp_left_section (content) and .mp_right_section (booking form) sit
+ * side by side as the two columns of .mp_details_page. On mobile (<=792px)
+ * .mp_details_page becomes a single column, which would otherwise push the
+ * booking form to the very bottom (below Description / FAQ / Related Items).
+ *
+ * The booking form and the features header (.rbfw-header-container) live at
+ * different DOM depths, so they cannot be reordered with pure CSS without
+ * flattening several wrappers that carry layout styles. We instead relocate the
+ * whole .mp_right_section node (preserving its bound state) to sit directly
+ * under .rbfw-header-container on mobile, and restore it as the last column on
+ * larger screens. Guarded so it only runs where all three nodes exist (the
+ * "default" template family); it no-ops on the muffin template and elsewhere.
+ */
+(function () {
+    var rbfwBookingMq = window.matchMedia('(max-width: 792px)');
+
+    function rbfwArrangeBookingForm() {
+        var detailsPage = document.querySelector('.mp_details_page');
+        if (!detailsPage) {
+            return;
+        }
+        var rightSection = detailsPage.querySelector('.mp_right_section');
+        var header = detailsPage.querySelector('.rbfw-header-container');
+        if (!rightSection || !header) {
+            return;
+        }
+
+        if (rbfwBookingMq.matches) {
+            // Mobile: place the booking form right after the features header.
+            if (header.nextElementSibling !== rightSection) {
+                header.insertAdjacentElement('afterend', rightSection);
+            }
+        } else {
+            // Desktop / tablet: keep the booking form as the last column.
+            if (detailsPage.lastElementChild !== rightSection) {
+                detailsPage.appendChild(rightSection);
+            }
+        }
+    }
+
+    // Re-run whenever the breakpoint is crossed (e.g. device rotation, resize).
+    if (typeof rbfwBookingMq.addEventListener === 'function') {
+        rbfwBookingMq.addEventListener('change', rbfwArrangeBookingForm);
+    } else if (typeof rbfwBookingMq.addListener === 'function') {
+        // Safari < 14 / legacy fallback.
+        rbfwBookingMq.addListener(rbfwArrangeBookingForm);
+    }
+
+    // This script is enqueued in the footer, so the template markup above it is
+    // already parsed: run immediately to avoid a visible jump, then re-run on
+    // DOMContentLoaded as a safety net if the nodes were not ready yet.
+    rbfwArrangeBookingForm();
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', rbfwArrangeBookingForm);
+    }
+})();

--- a/css/rbfw_style.css
+++ b/css/rbfw_style.css
@@ -1495,6 +1495,12 @@ ul.rbfw-feature-lists li i, .service-price-item .title i.sc-icon {
     div.mp_right_section {
         width: 100%;
         margin-top: 20px;
+        /* On mobile the booking form is relocated by JS to sit directly under
+           .rbfw-header-container. Drop the desktop sticky pinning so it scrolls
+           with the content; keep relative so the ::before border overlay stays
+           anchored to this box. */
+        position: relative;
+        top: auto;
     }
 
     .rbfw-single-right-container {
@@ -10858,6 +10864,42 @@ i.fas.fa-minus {
     .rbfw_default_hero_price_amount { font-size: 20px; }
     .rbfw_default_hero_desc { display: none; }
     .rbfw_default_hero_features_bar { display: none; }
+}
+/* Mobile: lift the hero title/price out of the image overlay and render it as a
+   plain text block below the slider, sitting above .rbfw-header-container with a
+   gap. Placed after the 768px block so it wins where the breakpoints overlap. */
+@media only screen and (max-width: 792px) {
+    .mp_default_theme .rbfw_default_hero_wrap {
+        margin-bottom: 16px;          /* gap before the Share / features section */
+    }
+    .rbfw_default_hero_overlay {
+        position: static;             /* drop the absolute image overlay */
+        width: 100%;
+        height: auto;
+        background: none;             /* remove the dark gradient */
+        display: block;
+        align-items: stretch;
+        padding: 14px 2px 2px;        /* gap between the image and the text */
+        pointer-events: auto;
+    }
+    .rbfw_default_hero_content {
+        color: #1a1a1a;               /* dark text now that it sits on white */
+        max-width: 100%;
+    }
+    .rbfw_default_hero_badge {
+        display: none;                /* keep current mobile appearance (was clipped) */
+    }
+    .rbfw_default_hero_title {
+        color: #1a1a1a;
+        text-shadow: none;
+        margin-bottom: 8px;
+    }
+    .rbfw_default_hero_desc {
+        display: none;
+    }
+    .rbfw_default_hero_price_label {
+        color: rgba(0, 0, 0, 0.55);
+    }
 }
 /* === End Default Template Hero Banner === */
 


### PR DESCRIPTION
Two mobile-only (max-width: 792px) fixes for the default ("Bike Theme") single-rental template family (single-day, multi-day, resort, multiple-items). Desktop/tablet (> 792px) and the muffin template are left unchanged. Both changes are CSS/JS only - no PHP, markup, data, or behavior outside the mobile breakpoint is touched.

-------------------------------------------------------------------- 1) Move the booking form directly under the features header on mobile -------------------------------------------------------------------- Problem:
  In all four default templates the DOM is:
    .mp_details_page
      |- .mp_left_section   (hero, .rbfw-header-container, tabs, related)
      \- .mp_right_section  (booking form / "Instant Booking Summary")
  At <=792px, .mp_details_page switches to display:block, so the booking
  form (a sibling AFTER the whole left column) stacked at the very bottom
  of the page, below Description / FAQ / Related Items.

Why JS instead of pure CSS:
  .rbfw-header-container is nested three levels deep inside
  .mp_left_section, while the booking form is a sibling of that section.
  Reordering across those levels with pure CSS would require flattening
  several wrappers (display:contents), which strips their layout styles
  and risks flex-sizing regressions in the owl-carousel related slider,
  calendars and tab tables. Relocating the single .mp_right_section node
  keeps every widget in normal block flow.

Changes:
  - assets/mp_script/rbfw_script.js Added a self-contained block (matchMedia '(max-width: 792px)') that moves the whole .mp_right_section node to sit right after .rbfw-header-container on mobile, and restores it as the last column of .mp_details_page on larger screens. Re-runs on breakpoint change (rotation/resize), is idempotent, runs immediately (footer script, markup already parsed) to avoid a layout flash, and is guarded so it only acts where all three nodes exist (no-op on muffin/other pages). The booking form's handlers are delegated on `document`, so moving the node preserves all bound state and inputs.
  - css/rbfw_style.css  (inside the existing @media max-width:792px block) Dropped the desktop position:sticky to position:relative on .mp_right_section so the relocated form scrolls with the content instead of pinning over it; kept relative so the ::before border overlay stays anchored.

-------------------------------------------------------------------- 2) Lift the hero title/price out of the image overlay on mobile -------------------------------------------------------------------- Problem:
  .rbfw_default_hero_overlay is position:absolute with a dark gradient and
  white text painted over the slider image. On phones the content is
  bottom-aligned and the "Best Seller" badge overflowed the top and was
  clipped by the wrapper's overflow:hidden.

Change:
  - css/rbfw_style.css Added a new @media (max-width: 792px) block (placed AFTER the existing 768px hero rules so it wins on overlap) that converts the overlay into a static text block flowing below the slider image, above .rbfw-header-container: * position:static, background:none, full width -> text drops below the image instead of over it * padding-top gap between image and text + margin-bottom on the hero wrap for a gap before the Share / features section * title -> dark (#1a1a1a), text-shadow removed; price label -> dark grey; price amount keeps its red; Book Now keeps its pill * badge and subtitle kept hidden (preserves the current mobile appearance and matches the approved design)

Testing:
  - <=792px: booking form renders under the features header; hero title/price render as readable dark text below the image with gaps.
  - 769-792px: covered (no white-on-white text, no desktop overlay).
  - >792px: desktop/tablet layout and sticky booking column unchanged.
  - All four default templates share these classes -> consistent.
  - Muffin template uses different classes -> unaffected.
  - JS validated with `node --check`; CSS braces balanced.