### PR TITLE
feat(pricing): require Duration / Start-End Time on rental option rows

### DIFF
--- a/admin/css/rbfw-modern-editor.css
+++ b/admin/css/rbfw-modern-editor.css
@@ -7957,6 +7957,7 @@ body.rtl.rbfw-modern-editor-screen .rbfw-me-step-nav {
     content: '⚠ ';
 }
 input.rbfw-me-field-invalid,
+select.rbfw-me-field-invalid,
 textarea.rbfw-me-field-invalid {
     border-color: #d63638 !important;
     box-shadow: 0 0 0 1px #d63638 !important;

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -785,8 +785,16 @@
 
     function validateSdPricingRows(rentType, errors) {
         var $sdRows = getMainSdPriceRows();
-        var isTimely = $wrap.find('[name="manage_inventory_as_timely"]').val() === 'on';
+        // Read the live checkbox state (matches syncTimelyUI's show/hide logic) rather
+        // than the value attribute, so validation never disagrees with the visible columns.
+        var isTimely = $wrap.find('input[type="checkbox"][name="manage_inventory_as_timely"]').is(':checked');
+        var isSpecific = $wrap.find('input[type="checkbox"][name="enable_specific_duration"]').is(':checked');
         var requireQty = rentType === 'appointment' || ! isTimely;
+        // Duration columns are required only when their column is actually visible:
+        //  - Start/End Time  → hourly inventory ON + duration-based ON
+        //  - Duration        → hourly inventory ON + duration-based OFF
+        var needTimeCols = isTimely && isSpecific;
+        var needDuration = isTimely && ! isSpecific;
         var typeLabel = rentType === 'appointment' ? 'Appointment' : 'Single Day';
         var hasValidRow = false;
 
@@ -828,11 +836,28 @@
                 }).first();
             }
 
+            // Duration / Start Time / End Time live in the same row; validate them only
+            // when their column is visible for the current mode. The seasonal (_sp) copies
+            // are excluded so we check the main table row only.
+            var notSp = function () {
+                return ( $( this ).attr( 'name' ) || '' ).indexOf( 'rbfw_bike_car_sd_data_sp' ) === -1;
+            };
+            var $duration = $row.find('[name*="[duration]"]').filter( notSp ).first();
+            var $start    = $row.find('[name*="[start_time]"]').filter( notSp ).first();
+            var $end      = $row.find('[name*="[end_time]"]').filter( notSp ).first();
+
             var rentTypeVal = $.trim($title.val());
             var priceVal = $.trim($price.val());
             var stockVal = $.trim($stock.val());
+            var durationVal = $.trim($duration.val());
+            var startVal = $.trim($start.val());
+            var endVal = $.trim($end.val());
 
-            if ( ! rentTypeVal && ! priceVal && ! stockVal ) {
+            // Skip a completely untouched row (nothing relevant to the current mode filled).
+            var rowTouched = rentTypeVal || priceVal || stockVal ||
+                             ( needDuration && durationVal ) ||
+                             ( needTimeCols && ( startVal || endVal ) );
+            if ( ! rowTouched ) {
                 return;
             }
 
@@ -845,8 +870,20 @@
             if ( requireQty && stockVal === '' ) {
                 errors.push({ $field: $stock, msg: 'Row ' + (idx + 1) + ': Stock/Day is required.' });
             }
+            if ( needDuration && durationVal === '' ) {
+                errors.push({ $field: $duration, msg: 'Row ' + (idx + 1) + ': Duration is required.' });
+            }
+            if ( needTimeCols && startVal === '' ) {
+                errors.push({ $field: $start, msg: 'Row ' + (idx + 1) + ': Start Time is required.' });
+            }
+            if ( needTimeCols && endVal === '' ) {
+                errors.push({ $field: $end, msg: 'Row ' + (idx + 1) + ': End Time is required.' });
+            }
 
-            if ( rentTypeVal && priceVal !== '' && ( ! requireQty || stockVal !== '' ) ) {
+            if ( rentTypeVal && priceVal !== '' &&
+                 ( ! requireQty || stockVal !== '' ) &&
+                 ( ! needDuration || durationVal !== '' ) &&
+                 ( ! needTimeCols || ( startVal !== '' && endVal !== '' ) ) ) {
                 hasValidRow = true;
             }
         });

