### PR TITLE
Booking forms: kses whitelist + rent-type CRUD + rental-list tweak

### DIFF
--- a/admin/RBFW_Rental_List.php
+++ b/admin/RBFW_Rental_List.php
@@ -281,7 +281,6 @@ if (!class_exists('RBFW_Rental_List')) {
             $base_url  = admin_url('admin.php?page=' . self::PAGE_SLUG);
             $trash_url = add_query_arg('rbfw_status', 'trash', $base_url);
             $add_url   = class_exists( 'RBFW_Modern_Editor' ) ? RBFW_Modern_Editor::add_new_url() : admin_url( 'post-new.php?post_type=rbfw_item' );
-            $classic   = admin_url('edit.php?post_type=rbfw_item&rbfw_view=classic');
             $rent_types = RBFW_Function::rbfw_rent_types();
             ?>
             <div class="wrap rbfw-fleet-wrap">
@@ -292,10 +291,6 @@ if (!class_exists('RBFW_Rental_List')) {
                             <span><?php echo esc_html(sprintf(_n('%d item', '%d items', $total, 'booking-and-rental-manager-for-woocommerce'), $total)); ?></span>
                         </div>
                         <div class="rbfw-header-actions">
-                            <a class="rbfw-classic-link" href="<?php echo esc_url($classic); ?>">
-                                <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-                                <?php esc_html_e('Classic view', 'booking-and-rental-manager-for-woocommerce'); ?>
-                            </a>
                             <a class="rbfw-add-btn" href="<?php echo esc_url($add_url); ?>">
                                 <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                                 <?php printf(esc_html__('Add New %s', 'booking-and-rental-manager-for-woocommerce'), esc_html($name)); ?>

--- a/admin/css/rbfw-modern-editor.css
+++ b/admin/css/rbfw-modern-editor.css
@@ -9262,3 +9262,62 @@ textarea.rbfw-me-field-invalid {
 .rbfw-me-panel[data-panel="pricing"][data-item-type="multiple_items"] .rbfw-sp-modern-panel > .sessional_price_multiple_items {
     display: block !important;
 }
+
+/* Rent-type chip hover actions (edit / delete) */
+.rbfw-me-checkbox-label.rbfw-rt-chip { position: relative; }
+/* The pill sets `span { pointer-events: none }` so text clicks fall through to the
+   label; re-enable it on the action icons or edit/delete clicks never register. */
+.rbfw-me-checkbox-label.rbfw-rt-chip .rbfw-rt-actions,
+.rbfw-me-checkbox-label.rbfw-rt-chip .rbfw-rt-actions span { pointer-events: auto; }
+.rbfw-me-checkbox-label.rbfw-rt-chip .rbfw-rt-actions {
+    position: absolute;
+    top: -12px;
+    right: -10px;
+    display: none;
+    align-items: center;
+    gap: 8px;
+    background: #fff;
+    border: 1px solid #d8dee9;
+    border-radius: 7px;
+    padding: 4px 9px;
+    box-shadow: 0 3px 10px rgba(0,0,0,.16);
+    z-index: 4;
+}
+.rbfw-me-checkbox-label.rbfw-rt-chip:hover .rbfw-rt-actions { display: inline-flex; }
+.rbfw-me-checkbox-label.rbfw-rt-chip .rbfw-rt-actions .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    line-height: 16px;
+    cursor: pointer;
+    color: #6b7280;
+    transition: color .15s, transform .15s;
+}
+.rbfw-me-checkbox-label.rbfw-rt-chip .rbfw-rt-actions .dashicons:hover { transform: scale(1.18); }
+.rbfw-me-checkbox-label.rbfw-rt-chip .rbfw-rt-actions .rbfw-rt-edit:hover { color: #2271b1; }
+.rbfw-me-checkbox-label.rbfw-rt-chip .rbfw-rt-actions .rbfw-rt-del:hover { color: #d63638; }
+
+/* Animated (moving) gradient border shown while hovering a rent-type chip */
+.rbfw-me-checkbox-label.rbfw-rt-chip::after {
+    content: "";
+    position: absolute;
+    inset: -2px;
+    border-radius: 999px;
+    padding: 2px;
+    background: linear-gradient(90deg, #1a73e8, #34a853, #fbbc05, #ea4335, #1a73e8);
+    background-size: 300% 100%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+            mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .2s ease;
+}
+.rbfw-me-checkbox-label.rbfw-rt-chip:hover::after {
+    opacity: 1;
+    animation: rbfw-rt-border-move 2s linear infinite;
+}
+@keyframes rbfw-rt-border-move {
+    to { background-position: 300% 0; }
+}

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -1314,9 +1314,24 @@
 
         function rtEsc(s) { return $('<div>').text(s == null ? '' : String(s)).html(); }
 
+        var meEditTermId = 0; // 0 = add mode, >0 = rename mode
+
+        function meCard()      { return $wrap.find('.rbfw-me-rent-type-card'); }
+        function meNonce()     { return meCard().data('nonce'); }
+        function meCanManage() { return String(meCard().data('can-manage')) === '1'; }
+        function meHidden()    { return $wrap.find('.rbfw-me-cats-hidden'); }
+
+        function meActionsHtml() {
+            if (!meCanManage()) { return ''; }
+            return '<span class="rbfw-rt-actions">' +
+                '<span class="rbfw-rt-edit dashicons dashicons-edit" title="Edit"></span>' +
+                '<span class="rbfw-rt-del dashicons dashicons-trash" title="Delete"></span>' +
+            '</span>';
+        }
+
         function rebuildRentTypes(rentTypes, selectName) {
             rentTypes = rentTypes || [];
-            var current = ($wrap.find('.rbfw-me-cats-hidden').val() || '').split(',').filter(Boolean);
+            var current = (meHidden().val() || '').split(',').filter(Boolean);
             if (selectName) {
                 var selectLower = String(selectName).toLowerCase().trim();
                 var has = current.some(function (n) { return String(n).toLowerCase().trim() === selectLower; });
@@ -1330,25 +1345,31 @@
                 var checked = current.some(function (n) { return String(n).toLowerCase().trim() === nameLower; });
                 var checkedAttr = checked ? ' checked' : '';
                 $grid.append(
-                    '<label class="rbfw-me-checkbox-label' + (checked ? ' is-checked' : '') + '">' +
+                    '<label class="rbfw-me-checkbox-label rbfw-rt-chip' + (checked ? ' is-checked' : '') + '" data-term-id="' + rtEsc(rt.term_id) + '" data-name="' + rtEsc(rt.name) + '">' +
                         '<input type="checkbox" class="rbfw-me-cat-checkbox" data-name="' + rtEsc(rt.name) + '"' + checkedAttr + ' />' +
                         '<span>' + rtEsc(rt.name.charAt(0).toUpperCase() + rt.name.slice(1)) + '</span>' +
+                        meActionsHtml() +
                     '</label>'
                 );
             });
-            $wrap.find('.rbfw-me-cats-hidden').val(current.join(','));
+            meHidden().val(current.join(','));
             $wrap.find('.rbfw-me-rent-type-empty').toggleClass('rbfw-me-hidden', rentTypes.length > 0);
         }
 
-        function openRentTypeModal() {
+        function openRentTypeModal(mode, termId, name) {
+            meEditTermId = mode === 'edit' ? (parseInt(termId, 10) || 0) : 0;
+            var isEdit = meEditTermId > 0;
             var $modal = $wrap.find('#rbfw-me-rent-type-modal');
-            $modal.find('#rbfw-me-rent-type-modal-input').val('');
+            $modal.find('.rbfw-me-faq-modal__head h3').text(isEdit ? 'Rename Rent Type' : 'Add New Rent Type');
+            $modal.find('#rbfw-me-rent-type-modal-save').text(isEdit ? 'Save Changes' : 'Add Rent Type');
+            $modal.find('#rbfw-me-rent-type-modal-input').val(name || '');
             $modal.addClass('is-open');
             setTimeout(function () { $modal.find('#rbfw-me-rent-type-modal-input').trigger('focus'); }, 50);
         }
 
         function closeRentTypeModal() {
             $wrap.find('#rbfw-me-rent-type-modal').removeClass('is-open');
+            meEditTermId = 0;
         }
 
         // Set initial pill state for pre-checked boxes
@@ -1362,12 +1383,44 @@
             $wrap.find('.rbfw-me-cat-checkbox:checked').each(function () {
                 selected.push($(this).data('name'));
             });
-            $wrap.find('.rbfw-me-cats-hidden').val(selected.join(','));
+            meHidden().val(selected.join(','));
         });
 
         $wrap.on('click', '.rbfw-rent-type-add-trigger', function (e) {
             e.preventDefault();
-            openRentTypeModal();
+            openRentTypeModal('add');
+        });
+
+        // Edit (rename) a rent type.
+        $wrap.on('click', '.rbfw-me-rent-type-card .rbfw-rt-edit', function (e) {
+            e.preventDefault(); e.stopPropagation();
+            var $chip = $(this).closest('.rbfw-rt-chip');
+            openRentTypeModal('edit', $chip.data('term-id'), $chip.data('name'));
+        });
+
+        // Delete a rent type.
+        $wrap.on('click', '.rbfw-me-rent-type-card .rbfw-rt-del', function (e) {
+            e.preventDefault(); e.stopPropagation();
+            var $chip  = $(this).closest('.rbfw-rt-chip');
+            var termId = parseInt($chip.data('term-id'), 10) || 0;
+            var name   = $chip.data('name');
+            if (!termId) { return; }
+            if (!window.confirm('Delete rent type "' + name + '"? Items using it will have this type removed.')) { return; }
+            $.post(window.ajaxurl, {
+                action: 'rbfw_rent_type_delete',
+                nonce:  meNonce(),
+                term_id: termId
+            }, function (resp) {
+                if (resp && resp.success) {
+                    var cur = (meHidden().val() || '').split(',').filter(Boolean).filter(function (n) {
+                        return n.toLowerCase() !== String(resp.data.deleted_name).toLowerCase();
+                    });
+                    meHidden().val(cur.join(','));
+                    rebuildRentTypes(resp.data.rent_types);
+                } else {
+                    window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                }
+            }).fail(function () { window.alert('Request failed.'); });
         });
 
         $wrap.on('click', '#rbfw-me-rent-type-modal .rbfw-me-faq-modal__close, #rbfw-me-rent-type-modal .rbfw-me-faq-modal__backdrop, .rbfw-me-rent-type-modal-cancel', function () {
@@ -1375,23 +1428,43 @@
         });
 
         $wrap.on('click', '#rbfw-me-rent-type-modal-save', function () {
-            var $card  = $wrap.find('.rbfw-me-rent-type-card');
             var $input = $wrap.find('#rbfw-me-rent-type-modal-input');
             var name   = $.trim($input.val());
             if (!name) { $input.trigger('focus'); return; }
             if (name.length > 200) { name = name.substring(0, 200); }
-            $.post(window.ajaxurl, {
-                action: 'rbfw_rent_type_add',
-                nonce:  $card.data('nonce'),
-                name:   name
-            }, function (resp) {
-                if (resp && resp.success) {
-                    rebuildRentTypes(resp.data.rent_types, resp.data.added_name);
-                    closeRentTypeModal();
-                } else {
-                    window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
-                }
-            }).fail(function () { window.alert('Request failed.'); });
+
+            if (meEditTermId > 0) {
+                $.post(window.ajaxurl, {
+                    action: 'rbfw_rent_type_rename',
+                    nonce:  meNonce(),
+                    term_id: meEditTermId,
+                    name:   name
+                }, function (resp) {
+                    if (resp && resp.success) {
+                        var cur = (meHidden().val() || '').split(',').filter(Boolean).map(function (n) {
+                            return n.toLowerCase() === String(resp.data.old_name).toLowerCase() ? resp.data.new_name : n;
+                        });
+                        meHidden().val(cur.join(','));
+                        rebuildRentTypes(resp.data.rent_types);
+                        closeRentTypeModal();
+                    } else {
+                        window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                    }
+                }).fail(function () { window.alert('Request failed.'); });
+            } else {
+                $.post(window.ajaxurl, {
+                    action: 'rbfw_rent_type_add',
+                    nonce:  meNonce(),
+                    name:   name
+                }, function (resp) {
+                    if (resp && resp.success) {
+                        rebuildRentTypes(resp.data.rent_types, resp.data.added_name);
+                        closeRentTypeModal();
+                    } else {
+                        window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                    }
+                }).fail(function () { window.alert('Request failed.'); });
+            }
         });
 
         $wrap.on('keypress', '#rbfw-me-rent-type-modal-input', function (e) {

--- a/admin/settings/General_Info.php
+++ b/admin/settings/General_Info.php
@@ -12,6 +12,8 @@
 				add_action( 'rbfw_meta_box_tab_content', [ $this, 'add_tabs_content' ] );
 				add_action( 'save_post', array( $this, 'settings_save' ), 99, 1 );
 				add_action( 'wp_ajax_rbfw_rent_type_add', [ $this, 'ajax_rent_type_add' ] );
+				add_action( 'wp_ajax_rbfw_rent_type_rename', [ $this, 'ajax_rent_type_rename' ] );
+				add_action( 'wp_ajax_rbfw_rent_type_delete', [ $this, 'ajax_rent_type_delete' ] );
 			}
 
 			/**
@@ -59,6 +61,135 @@
 					'rent_types' => $this->rbfw_get_rent_type_list(),
 					'added_name' => $name,
 				) );
+			}
+
+			/**
+			 * AJAX: rename a rent type and migrate the name-based selection meta on every
+			 * item that used it ( rbfw_categories stores names, not ids ).
+			 */
+			public function ajax_rent_type_rename() {
+				$this->rbfw_rent_type_crud_guard();
+				$term_id = isset( $_POST['term_id'] ) ? absint( wp_unslash( $_POST['term_id'] ) ) : 0;
+				$name    = isset( $_POST['name'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['name'] ) ) ) : '';
+				if ( ! $term_id ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Invalid rent type.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				if ( '' === $name ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Please enter a rent type name.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				if ( mb_strlen( $name ) > 200 ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Rent type name must be 200 characters or fewer.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$term = get_term( $term_id, 'rbfw_item_caregory' );
+				if ( ! $term || is_wp_error( $term ) ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Rent type not found.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$old_name = $term->name;
+				if ( $old_name !== $name ) {
+					$res = wp_update_term( $term_id, 'rbfw_item_caregory', array( 'name' => $name ) );
+					if ( is_wp_error( $res ) ) {
+						wp_send_json_error( array( 'message' => sanitize_text_field( $res->get_error_message() ) ) );
+					}
+					$this->rbfw_sync_rent_type_meta( $this->rbfw_get_items_with_term( $term_id ), $old_name, $name );
+				}
+				wp_send_json_success( array(
+					'rent_types' => $this->rbfw_get_rent_type_list(),
+					'term_id'    => $term_id,
+					'old_name'   => $old_name,
+					'new_name'   => $name,
+				) );
+			}
+
+			/**
+			 * AJAX: delete a rent type and drop its name from every item's selection meta.
+			 */
+			public function ajax_rent_type_delete() {
+				$this->rbfw_rent_type_crud_guard();
+				$term_id = isset( $_POST['term_id'] ) ? absint( wp_unslash( $_POST['term_id'] ) ) : 0;
+				if ( ! $term_id ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Invalid rent type.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$term = get_term( $term_id, 'rbfw_item_caregory' );
+				if ( ! $term || is_wp_error( $term ) ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Rent type not found.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$old_name = $term->name;
+				// Capture affected items before the term relationship is removed.
+				$affected = $this->rbfw_get_items_with_term( $term_id );
+				$res      = wp_delete_term( $term_id, 'rbfw_item_caregory' );
+				if ( is_wp_error( $res ) ) {
+					wp_send_json_error( array( 'message' => sanitize_text_field( $res->get_error_message() ) ) );
+				}
+				if ( false === $res || 0 === $res ) {
+					wp_send_json_error( array( 'message' => esc_html__( 'Could not delete the rent type.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+				}
+				$this->rbfw_sync_rent_type_meta( $affected, $old_name, null );
+				wp_send_json_success( array(
+					'rent_types'      => $this->rbfw_get_rent_type_list(),
+					'deleted_term_id' => $term_id,
+					'deleted_name'    => $old_name,
+				) );
+			}
+
+			/**
+			 * IDs of rbfw_item posts that currently have the given term assigned.
+			 *
+			 * @param int $term_id
+			 * @return int[]
+			 */
+			private function rbfw_get_items_with_term( $term_id ) {
+				$query = new WP_Query( array(
+					'post_type'              => 'rbfw_item',
+					'post_status'            => 'any',
+					'fields'                 => 'ids',
+					'posts_per_page'         => -1,
+					'no_found_rows'          => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+					'tax_query'              => array(
+						array(
+							'taxonomy' => 'rbfw_item_caregory',
+							'field'    => 'term_id',
+							'terms'    => (int) $term_id,
+						),
+					),
+				) );
+				return array_map( 'intval', (array) $query->posts );
+			}
+
+			/**
+			 * Update the name-based rbfw_categories post meta for affected items.
+			 *
+			 * @param int[]       $post_ids
+			 * @param string      $old_name
+			 * @param string|null $new_name Pass null to remove the name (delete).
+			 */
+			private function rbfw_sync_rent_type_meta( $post_ids, $old_name, $new_name ) {
+				$old_key = strtolower( trim( $old_name ) );
+				foreach ( (array) $post_ids as $pid ) {
+					$cats = get_post_meta( $pid, 'rbfw_categories', true );
+					$cats = is_array( $cats ) ? $cats : ( $cats ? maybe_unserialize( $cats ) : array() );
+					if ( ! is_array( $cats ) ) {
+						continue;
+					}
+					$changed = false;
+					$out     = array();
+					foreach ( $cats as $cat ) {
+						if ( strtolower( trim( (string) $cat ) ) === $old_key ) {
+							$changed = true;
+							if ( null !== $new_name && '' !== $new_name ) {
+								$out[] = $new_name; // rename
+							}
+							// delete -> drop it
+						} else {
+							$out[] = $cat;
+						}
+					}
+					if ( $changed ) {
+						$out = array_values( array_unique( $out ) );
+						update_post_meta( $pid, 'rbfw_categories', $out );
+					}
+				}
 			}
 
 			public function add_tab_menu() {
@@ -111,13 +242,20 @@
                         </p>
                     </div>
                 </section>
-                <section class="rbfw_off_days justify-content-center rbfw-rent-type-checkboxes" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_rent_type_crud' ) ); ?>">
+                <?php $rbfw_rt_can_manage = current_user_can( 'manage_categories' ); ?>
+                <section class="rbfw_off_days justify-content-center rbfw-rent-type-checkboxes" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_rent_type_crud' ) ); ?>" data-can-manage="<?php echo $rbfw_rt_can_manage ? '1' : '0'; ?>">
                     <div class="groupCheckBox">
                         <input type="hidden" name="rbfw_categories[]" value="<?php echo esc_attr( $rbfw_categories_items ); ?>">
                         <?php foreach ( $terms as $key => $value ) { ?>
-                            <label class="customCheckboxLabel">
+                            <label class="customCheckboxLabel rbfw-rt-chip" data-term-id="<?php echo esc_attr( $value->term_id ); ?>" data-name="<?php echo esc_attr( $value->name ); ?>">
                                 <input type="checkbox" <?php echo esc_attr( in_array( $value->name, $rbfw_categories_array ) ) ? 'checked' : ''; ?> data-checked="<?php echo esc_attr( $value->name ) ?>">
                                 <span class="customCheckbox"><?php echo esc_html( ucfirst( $value->name ) ); ?></span>
+                                <?php if ( $rbfw_rt_can_manage ) { ?>
+                                    <span class="rbfw-rt-actions">
+                                        <span class="rbfw-rt-edit dashicons dashicons-edit" title="<?php esc_attr_e( 'Edit', 'booking-and-rental-manager-for-woocommerce' ); ?>"></span>
+                                        <span class="rbfw-rt-del dashicons dashicons-trash" title="<?php esc_attr_e( 'Delete', 'booking-and-rental-manager-for-woocommerce' ); ?>"></span>
+                                    </span>
+                                <?php } ?>
                             </label>
                         <?php } ?>
                     </div>
@@ -141,8 +279,21 @@
                 </div>
                 <script>
                     (function () {
+                        var editTermId = 0; // 0 = add mode, >0 = rename mode
+
                         function rtEsc(s) { return jQuery('<div>').text(s == null ? '' : String(s)).html(); }
                         function rtNonce() { return jQuery('.rbfw-rent-type-checkboxes').data('nonce'); }
+                        function rtCanManage() { return String(jQuery('.rbfw-rent-type-checkboxes').data('can-manage')) === '1'; }
+
+                        function rtActionsHtml() {
+                            if (!rtCanManage()) { return ''; }
+                            return '<span class="rbfw-rt-actions">' +
+                                '<span class="rbfw-rt-edit dashicons dashicons-edit" title="Edit"></span>' +
+                                '<span class="rbfw-rt-del dashicons dashicons-trash" title="Delete"></span>' +
+                            '</span>';
+                        }
+
+                        function rtHidden() { return jQuery('.rbfw-rent-type-checkboxes input[type="hidden"]'); }
 
                         function rtRebuild(rentTypes, selectName) {
                             rentTypes = rentTypes || [];
@@ -156,29 +307,68 @@
                             rentTypes.forEach(function (rt) {
                                 var checked = current.indexOf(rt.name) !== -1 ? ' checked' : '';
                                 $group.append(
-                                    '<label class="customCheckboxLabel">' +
+                                    '<label class="customCheckboxLabel rbfw-rt-chip" data-term-id="' + rtEsc(rt.term_id) + '" data-name="' + rtEsc(rt.name) + '">' +
                                         '<input type="checkbox"' + checked + ' data-checked="' + rtEsc(rt.name) + '">' +
                                         '<span class="customCheckbox">' + rtEsc(rt.name.charAt(0).toUpperCase() + rt.name.slice(1)) + '</span>' +
+                                        rtActionsHtml() +
                                     '</label>'
                                 );
                             });
                             $group.find('input[type="hidden"]').val(current.join(','));
                         }
 
-                        function rtOpenModal() {
-                            jQuery('#rbfw-rent-type-modal-input').val('');
+                        function rtOpenModal(mode, termId, name) {
+                            editTermId = mode === 'edit' ? (parseInt(termId, 10) || 0) : 0;
+                            var isEdit = editTermId > 0;
+                            jQuery('#rbfw-rent-type-modal .rbfw-rent-type-modal__head h3').text(isEdit ? 'Rename Rent Type' : 'Add New Rent Type');
+                            jQuery('#rbfw-rent-type-modal-save').text(isEdit ? 'Save Changes' : 'Add Rent Type');
+                            jQuery('#rbfw-rent-type-modal-input').val(name || '');
                             jQuery('#rbfw-rent-type-modal').addClass('is-open');
                             setTimeout(function () { jQuery('#rbfw-rent-type-modal-input').trigger('focus'); }, 50);
                         }
 
                         function rtCloseModal() {
                             jQuery('#rbfw-rent-type-modal').removeClass('is-open');
+                            editTermId = 0;
                         }
 
                         jQuery(document).on('click', '.rbfw-rent-type-add-trigger', function (e) {
                             e.preventDefault();
-                            rtOpenModal();
+                            rtOpenModal('add');
                         });
+
+                        // Edit (rename) a rent type.
+                        jQuery(document).on('click', '.rbfw-rent-type-checkboxes .rbfw-rt-edit', function (e) {
+                            e.preventDefault(); e.stopPropagation();
+                            var $chip = jQuery(this).closest('.rbfw-rt-chip');
+                            rtOpenModal('edit', $chip.data('term-id'), $chip.data('name'));
+                        });
+
+                        // Delete a rent type.
+                        jQuery(document).on('click', '.rbfw-rent-type-checkboxes .rbfw-rt-del', function (e) {
+                            e.preventDefault(); e.stopPropagation();
+                            var $chip  = jQuery(this).closest('.rbfw-rt-chip');
+                            var termId = parseInt($chip.data('term-id'), 10) || 0;
+                            var name   = $chip.data('name');
+                            if (!termId) { return; }
+                            if (!window.confirm('Delete rent type "' + name + '"? Items using it will have this type removed.')) { return; }
+                            jQuery.post(ajaxurl, {
+                                action: 'rbfw_rent_type_delete',
+                                nonce: rtNonce(),
+                                term_id: termId
+                            }, function (resp) {
+                                if (resp && resp.success) {
+                                    var cur = (rtHidden().val() || '').split(',').filter(Boolean).filter(function (n) {
+                                        return n.toLowerCase() !== String(resp.data.deleted_name).toLowerCase();
+                                    });
+                                    rtHidden().val(cur.join(','));
+                                    rtRebuild(resp.data.rent_types);
+                                } else {
+                                    window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                                }
+                            }).fail(function () { window.alert('Request failed.'); });
+                        });
+
                         jQuery(document).on('click', '.rbfw-rent-type-modal__close, .rbfw-rent-type-modal__backdrop', function () {
                             rtCloseModal();
                         });
@@ -186,18 +376,39 @@
                             var name = jQuery.trim(jQuery('#rbfw-rent-type-modal-input').val());
                             if (!name) { jQuery('#rbfw-rent-type-modal-input').trigger('focus'); return; }
                             if (name.length > 200) { name = name.substring(0, 200); }
-                            jQuery.post(ajaxurl, {
-                                action: 'rbfw_rent_type_add',
-                                nonce: rtNonce(),
-                                name: name
-                            }, function (resp) {
-                                if (resp && resp.success) {
-                                    rtRebuild(resp.data.rent_types, resp.data.added_name);
-                                    rtCloseModal();
-                                } else {
-                                    window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
-                                }
-                            }).fail(function () { window.alert('Request failed.'); });
+
+                            if (editTermId > 0) {
+                                jQuery.post(ajaxurl, {
+                                    action: 'rbfw_rent_type_rename',
+                                    nonce: rtNonce(),
+                                    term_id: editTermId,
+                                    name: name
+                                }, function (resp) {
+                                    if (resp && resp.success) {
+                                        var cur = (rtHidden().val() || '').split(',').filter(Boolean).map(function (n) {
+                                            return n.toLowerCase() === String(resp.data.old_name).toLowerCase() ? resp.data.new_name : n;
+                                        });
+                                        rtHidden().val(cur.join(','));
+                                        rtRebuild(resp.data.rent_types);
+                                        rtCloseModal();
+                                    } else {
+                                        window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                                    }
+                                }).fail(function () { window.alert('Request failed.'); });
+                            } else {
+                                jQuery.post(ajaxurl, {
+                                    action: 'rbfw_rent_type_add',
+                                    nonce: rtNonce(),
+                                    name: name
+                                }, function (resp) {
+                                    if (resp && resp.success) {
+                                        rtRebuild(resp.data.rent_types, resp.data.added_name);
+                                        rtCloseModal();
+                                    } else {
+                                        window.alert((resp && resp.data && resp.data.message) || 'Action failed.');
+                                    }
+                                }).fail(function () { window.alert('Request failed.'); });
+                            }
                         });
                         jQuery(document).on('keypress', '#rbfw-rent-type-modal-input', function (e) {
                             if (e.which === 13) { e.preventDefault(); jQuery('#rbfw-rent-type-modal-save').trigger('click'); }
@@ -214,6 +425,12 @@
                     .rbfw-rent-type-modal__close { background: none; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: #6b7280; }
                     .rbfw-rent-type-modal__body { padding: 18px; }
                     .rbfw-rent-type-modal__foot { padding: 14px 18px; border-top: 1px solid #e2e6ee; display: flex; gap: 8px; }
+                    .rbfw-rent-type-checkboxes .rbfw-rt-chip { position: relative; }
+                    .rbfw-rent-type-checkboxes .rbfw-rt-actions { position: absolute; top: -9px; right: -7px; display: none; align-items: center; gap: 1px; background: #fff; border: 1px solid #e2e6ee; border-radius: 4px; padding: 1px 3px; box-shadow: 0 2px 6px rgba(0,0,0,.14); z-index: 3; }
+                    .rbfw-rent-type-checkboxes .rbfw-rt-chip:hover .rbfw-rt-actions { display: inline-flex; }
+                    .rbfw-rent-type-checkboxes .rbfw-rt-actions .dashicons { font-size: 15px; width: 15px; height: 15px; line-height: 15px; cursor: pointer; color: #6b7280; }
+                    .rbfw-rent-type-checkboxes .rbfw-rt-actions .rbfw-rt-edit:hover { color: #2271b1; }
+                    .rbfw-rent-type-checkboxes .rbfw-rt-actions .rbfw-rt-del:hover { color: #d63638; }
                 </style>
 				<?php
 			}

--- a/admin/views/rbfw-modern-editor.php
+++ b/admin/views/rbfw-modern-editor.php
@@ -144,7 +144,7 @@
 				</div>
 
 				<!-- Category Settings ───────────────────────────────── -->
-				<div class="rbfw-me-card rbfw-me-rent-type-card" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_rent_type_crud' ) ); ?>">
+				<div class="rbfw-me-card rbfw-me-rent-type-card" data-nonce="<?php echo esc_attr( wp_create_nonce( 'rbfw_rent_type_crud' ) ); ?>" data-can-manage="<?php echo current_user_can( 'manage_categories' ) ? '1' : '0'; ?>">
 					<div class="rbfw-me-card__head">
 						<h2><?php esc_html_e( 'Category Settings', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
 						<p>
@@ -163,14 +163,14 @@
 							<?php foreach ( $all_cat_terms as $term ) :
 								$checked = in_array( strtolower( trim( $term->name ) ), $saved_cat_names, true );
 							?>
-								<label class="rbfw-me-checkbox-label">
+								<label class="rbfw-me-checkbox-label rbfw-rt-chip" data-term-id="<?php echo esc_attr( $term->term_id ); ?>" data-name="<?php echo esc_attr( $term->name ); ?>">
 									<input
 										type="checkbox"
 										class="rbfw-me-cat-checkbox"
 										data-name="<?php echo esc_attr( $term->name ); ?>"
 										<?php checked( $checked ); ?>
 									/>
-									<span><?php echo esc_html( ucfirst( $term->name ) ); ?></span>
+									<span><?php echo esc_html( ucfirst( $term->name ) ); ?></span><?php if ( current_user_can( 'manage_categories' ) ) : ?><span class="rbfw-rt-actions"><span class="rbfw-rt-edit dashicons dashicons-edit" title="<?php esc_attr_e( 'Edit', 'booking-and-rental-manager-for-woocommerce' ); ?>"></span><span class="rbfw-rt-del dashicons dashicons-trash" title="<?php esc_attr_e( 'Delete', 'booking-and-rental-manager-for-woocommerce' ); ?>"></span></span><?php endif; ?>
 								</label>
 							<?php endforeach; ?>
 						</div>

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -18,6 +18,11 @@
 				'onclick' => true, // Allows inline JavaScript
 				'data-step' => true, // Allows inline JavaScript
 				'data-key' => true, // Allows inline JavaScript
+				'data-rbfw-field' => true,      // conditional logic: field wrapper key
+				'data-rbfw-rules' => true,      // conditional logic: base64 rules JSON
+				'data-rbfw-form' => true,       // conditional logic: form id
+				'data-rbfw-item' => true,       // conditional logic: rental item id
+				'data-rbfw-rent-type' => true,  // conditional logic: rent type token
 			),
 			'table'   => array(
                 'class' => true,
@@ -74,6 +79,7 @@
 				'class'   => true,
 				'onclick' => true, // Allows inline JavaScript
 				'for' => true, // Allows inline JavaScript
+				'data-rbfw-field' => true, // conditional logic: field wrapper key
 			),
 			'i'       => array(
 				'style'   => true, // Allows inline styles


### PR DESCRIPTION
- rbfw_allowed_html(): allow data-rbfw-* attributes on div/label so the conditional-logic rules and field markers survive wp_kses on the frontend.
- Rent-type chips: inline edit/delete (rename/delete) in the classic and modern item editors.
- Rent list: remove the redundant "Classic view" button.