### PR TITLE
feat(calendar): disable + label fully-sold-out dates for single-day i…

### DIFF
--- a/assets/mp_script/rbfw_script.js
+++ b/assets/mp_script/rbfw_script.js
@@ -140,12 +140,12 @@ function rbfw_off_day_dates(date,type='',today_enable='no',dropoff=null){
 
             let rbfw_rent_type = jQuery("#rbfw_rent_type").val();
 
-            if(rbfw_rent_type == 'bike_car_md'){
+            if(rbfw_rent_type == 'bike_car_md' || rbfw_rent_type == 'bike_car_sd' || rbfw_rent_type == 'appointment'){
                 if(jQuery('#rbfw_month_wise_inventory').val()){
                     const  day_wise_inventory = JSON.parse(jQuery('#rbfw_month_wise_inventory').val());
 
                     if(day_wise_inventory[date_in]==0){
-                        return [false, "notav", rbfw_translation.sold_out];
+                        return [false, "notav rbfw-soldout-day", rbfw_translation.sold_out];
                     }
 
 

--- a/css/rbfw_style.css
+++ b/css/rbfw_style.css
@@ -5416,6 +5416,33 @@ span {
     background: transparent;
 }
 
+/* Fully sold-out day: struck-through date + a small "Sold Out" label
+   ( label text comes from the cell's title attribute, so it stays translated ). */
+#rbfw-bikecarsd-calendar .ui-datepicker table td.rbfw-soldout-day {
+    background: #FFF4F3;
+    line-height: 1;
+    vertical-align: top;
+    padding-bottom: 3px;
+}
+#rbfw-bikecarsd-calendar .ui-datepicker table td.rbfw-soldout-day span.ui-state-default {
+    text-decoration: line-through;
+    opacity: .55;
+    color: #b91c1c;
+}
+#rbfw-bikecarsd-calendar .ui-datepicker table td.rbfw-soldout-day::after {
+    content: attr(title);
+    display: block;
+    margin-top: 2px;
+    font-size: 7.5px;
+    line-height: 1;
+    font-weight: 700;
+    letter-spacing: .2px;
+    text-transform: uppercase;
+    color: #d63638;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
 .single-rbfw_item  .ui-widget-content {
     border-radius:0;
     border: 1px solid #dfdedd;

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -704,6 +704,68 @@ function rbfw_day_wise_sold_out_check_by_month($post_id, $year,  $month, $total_
     return $day_wise_inventory;
 
 }
+/**
+ * Single-day (bike_car_sd / appointment) fully-sold-out dates.
+ *
+ * Unlike multi-day (one shared stock), a single-day item has per-option stock,
+ * so a date is sold out only when EVERY rental option has zero remaining
+ * quantity. Only dates that actually have bookings can be sold out, so we test
+ * just those — O(booked dates x options), not a full-calendar scan — using the
+ * same rbfw_get_bike_car_sd_available_qty() the booking step uses, so the
+ * calendar and the step-3 availability always agree.
+ *
+ * @param int $post_id Rental item ID.
+ * @return array<string,int> Map of sold-out dates ( value 0 ), keyed 'd-m-Y' to
+ *                           match the datepicker's date_in.
+ */
+function rbfw_sd_sold_out_dates( $post_id ) {
+    if ( empty( $post_id ) ) {
+        return [];
+    }
+    $sd_data = get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true );
+    if ( empty( $sd_data ) || ! is_array( $sd_data ) ) {
+        return [];
+    }
+    $types = array_filter( array_column( $sd_data, 'rent_type' ) );
+    if ( empty( $types ) ) {
+        return [];
+    }
+    $inventory = get_post_meta( $post_id, 'rbfw_inventory', true );
+    if ( empty( $inventory ) || ! is_array( $inventory ) ) {
+        return [];
+    }
+
+    // Candidate dates = every booked date; a date with no bookings can't be sold out.
+    $candidates = [];
+    foreach ( $inventory as $inv ) {
+        if ( ! empty( $inv['booked_dates'] ) && is_array( $inv['booked_dates'] ) ) {
+            foreach ( $inv['booked_dates'] as $d ) {
+                $candidates[ $d ] = true;
+            }
+        }
+    }
+
+    $sold_out = [];
+    foreach ( array_keys( $candidates ) as $date_dmy ) {
+        $dt = DateTime::createFromFormat( 'd-m-Y', $date_dmy );
+        if ( ! $dt ) {
+            continue;
+        }
+        $date_ymd     = $dt->format( 'Y-m-d' );
+        $all_sold_out = true;
+        foreach ( $types as $type ) {
+            if ( (int) rbfw_get_bike_car_sd_available_qty( $post_id, $date_ymd, $type, '' ) > 0 ) {
+                $all_sold_out = false;
+                break;
+            }
+        }
+        if ( $all_sold_out ) {
+            $sold_out[ $date_dmy ] = 0;
+        }
+    }
+
+    return $sold_out;
+}
 function total_service_quantity($paraent,$service,$date,$inventory,$inventory_based_on_return,$start_time = null, $end_time = null){
     $total_single_service = 0;
 

--- a/templates/forms/single-day-registration.php
+++ b/templates/forms/single-day-registration.php
@@ -503,6 +503,7 @@
                 <input type="hidden" name="appointment_days" id="appointment_days"  value='<?php echo esc_attr($appointment_days); ?>'>
                 <input type="hidden" name="rbfw_off_days" id="rbfw_off_days"  value='<?php echo esc_attr(rbfw_off_days($post_id)); ?>'>
                 <input type="hidden" name="rbfw_offday_range" id="rbfw_offday_range"  value='<?php echo esc_attr(rbfw_off_dates($post_id)); ?>'>
+                <input type="hidden" id="rbfw_month_wise_inventory" value='<?php echo esc_attr( wp_json_encode( rbfw_sd_sold_out_dates( $post_id ) ) ); ?>'>
 
                 <input type="hidden" name="rbfw_particular_switch" id="rbfw_particular_switch"  value='<?php echo esc_attr($rbfw_particular_switch); ?>'>
                 <input type="hidden" name="rbfw_particulars_data" id="rbfw_particulars_data"  value='<?php echo esc_attr(wp_json_encode($particulars_data)); ?>'>


### PR DESCRIPTION
…tems

On single-day (bike_car_sd) items, a date could be picked from the availability calendar even when every rental option was already sold out; the shopper only discovered "Sold Out" on the next step. Multi-day items already grey out sold-out dates via #rbfw_month_wise_inventory — single-day was never wired up.

- inc/rbfw_inventory_functions.php: new rbfw_sd_sold_out_dates() — a date is sold out only when EVERY option has 0 remaining, computed with the same rbfw_get_bike_car_sd_available_qty() the booking step uses (so calendar and step-3 always agree). Only booked dates are tested, so it's cheap and covers all months.
- templates/forms/single-day-registration.php: output that map into the #rbfw_month_wise_inventory input the calendar already reads.
- assets/mp_script/rbfw_script.js: beforeShowDay now applies the sold-out check to bike_car_sd / appointment too, returning the date as unselectable with a "Sold Out" tooltip and a distinct rbfw-soldout-day class.
- css/rbfw_style.css: sold-out day shows a struck-through date + a small "Sold Out" label (text from the cell title, so it stays translated).

Only fully-booked dates are disabled; partially-available dates stay selectable. Display/availability only — no booking logic changed.