--- a/admin/settings/Pricing.php
+++ b/admin/settings/Pricing.php
@@ -13,6 +13,7 @@
 				add_action( 'wp_ajax_rbfw_load_duration_form', [ $this, 'rbfw_load_duration_form' ] );
 				add_action( 'wp_ajax_nopriv_rbfw_load_duration_form', [ $this, 'rbfw_load_duration_form' ] );
                 add_action( 'save_post', array( $this, 'settings_save' ), 99, 1 );
+                add_action( 'admin_notices', array( $this, 'render_pricing_save_errors_notice' ) );
 			}
 
 			public function add_tab_menu() {
@@ -1603,6 +1604,39 @@
                 <?php
             }
 
+            /**
+             * Show the pricing validation errors saved by settings_save() when a
+             * classic-editor save was rejected. The modern editor surfaces the same
+             * errors through its AJAX response, so this notice is for the classic
+             * meta-box edit screen only.
+             */
+            public function render_pricing_save_errors_notice() {
+                if ( ! function_exists( 'get_current_screen' ) ) {
+                    return;
+                }
+                $screen = get_current_screen();
+                if ( ! $screen || 'rbfw_item' !== $screen->post_type || 'post' !== $screen->base ) {
+                    return;
+                }
+                $post_id = isset( $_GET['post'] ) ? absint( wp_unslash( $_GET['post'] ) ) : 0;
+                if ( ! $post_id && isset( $GLOBALS['post']->ID ) ) {
+                    $post_id = (int) $GLOBALS['post']->ID;
+                }
+                if ( ! $post_id ) {
+                    return;
+                }
+                $errors = get_transient( 'rbfw_pricing_save_errors_' . $post_id );
+                if ( empty( $errors ) || ! is_array( $errors ) ) {
+                    return;
+                }
+                delete_transient( 'rbfw_pricing_save_errors_' . $post_id );
+                echo '<div class="notice notice-error is-dismissible"><p><strong>' . esc_html__( 'Pricing was not saved. Please fix the following and save again:', 'booking-and-rental-manager-for-woocommerce' ) . '</strong></p><ul style="list-style:disc;margin:4px 0 4px 22px;">';
+                foreach ( $errors as $err ) {
+                    echo '<li>' . esc_html( $err ) . '</li>';
+                }
+                echo '</ul></div>';
+            }
+
             public function get_pricing_validation_errors( $item_type, $post_data ) {
                 $errors = [];
                 $item_type = sanitize_text_field( (string) $item_type );
@@ -1612,7 +1646,12 @@
                         ? $post_data['rbfw_bike_car_sd_data']
                         : [];
                     $timely = isset( $post_data['manage_inventory_as_timely'] ) && $post_data['manage_inventory_as_timely'] === 'on';
+                    $specific = isset( $post_data['enable_specific_duration'] ) && $post_data['enable_specific_duration'] === 'on';
                     $require_qty = $item_type === 'appointment' || ! $timely;
+                    // Mirror the visible columns: Duration when hourly inventory is on and
+                    // duration-based is off; Start/End Time when both are on.
+                    $need_duration = $timely && ! $specific;
+                    $need_time     = $timely && $specific;
                     $has_valid_row = false;
 
                     if ( empty( $rows ) ) {
@@ -1629,8 +1668,15 @@
                         $rent_type = trim( (string) ( $row['rent_type'] ?? '' ) );
                         $price     = trim( (string) ( $row['price'] ?? '' ) );
                         $qty       = trim( (string) ( $row['qty'] ?? '' ) );
+                        $duration  = trim( (string) ( $row['duration'] ?? '' ) );
+                        $start     = trim( (string) ( $row['start_time'] ?? '' ) );
+                        $end       = trim( (string) ( $row['end_time'] ?? '' ) );
 
-                        if ( $rent_type === '' && $price === '' && $qty === '' ) {
+                        // Skip a completely untouched row (nothing relevant to the current mode filled).
+                        $row_has_data = $rent_type !== '' || $price !== '' || $qty !== ''
+                            || ( $need_duration && $duration !== '' )
+                            || ( $need_time && ( $start !== '' || $end !== '' ) );
+                        if ( ! $row_has_data ) {
                             continue;
                         }
 
@@ -1657,14 +1703,38 @@
                                 $row_num
                             );
                         }
+                        if ( $need_duration && $duration === '' ) {
+                            $errors[] = sprintf(
+                                /* translators: %d: row number */
+                                __( 'Row %d: Duration is required.', 'booking-and-rental-manager-for-woocommerce' ),
+                                $row_num
+                            );
+                        }
+                        if ( $need_time && $start === '' ) {
+                            $errors[] = sprintf(
+                                /* translators: %d: row number */
+                                __( 'Row %d: Start Time is required.', 'booking-and-rental-manager-for-woocommerce' ),
+                                $row_num
+                            );
+                        }
+                        if ( $need_time && $end === '' ) {
+                            $errors[] = sprintf(
+                                /* translators: %d: row number */
+                                __( 'Row %d: End Time is required.', 'booking-and-rental-manager-for-woocommerce' ),
+                                $row_num
+                            );
+                        }
 
-                        if ( $rent_type !== '' && $price !== '' && ( ! $require_qty || $qty !== '' ) ) {
+                        if ( $rent_type !== '' && $price !== ''
+                            && ( ! $require_qty || $qty !== '' )
+                            && ( ! $need_duration || $duration !== '' )
+                            && ( ! $need_time || ( $start !== '' && $end !== '' ) ) ) {
                             $has_valid_row = true;
                         }
                     }
 
                     if ( ! $has_valid_row ) {
-                        $errors[] = __( 'At least one complete rental option row is required (name, price, stock/day).', 'booking-and-rental-manager-for-woocommerce' );
+                        $errors[] = __( 'At least one complete rental option row is required.', 'booking-and-rental-manager-for-woocommerce' );
                     }
 
                     return $errors;


### PR DESCRIPTION
Rental option rows show a red "*" on Price, Duration and Duration Type, but Duration (and Start/End Time) were never enforced anywhere — the single-day engine keys off name + price only — so items saved with blank durations in both editors. Per product decision, make the visible required columns actually block the save.

Enforcement is server-side in the shared validator so it covers BOTH the classic meta-box editor and the modern SPA editor from one place:

- admin/settings/Pricing.php
  - get_pricing_validation_errors(): for bike_car_sd / appointment, also require Duration when the Duration column is visible (hourly inventory ON + duration-based OFF) and Start/End Time when those are visible (both ON), mirroring the table's own show/hide logic. Empty required fields abort the save (classic: transient + early return, preserving existing data; modern: wp_send_json_error via ajax_save). Untouched spare rows are still skipped; non-timely mode still requires Stock/Day.
  - Add render_pricing_save_errors_notice() on admin_notices — the classic save previously set the error transient but nothing displayed it (silent failure); now it renders an escaped notice listing the errors.

- admin/js/rbfw-modern-editor.js + admin/css/rbfw-modern-editor.css
  - Modern editor: matching client-side check highlights the empty required input (red border + inline message) before the AJAX save, so users get per-field feedback; the server-side stays the guarantee. Mode read from the live checkbox state (:checked) to match the visible columns; select fields now also get the invalid red border.

Note: existing bike_car_sd items with blank durations (in this mode) can no longer save their pricing until Duration is filled on each row.