### PR TITLE
feat(admin): modern Tour-style design for Global Settings page

### DIFF
--- a/admin/css/rbfw_global_settings.css
+++ b/admin/css/rbfw_global_settings.css
@@ -1,0 +1,540 @@
+/* ===================================================================
+   Global Settings Page — modern two-column layout
+   (panel + right sidebar cards), matched to the Tour Booking Manager
+   Global Settings design. Everything is scoped under
+   .rbfw_global_settings and relies on higher specificity than
+   admin_style.css, so no shared markup / Settings API is modified.
+   =================================================================== */
+
+.rbfw_global_settings {
+    --rbfw-gs-accent: #2271B1;   /* blue — active tab, header end, doc links */
+    --rbfw-gs-primary: #F12971;  /* brand pink — save button, pro card, hovers */
+    --rbfw-gs-heading: #1D2327;
+    margin: 20px 20px 20px 0;
+    box-sizing: border-box;
+}
+
+.rbfw_global_settings *,
+.rbfw_global_settings *::before,
+.rbfw_global_settings *::after {
+    box-sizing: border-box;
+}
+
+/* ── Outer flex layout: main panel + right sidebar ── */
+.rbfw_global_settings .rbfw-gs-layout {
+    display: flex;
+    align-items: flex-start;
+    gap: 20px;
+}
+
+.rbfw_global_settings .rbfw-gs-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.rbfw_global_settings .rbfw-gs-sidebar {
+    width: 260px;
+    min-width: 260px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+/* ── Panel shell ── */
+.rbfw_global_settings .rbfwPanel {
+    background: #fff;
+    border: 1px solid #E8E8E8;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+}
+
+/* ── Panel header (gradient) ── */
+.rbfw_global_settings .rbfwPanelHeader {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 18px 24px;
+    background: linear-gradient(135deg, #3F13A4 0%, #2271B1 100%);
+}
+
+.rbfw_global_settings .rbfw-gs-header-icon {
+    width: 48px;
+    height: 48px;
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.rbfw_global_settings .rbfw-gs-header-icon i {
+    font-size: 22px;
+    color: #fff;
+}
+
+.rbfw_global_settings .rbfw-gs-header-text h2 {
+    color: #fff;
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0 0 3px;
+    padding: 0;
+    line-height: 1.2;
+    border: none;
+}
+
+.rbfw_global_settings .rbfw-gs-header-text p {
+    color: rgba(255, 255, 255, 0.80);
+    font-size: 12.5px;
+    margin: 0;
+    line-height: 1.4;
+    font-weight: 400;
+}
+
+.rbfw_global_settings .rbfw-gs-version {
+    margin-left: auto;
+    align-self: flex-start;
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.rbfw_global_settings .rbfw-gs-version small {
+    font-weight: 400;
+    opacity: 0.85;
+}
+
+.rbfw_global_settings .rbfwPanelBody {
+    padding: 0;
+}
+
+/* Neutralise the legacy settings-wrapper scroll / spacing so the new
+   panel controls the layout. */
+.rbfw_global_settings .rbfwPanelBody .rbfw_settings_wrapper {
+    overflow: visible;
+    margin: 0;
+    width: 100%;
+    border: none;
+}
+
+/* ── Two-column body: left tabs + form content ── */
+.rbfw_global_settings .mage_settings_panel_wrap {
+    display: flex;
+    align-items: stretch;
+    min-height: 520px;
+    background: #fff;
+    overflow: visible;
+}
+
+/* Left tab rail */
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab-wrapper {
+    width: 240px;
+    min-width: 240px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    background: #EDF2F7;
+    padding: 10px 8px;
+}
+
+/* Tab item (rendered as <a>) */
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    margin: 0 0 3px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #3D4A5C;
+    background: transparent;
+    border: none;
+    border-left: none;
+    border-radius: 7px;
+    text-decoration: none;
+    transition: background 0.18s ease, color 0.18s ease;
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab::after {
+    display: none;
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab i {
+    color: #6B7C93;
+    font-size: 15px;
+    width: 18px;
+    text-align: center;
+    margin: 0;
+    flex-shrink: 0;
+    transition: color 0.18s ease;
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab:hover {
+    background: #D6E4F0;
+    color: #1E3A5F;
+    border-left: none;
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab:hover i {
+    color: var(--rbfw-gs-accent);
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab.rbfw-nav-tab-active {
+    background: var(--rbfw-gs-accent);
+    color: #fff;
+    border-left: none;
+    box-shadow: 0 2px 8px rgba(34, 113, 177, 0.30);
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab.rbfw-nav-tab-active::after {
+    display: none;
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab.rbfw-nav-tab-active i {
+    color: #fff;
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab:focus {
+    outline: 0;
+    box-shadow: none;
+}
+
+/* Form content column */
+.rbfw_global_settings .mage_settings_panel_wrap .metabox-holder {
+    width: auto;
+    flex: 1;
+    min-width: 0;
+    padding: 20px 24px;
+    background: #fff;
+}
+
+.rbfw_global_settings .mage_settings_panel_wrap .metabox-holder .group {
+    padding: 0;
+}
+
+/* ── Section heading (rendered as <h2> by do_settings_sections) ── */
+.rbfw_global_settings .metabox-holder .group h2 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--rbfw-gs-heading);
+    margin: 0 0 16px;
+    padding: 14px 18px;
+    background: #F8FAFC;
+    border: none;
+    border-radius: 6px;
+    line-height: 1.3;
+}
+
+.rbfw_global_settings .metabox-holder .group h2 i {
+    color: var(--rbfw-gs-accent);
+    font-size: 16px;
+    width: auto;
+    margin: 0;
+}
+
+.rbfw_global_settings .metabox-holder .group .inside {
+    margin: -8px 0 16px;
+    padding: 0 2px;
+    font-size: 12.5px;
+    color: #6B7280;
+    line-height: 1.55;
+}
+
+/* ── Settings field table styled as a card ── */
+.rbfw_global_settings .rbfw_settings_wrapper table.form-table {
+    background: #fff;
+    border: 1px solid #EAEAEA;
+    border-radius: 8px;
+    border-collapse: separate;
+    border-spacing: 0;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    margin: 0 0 20px;
+    width: 100%;
+    overflow: hidden;
+}
+
+/* Row striping + hover */
+.rbfw_global_settings .rbfw_settings_wrapper table.form-table tr {
+    border-bottom: 1px solid #F0F2F5;
+    transition: background-color 0.18s ease;
+}
+
+.rbfw_global_settings .rbfw_settings_wrapper table.form-table tr:last-child {
+    border-bottom: none;
+}
+
+.rbfw_global_settings .rbfw_settings_wrapper table.form-table tr:nth-child(odd) {
+    background-color: #F8FAFC;
+}
+
+.rbfw_global_settings .rbfw_settings_wrapper table.form-table tr:nth-child(even) {
+    background-color: #ffffff;
+}
+
+.rbfw_global_settings .rbfw_settings_wrapper table.form-table tr:hover {
+    background-color: #EEF2FF;
+}
+
+/* Label + input cells */
+.rbfw_global_settings .metabox-holder table.form-table th {
+    width: 38%;
+    padding: 14px 16px;
+    vertical-align: top;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--rbfw-gs-heading);
+    line-height: 1.4;
+}
+
+.rbfw_global_settings .metabox-holder table.form-table td {
+    padding: 12px 16px;
+    vertical-align: top;
+}
+
+/* Inputs — consistent, comfortable width (exclude the color picker field) */
+.rbfw_global_settings .metabox-holder table.form-table td input.regular-text:not(.wp-color-picker-field),
+.rbfw_global_settings .metabox-holder table.form-table td input[type="text"]:not(.wp-color-picker-field),
+.rbfw_global_settings .metabox-holder table.form-table td input[type="url"],
+.rbfw_global_settings .metabox-holder table.form-table td input[type="email"],
+.rbfw_global_settings .metabox-holder table.form-table td input[type="number"],
+.rbfw_global_settings .metabox-holder table.form-table td select {
+    width: 100%;
+    max-width: 420px;
+}
+
+.rbfw_global_settings .metabox-holder table.form-table td textarea {
+    width: 100%;
+    max-width: 100%;
+    min-height: 180px;
+    font-family: Consolas, Monaco, monospace;
+}
+
+.rbfw_global_settings .metabox-holder table.form-table td p.description {
+    color: #6B7280;
+    font-size: 12px;
+    font-style: normal;
+    margin-top: 6px;
+    line-height: 1.5;
+}
+
+/* Multicheck / radio fieldsets */
+.rbfw_global_settings .metabox-holder table.form-table td fieldset label {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 14px;
+    font-size: 13px;
+}
+
+/* Checkout Page tab — stack Booking Mode / option radios as a clean list */
+.rbfw_global_settings #rbfw_basic_payment_settings table.form-table td fieldset label {
+    display: flex;
+    margin: 0 0 6px;
+}
+
+.rbfw_global_settings #rbfw_basic_payment_settings table.form-table td fieldset label:last-child {
+    margin-bottom: 0;
+}
+
+/* ── Save button ── */
+.rbfw_global_settings .metabox-holder p.submit {
+    text-align: right;
+    margin: 0;
+    padding-top: 6px;
+}
+
+.rbfw_global_settings .metabox-holder p.submit input.button-primary,
+.rbfw_global_settings .metabox-holder .button-primary {
+    background: var(--rbfw-gs-primary);
+    border-color: var(--rbfw-gs-primary);
+    color: #fff;
+    border-radius: 6px;
+    padding: 4px 30px;
+    min-width: 150px;
+    height: auto;
+    line-height: 2.2;
+    box-shadow: none;
+    transition: opacity 0.2s ease;
+}
+
+.rbfw_global_settings .metabox-holder p.submit input.button-primary:hover,
+.rbfw_global_settings .metabox-holder .button-primary:hover {
+    background: var(--rbfw-gs-primary);
+    border-color: var(--rbfw-gs-primary);
+    opacity: 0.9;
+}
+
+/* ── Right sidebar cards ── */
+.rbfw_global_settings .rbfw-gs-card {
+    background: #fff;
+    border-radius: 8px;
+    border: 1px solid #E8E8E8;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    padding: 20px;
+}
+
+.rbfw_global_settings .rbfw-gs-pro-card {
+    background: linear-gradient(135deg, var(--rbfw-gs-primary) 0%, #C4185B 100%);
+    border: none;
+    text-align: center;
+}
+
+.rbfw_global_settings .rbfw-gs-card-icon {
+    font-size: 34px;
+    color: rgba(255, 255, 255, 0.85);
+    margin-bottom: 10px;
+    line-height: 1;
+}
+
+.rbfw_global_settings .rbfw-gs-pro-card h4 {
+    color: #fff;
+    font-size: 17px;
+    font-weight: 700;
+    margin: 0 0 8px;
+    padding: 0;
+    border: none;
+}
+
+.rbfw_global_settings .rbfw-gs-pro-card p {
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 12.5px;
+    margin: 0 0 16px;
+    line-height: 1.55;
+}
+
+.rbfw_global_settings .rbfw-gs-card:not(.rbfw-gs-pro-card) h4 {
+    color: var(--rbfw-gs-heading);
+    font-size: 13.5px;
+    font-weight: 600;
+    margin: 0 0 12px;
+    padding: 0 0 10px;
+    border-bottom: 1px solid #EAEAEA;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.rbfw_global_settings .rbfw-gs-card:not(.rbfw-gs-pro-card) h4 i {
+    color: var(--rbfw-gs-accent);
+    font-size: 15px;
+}
+
+.rbfw_global_settings .rbfw-gs-card:not(.rbfw-gs-pro-card) p {
+    color: #50575e;
+    font-size: 12.5px;
+    margin: 0 0 14px;
+    line-height: 1.55;
+}
+
+/* Documentation link list */
+.rbfw_global_settings .rbfw-gs-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.rbfw_global_settings .rbfw-gs-links li {
+    margin-bottom: 9px;
+}
+
+.rbfw_global_settings .rbfw-gs-links li:last-child {
+    margin-bottom: 0;
+}
+
+.rbfw_global_settings .rbfw-gs-links li a {
+    color: var(--rbfw-gs-accent);
+    font-size: 13px;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: color 0.2s ease;
+}
+
+.rbfw_global_settings .rbfw-gs-links li a::before {
+    content: '→';
+    font-size: 11px;
+    opacity: 0.7;
+}
+
+.rbfw_global_settings .rbfw-gs-links li a:hover {
+    color: var(--rbfw-gs-primary);
+    text-decoration: underline;
+}
+
+/* Sidebar buttons */
+.rbfw_global_settings .rbfw-gs-btn {
+    display: block;
+    text-align: center;
+    padding: 9px 16px;
+    border-radius: 5px;
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none !important;
+    transition: all 0.2s ease;
+}
+
+.rbfw_global_settings .rbfw-gs-btn-pro {
+    background: #fff;
+    color: var(--rbfw-gs-primary) !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.rbfw_global_settings .rbfw-gs-btn-pro:hover {
+    background: rgba(255, 255, 255, 0.88);
+}
+
+.rbfw_global_settings .rbfw-gs-btn-outline {
+    background: transparent;
+    border: 1px solid var(--rbfw-gs-accent);
+    color: var(--rbfw-gs-accent) !important;
+}
+
+.rbfw_global_settings .rbfw-gs-btn-outline:hover {
+    background: var(--rbfw-gs-accent);
+    color: #fff !important;
+}
+
+/* ── Responsive ── */
+@media only screen and (max-width: 1200px) {
+    .rbfw_global_settings .rbfw-gs-layout {
+        flex-direction: column;
+    }
+    .rbfw_global_settings .rbfw-gs-sidebar {
+        width: 100%;
+        min-width: 0;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .rbfw_global_settings .rbfw-gs-sidebar .rbfw-gs-card {
+        flex: 1;
+        min-width: 240px;
+    }
+}
+
+@media only screen and (max-width: 782px) {
+    .rbfw_global_settings {
+        margin-right: 10px;
+    }
+    .rbfw_global_settings .mage_settings_panel_wrap {
+        flex-direction: column;
+    }
+    .rbfw_global_settings .mage_settings_panel_wrap .rbfw-nav-tab-wrapper {
+        width: 100%;
+        min-width: 0;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .rbfw_global_settings .metabox-holder table.form-table th,
+    .rbfw_global_settings .metabox-holder table.form-table td {
+        display: block;
+        width: 100%;
+    }
+}

--- a/admin/settings/RBFW_Payment_Settings.php
+++ b/admin/settings/RBFW_Payment_Settings.php
@@ -696,6 +696,16 @@
 				tr.wc-payment-methods-field .rbfw-wc-payment-manager{margin-top:4px;padding:6px 2px;}
 				/* WooCommerce enable toggle row + additional fields: lighter rows */
 				tr.woocommerce-field td, tr.no-woocommerce-field td{vertical-align:middle;}
+
+				/* --- Align with the modern Global Settings shell ---
+				   The gateway cards / sub-tabs / accordions are the visual layer on
+				   this tab, so neutralise the generic form-table "card" (border,
+				   shadow, row striping + hover) that the shell applies to every tab,
+				   otherwise a striped box sits behind the cards. */
+				#rbfw_payment_settings table.form-table{background:transparent !important;border:none !important;box-shadow:none !important;border-radius:0 !important;margin-bottom:0 !important;}
+				#rbfw_payment_settings table.form-table tr{background:transparent !important;border-bottom:none !important;}
+				#rbfw_payment_settings table.form-table tr:hover{background:transparent !important;}
+				#rbfw_payment_settings table.form-table > tbody > tr > th{padding-left:0 !important;}
 				</style>
 				<script>
 				jQuery(function($){

--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -103,6 +103,19 @@
 				// (scoped under .rbfw_ol). The legacy rbfw-order-list-modern.css was retired:
 				// it wrapped the page in a centered max-width card (margin:0 auto -> side gaps)
 				// and shipped a global "*"/"body" reset that leaked into the rest of wp-admin.
+
+				// Global Settings page — modern two-column layout (panel + sidebar cards).
+				// Scoped under .rbfw_global_settings and loaded after the base admin style
+				// ( dependency ) so its overrides win without touching the shared Settings API.
+				if ( 'rbfw_item_page_rbfw_settings_page' === $hook ) {
+					$gs_css = RBFW_PLUGIN_DIR . '/admin/css/rbfw_global_settings.css';
+					wp_enqueue_style(
+						'rbfw-global-settings',
+						RBFW_PLUGIN_URL . '/admin/css/rbfw_global_settings.css',
+						array( 'rbfw-admin-style' ),
+						file_exists( $gs_css ) ? filemtime( $gs_css ) : false
+					);
+				}
 			}
 
 			public function rbfw_time_slots() {
@@ -614,21 +627,59 @@
 			}
 
 			function plugin_page() {
-				echo '<div class="wrap">';
-				settings_errors();
-				echo '</div>';
-				echo '<div class="rbfw_settings_wrapper">';
-				echo '<div class="rbfw_settings_inner_wrapper">';
-				echo '<div class="rbfw_settings_panel_header">';
-				echo esc_html( RBFW_Rent_Manager::get_plugin_data( 'Name' ) );
-				echo '<small>' . esc_html( RBFW_Rent_Manager::get_plugin_data( 'Version' ) ) . '</small>';
-				echo '</div>';
-				echo '<div class="mage_settings_panel_wrap rbfw_settings_panel">';
-				$this->settings_api->show_navigation();
-				$this->settings_api->show_forms();
-				echo '</div>';
-				echo '</div>';
-				echo '</div>';
+				$pro_active = is_plugin_active( 'booking-and-rental-manager-for-woocommerce-pro/rent-pro.php' );
+				?>
+				<div class="wrap rbfw_gs_notices"><?php settings_errors(); ?></div>
+				<div id="rbfw_content" class="rbfw_global_settings">
+					<div class="rbfw-gs-layout">
+						<div class="rbfw-gs-main">
+							<div class="rbfwPanel">
+								<div class="rbfwPanelHeader">
+									<div class="rbfw-gs-header-icon"><i class="fas fa-gear"></i></div>
+									<div class="rbfw-gs-header-text">
+										<h2><?php esc_html_e( 'Global Settings', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+										<p><?php esc_html_e( 'Configure plugin preferences — general behaviour, styling, custom CSS, checkout, and license settings.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+									</div>
+									<span class="rbfw-gs-version"><?php echo esc_html( RBFW_Rent_Manager::get_plugin_data( 'Name' ) ); ?> <small>v<?php echo esc_html( RBFW_Rent_Manager::get_plugin_data( 'Version' ) ); ?></small></span>
+								</div>
+								<div class="rbfwPanelBody">
+									<div class="rbfw_settings_wrapper">
+										<div class="mage_settings_panel_wrap rbfw_settings_panel">
+											<?php
+												$this->settings_api->show_navigation();
+												$this->settings_api->show_forms();
+											?>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+						<aside class="rbfw-gs-sidebar">
+							<?php if ( ! $pro_active ) : ?>
+								<div class="rbfw-gs-card rbfw-gs-pro-card">
+									<div class="rbfw-gs-card-icon"><i class="fas fa-crown"></i></div>
+									<h4><?php esc_html_e( 'Upgrade to Pro', 'booking-and-rental-manager-for-woocommerce' ); ?></h4>
+									<p><?php esc_html_e( 'Unlock advanced pricing, security deposits, PDF invoices, backend orders, and priority support.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+									<a href="https://mage-people.com/product/booking-and-rental-manager-for-woocommerce-pro/" target="_blank" rel="noopener" class="rbfw-gs-btn rbfw-gs-btn-pro"><?php esc_html_e( 'Get Pro Now', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
+								</div>
+							<?php endif; ?>
+							<div class="rbfw-gs-card">
+								<h4><i class="fas fa-book"></i> <?php esc_html_e( 'Documentation', 'booking-and-rental-manager-for-woocommerce' ); ?></h4>
+								<ul class="rbfw-gs-links">
+									<li><a href="https://www.wprently.com/docs/" target="_blank" rel="noopener"><?php esc_html_e( 'Getting Started', 'booking-and-rental-manager-for-woocommerce' ); ?></a></li>
+									<li><a href="https://www.wprently.com/docs/" target="_blank" rel="noopener"><?php esc_html_e( 'Configuration Guide', 'booking-and-rental-manager-for-woocommerce' ); ?></a></li>
+									<li><a href="https://www.wprently.com/docs/" target="_blank" rel="noopener"><?php esc_html_e( 'View All Docs', 'booking-and-rental-manager-for-woocommerce' ); ?></a></li>
+								</ul>
+							</div>
+							<div class="rbfw-gs-card">
+								<h4><i class="fas fa-puzzle-piece"></i> <?php esc_html_e( 'Addons', 'booking-and-rental-manager-for-woocommerce' ); ?></h4>
+								<p><?php esc_html_e( 'Extend your plugin with our powerful addon collection.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+								<a href="https://mage-people.com/" target="_blank" rel="noopener" class="rbfw-gs-btn rbfw-gs-btn-outline"><?php esc_html_e( 'Browse Addons', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
+							</div>
+						</aside>
+					</div>
+				</div>
+				<?php
 			}
 
 			function get_pages() {


### PR DESCRIPTION
Restyle the rental Global Settings page (Rent → Settings) to match the Tour Booking Manager Global Settings layout: a gradient header card, a left tab rail with pill-style items, card-style striped setting rows, and a right sidebar with Upgrade-to-Pro / Documentation / Addons cards.

The rental plugin uses the bundled WeDevs Settings API, whose markup (.rbfw-nav-tab-wrapper / .rbfw-nav-tab / .metabox-holder / .group / .form-table) differs from the Tour plugin's custom markup, so the Tour CSS could not be reused verbatim. Instead the redesign re-creates the same visual language against the rental's own markup, without touching the shared Settings API or its tab-switching JS.

Changes
- lib/classes/class-admin-menu.php
  - Rewrite plugin_page(): new two-column shell (gradient header with icon/title/subtitle + version badge, main panel, right sidebar cards). Keeps the existing .rbfw_settings_wrapper / .mage_settings_panel_wrap classes so the payment-tab styling keeps working. The Upgrade-to-Pro card is hidden when the Pro plugin is active.
  - Enqueue the new stylesheet only on the settings screen (rbfw_item_page_rbfw_settings_page), declared dependent on rbfw-admin-style so its scoped overrides win regardless of load order.
- admin/css/rbfw_global_settings.css (new)
  - All rules scoped under .rbfw_global_settings with higher specificity than admin_style.css: gradient header, vertical pill tabs (blue active state), section-header <h2>, card/striped/hover setting tables, pink Save button, sidebar Pro/Docs/Addons cards, and responsive stacking. Color-picker inputs are excluded from the width override so the Style Settings tab keeps its native picker. Checkout Page radios stack as a clean list.
- admin/settings/RBFW_Payment_Settings.php
  - Reconcile the Payments tab with the new shell: neutralize the generic form-table card/border/shadow/row-striping/hover on #rbfw_payment_settings so the existing modern gateway cards, sub-tabs and accordions render cleanly instead of sitting inside a striped box. Added to the tab's own inline <style> (footer) so it reliably overrides the shell CSS. No gateway markup, AJAX or JS changed.

Notes
- Presentation-only; no settings keys, option names, save handlers or Settings API behaviour changed. Pro sections/fields (registered via the rbfw_settings_sec_reg / rbfw_settings_field filters) inherit the new design automatically.