### PR TITLE
fix: hide meaningless day-wise booking time everywhere + fix Pricing ……fatal

### DIFF
--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -1325,7 +1325,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                 endif;
                 $rbfw_bikecarsd_duration_price = $values['rbfw_bikecarsd_duration_price'] ? $values['rbfw_bikecarsd_duration_price'] : '';
                 $rbfw_bikecarsd_service_price  = $values['rbfw_bikecarsd_service_price'] ? $values['rbfw_bikecarsd_service_price'] : '';
-                if ( $rbfw_start_time != '00:00' ) {
+                if ( rbfw_booking_has_time( $rbfw_start_time ) ) {
                     $start_date_time_label = (
                         $rbfw->get_option_trans( 'rbfw_text_start_date_and_time', 'rbfw_basic_translation_settings' )
                         && want_loco_translate() == 'no'
@@ -1351,7 +1351,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                     );
                 }
                 if ( ! empty( $rbfw_end_datetime ) ) {
-                    if ( $rbfw_end_time != '00:00' ) {
+                    if ( rbfw_booking_has_time( $rbfw_start_time ) && rbfw_booking_has_time( $rbfw_end_time ) ) {
                         $end_date_time_label = (
                             $rbfw->get_option_trans( 'rbfw_text_end_date_and_time', 'rbfw_basic_translation_settings' )
                             && want_loco_translate() == 'no'
@@ -1518,7 +1518,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $multiple_items_info = get_post_meta( $rbfw_id, 'multiple_items_info', true ) ? get_post_meta( $rbfw_id, 'multiple_items_info', true ) : array();
 
 
-                if ( $rbfw_start_time != '00:00' ) {
+                if ( rbfw_booking_has_time( $rbfw_start_time ) ) {
                     $start_date_time_label = (
                         $rbfw->get_option_trans( 'rbfw_text_start_date_and_time', 'rbfw_basic_translation_settings' )
                         && want_loco_translate() == 'no'
@@ -1544,7 +1544,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                     );
                 }
                 if ( ! empty( $rbfw_end_datetime ) ) {
-                    if ( $rbfw_end_time != '00:00' ) {
+                    if ( rbfw_booking_has_time( $rbfw_start_time ) && rbfw_booking_has_time( $rbfw_end_time ) ) {
                         $end_date_time_label = (
                             $rbfw->get_option_trans( 'rbfw_text_end_date_and_time', 'rbfw_basic_translation_settings' )
                             && want_loco_translate() == 'no'

--- a/admin/settings/Pricing.php
+++ b/admin/settings/Pricing.php
@@ -1639,39 +1639,6 @@
                 <?php
             }
 
-            /**
-             * Show the pricing validation errors saved by settings_save() when a
-             * classic-editor save was rejected. The modern editor surfaces the same
-             * errors through its AJAX response, so this notice is for the classic
-             * meta-box edit screen only.
-             */
-            public function render_pricing_save_errors_notice() {
-                if ( ! function_exists( 'get_current_screen' ) ) {
-                    return;
-                }
-                $screen = get_current_screen();
-                if ( ! $screen || 'rbfw_item' !== $screen->post_type || 'post' !== $screen->base ) {
-                    return;
-                }
-                $post_id = isset( $_GET['post'] ) ? absint( wp_unslash( $_GET['post'] ) ) : 0;
-                if ( ! $post_id && isset( $GLOBALS['post']->ID ) ) {
-                    $post_id = (int) $GLOBALS['post']->ID;
-                }
-                if ( ! $post_id ) {
-                    return;
-                }
-                $errors = get_transient( 'rbfw_pricing_save_errors_' . $post_id );
-                if ( empty( $errors ) || ! is_array( $errors ) ) {
-                    return;
-                }
-                delete_transient( 'rbfw_pricing_save_errors_' . $post_id );
-                echo '<div class="notice notice-error is-dismissible"><p><strong>' . esc_html__( 'Pricing was not saved. Please fix the following and save again:', 'booking-and-rental-manager-for-woocommerce' ) . '</strong></p><ul style="list-style:disc;margin:4px 0 4px 22px;">';
-                foreach ( $errors as $err ) {
-                    echo '<li>' . esc_html( $err ) . '</li>';
-                }
-                echo '</ul></div>';
-            }
-
             public function get_pricing_validation_errors( $item_type, $post_data ) {
                 $errors = [];
                 $item_type = sanitize_text_field( (string) $item_type );

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -298,6 +298,22 @@ function rbfw_url_exclude_search_engine() {
 
 		return $rbfw->get_datetime( $date, $type );
 	}
+	if ( ! function_exists( 'rbfw_booking_has_time' ) ) {
+		/**
+		 * Whether a stored booking time value represents a real, meaningful time.
+		 *
+		 * Day-wise (non-hourly) rentals store no time — the value is either an
+		 * empty string or a midnight placeholder ("00:00" / "00:00:00"). Use this
+		 * to decide whether the time should be shown/edited anywhere in the UI.
+		 *
+		 * @param string $time Raw stored time value.
+		 * @return bool True when the value is a real time; false for empty/midnight.
+		 */
+		function rbfw_booking_has_time( $time ) {
+			$time = trim( (string) $time );
+			return '' !== $time && '00:00' !== $time && '00:00:00' !== $time;
+		}
+	}
 	function rbfw_check_product_exists( $id ) {
 		return is_string( get_post_status( $id ) );
 	}

--- a/inc/rbfw_order_meta.php
+++ b/inc/rbfw_order_meta.php
@@ -316,6 +316,14 @@ function rbfw_sync_attendee_meta_from_edit( $wc_order_id, $t, $billing, $billing
     $end_dt   = isset( $t['rbfw_end_datetime'] ) ? $t['rbfw_end_datetime'] : '';
     $address  = trim( $billing_fields['address_1'] . ' ' . $billing_fields['address_2'] );
 
+    // Day-wise bookings store no real time — keep the stored datetime date-only
+    // so it never surfaces a meaningless 12:00 AM anywhere it is displayed. The
+    // booking is "timed" only when it has a real START time; the end time can be
+    // a duration artifact, so gate it on the start too.
+    $rbfw_meta_is_timed = rbfw_booking_has_time( isset( $t['rbfw_start_time'] ) ? $t['rbfw_start_time'] : '' );
+    $start_dt_fmt = $rbfw_meta_is_timed ? 'Y-m-d h:i A' : 'Y-m-d';
+    $end_dt_fmt   = ( $rbfw_meta_is_timed && rbfw_booking_has_time( isset( $t['rbfw_end_time'] ) ? $t['rbfw_end_time'] : '' ) ) ? 'Y-m-d h:i A' : 'Y-m-d';
+
     $meta = array(
         'ticket_price'            => $grand_total,
         'rbfw_ticket_total_price' => $order_total,
@@ -330,8 +338,8 @@ function rbfw_sync_attendee_meta_from_edit( $wc_order_id, $t, $billing, $billing
         'end_date'                => isset( $t['rbfw_end_date'] ) ? gmdate( 'Y-m-d', strtotime( $t['rbfw_end_date'] ) ) : '',
         'start_date'              => isset( $t['rbfw_start_date'] ) ? gmdate( 'Y-m-d', strtotime( $t['rbfw_start_date'] ) ) : '',
         'rbfw_end_date'           => isset( $t['rbfw_end_date'] ) ? gmdate( 'Y-m-d', strtotime( $t['rbfw_end_date'] ) ) : '',
-        'rbfw_start_datetime'     => $start_dt ? gmdate( 'Y-m-d h:i A', strtotime( $start_dt ) ) : '',
-        'rbfw_end_datetime'       => $end_dt ? gmdate( 'Y-m-d h:i A', strtotime( $end_dt ) ) : '',
+        'rbfw_start_datetime'     => $start_dt ? gmdate( $start_dt_fmt, strtotime( $start_dt ) ) : '',
+        'rbfw_end_datetime'       => $end_dt ? gmdate( $end_dt_fmt, strtotime( $end_dt ) ) : '',
         'rbfw_billing_phone'      => $billing_fields['phone'],
         'rbfw_billing_address'    => $address,
     );
@@ -423,25 +431,52 @@ function rbfw_get_order_edit_form_callback() {
     <input type="hidden" id="rbfw_eo_post_id" value="<?php echo esc_attr( $post_id ); ?>">
     <input type="hidden" id="rbfw_eo_total_days" value="<?php echo esc_attr( (int) $get( 'total_days', 1 ) ); ?>">
 
+    <?php
+    // Day-wise (non-hourly) bookings store no meaningful time. A booking is only
+    // "timed" when it has a real START time — that is what gets set when the
+    // customer actually picks a time/slot. The end time can be a mere duration
+    // artifact (e.g. a "2 hour" rental stores 02:00 with no start), so it must
+    // never be trusted on its own. When there is no start time, hide both inputs
+    // so the Edit Order form reflects the real order data, not a bogus 12:00 am.
+    $eo_start_time    = $get( 'rbfw_start_time' );
+    $eo_end_time      = $get( 'rbfw_end_time' );
+    $eo_booking_timed = rbfw_booking_has_time( $eo_start_time );
+    $eo_has_st_time   = $eo_booking_timed;
+    $eo_has_en_time   = $eo_booking_timed && rbfw_booking_has_time( $eo_end_time );
+    ?>
     <div class="rbfw_eo_section_title"><?php esc_html_e( 'Booking Dates', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
     <div class="rbfw_eo_grid">
         <div class="rbfw_eo_field">
             <label><?php esc_html_e( 'Start Date', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
             <input type="text" id="rbfw_eo_start_date" class="rbfw_eo_fp_date" value="<?php echo esc_attr( $get( 'rbfw_start_date' ) ); ?>" autocomplete="off">
         </div>
+        <?php if ( $eo_has_st_time ) { ?>
         <div class="rbfw_eo_field">
             <label><?php esc_html_e( 'Start Time', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
-            <input type="text" id="rbfw_eo_start_time" class="rbfw_eo_fp_time" value="<?php echo esc_attr( $get( 'rbfw_start_time' ) ); ?>" autocomplete="off">
+            <input type="text" id="rbfw_eo_start_time" class="rbfw_eo_fp_time" value="<?php echo esc_attr( $eo_start_time ); ?>" autocomplete="off">
         </div>
+        <?php } ?>
         <div class="rbfw_eo_field">
             <label><?php esc_html_e( 'End Date', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
             <input type="text" id="rbfw_eo_end_date" class="rbfw_eo_fp_date" value="<?php echo esc_attr( $get( 'rbfw_end_date' ) ); ?>" autocomplete="off">
         </div>
+        <?php if ( $eo_has_en_time ) { ?>
         <div class="rbfw_eo_field">
             <label><?php esc_html_e( 'End Time', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
-            <input type="text" id="rbfw_eo_end_time" class="rbfw_eo_fp_time" value="<?php echo esc_attr( $get( 'rbfw_end_time' ) ); ?>" autocomplete="off">
+            <input type="text" id="rbfw_eo_end_time" class="rbfw_eo_fp_time" value="<?php echo esc_attr( $eo_end_time ); ?>" autocomplete="off">
         </div>
+        <?php } ?>
     </div>
+    <?php
+    // Preserve the (empty/midnight) values on save without showing the inputs,
+    // so saving a day-wise order never mutates its stored time data.
+    if ( ! $eo_has_st_time ) {
+        ?><input type="hidden" id="rbfw_eo_start_time" value="<?php echo esc_attr( $eo_start_time ); ?>"><?php
+    }
+    if ( ! $eo_has_en_time ) {
+        ?><input type="hidden" id="rbfw_eo_end_time" value="<?php echo esc_attr( $eo_end_time ); ?>"><?php
+    }
+    ?>
 
     <div class="rbfw_eo_section_title"><?php esc_html_e( 'Billing Details', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
     <div class="rbfw_eo_grid">
@@ -742,8 +777,8 @@ function rbfw_save_order_edit_callback() {
         'order_total'   => (float) $order_total,
         'total_html'    => wc_price( $order_total ),
         'billing'       => $billing,
-        'start_display' => $s_ts ? date_i18n( 'F j, Y g:i a', strtotime( $t['rbfw_start_datetime'] ) ) : '',
-        'end_display'   => $e_ts ? date_i18n( 'F j, Y g:i a', strtotime( $t['rbfw_end_datetime'] ) ) : '',
+        'start_display' => $s_ts ? date_i18n( rbfw_booking_has_time( $start_time ) ? 'F j, Y g:i a' : 'F j, Y', strtotime( $t['rbfw_start_datetime'] ) ) : '',
+        'end_display'   => $e_ts ? date_i18n( ( rbfw_booking_has_time( $start_time ) && rbfw_booking_has_time( $end_time ) ) ? 'F j, Y g:i a' : 'F j, Y', strtotime( $t['rbfw_end_datetime'] ) ) : '',
     ) );
 }
 
@@ -810,7 +845,7 @@ function fetch_order_details_callback() {
                     $rbfw_management_info       = ! empty( $ticket_info['rbfw_management_info'] ) ? $ticket_info['rbfw_management_info'] : '';
                     $rbfw_management_price       = ! empty( $ticket_info['rbfw_management_price'] ) ? $ticket_info['rbfw_management_price'] : '';
 
-                    if ( $rent_type == 'resort' || ( empty( $rbfw_start_time ) && empty( $rbfw_end_time ) ) ) {
+                    if ( $rent_type == 'resort' || ! rbfw_booking_has_time( $rbfw_start_time ) ) {
                         $rbfw_start_datetime = rbfw_get_datetime( $ticket_info['rbfw_start_datetime'], 'date-text' );
                         $rbfw_end_datetime   = rbfw_get_datetime( $ticket_info['rbfw_end_datetime'], 'date-text' );
                     }
@@ -818,7 +853,7 @@ function fetch_order_details_callback() {
                     if ( $rent_type == 'bike_car_sd' || $rent_type == 'appointment' ) {
                         $BikeCarSdClass = new RBFW_BikeCarSd_Function();
                         $rent_info      = ! empty( $ticket_info['rbfw_type_info'] ) ? $ticket_info['rbfw_type_info'] : [];
-                        if($ticket_info['rbfw_end_time']){
+                        if( rbfw_booking_has_time( $rbfw_start_time ) && rbfw_booking_has_time( $rbfw_end_time ) ){
                             $rbfw_end_datetime = rbfw_get_datetime($ticket_info['rbfw_end_datetime'], 'date-time-text');
                         }else{
                             $rbfw_end_datetime = rbfw_get_datetime($ticket_info['rbfw_end_datetime'], 'date-text');
@@ -1544,6 +1579,12 @@ function rbfw_order_meta_box_callback() {
                 $rent_type = $ticket_info['rbfw_rent_type'];
                 $rbfw_start_datetime = rbfw_get_datetime( $ticket_info['rbfw_start_datetime'], 'date-time-text' );
                 $rbfw_end_datetime   = rbfw_get_datetime( $ticket_info['rbfw_end_datetime'] ?? '', 'date-time-text' );
+                // Day-wise bookings carry no real time (the end time may be a mere
+                // duration artifact), so anchor on the start time and show date only.
+                if ( ! rbfw_booking_has_time( isset( $ticket_info['rbfw_start_time'] ) ? $ticket_info['rbfw_start_time'] : '' ) ) {
+                    $rbfw_start_datetime = rbfw_get_datetime( $ticket_info['rbfw_start_datetime'], 'date-text' );
+                    $rbfw_end_datetime   = rbfw_get_datetime( $ticket_info['rbfw_end_datetime'] ?? '', 'date-text' );
+                }
                 $tax        = ! empty( $ticket_info['rbfw_mps_tax'] ) ? $ticket_info['rbfw_mps_tax'] : 0;
                 $tax_status = '';
                 if ( $rent_type == 'bike_car_sd' || $rent_type == 'appointment' ) {

--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -386,24 +386,34 @@
                                     $ticket_info_array = maybe_unserialize( $ticket_infos );
                                     $rbfw_start_datetime = '';
                                     $rbfw_end_datetime   = '';
+                                    $rbfw_start_time     = '';
+                                    $rbfw_end_time       = '';
                                     $rbfw_row_item_ids   = array();
                                     if ( ! empty( $ticket_info_array ) && is_array( $ticket_info_array ) ) {
                                         foreach ( $ticket_info_array as $ticket_info ) {
                                             $rbfw_start_datetime = isset( $ticket_info['rbfw_start_datetime'] ) ? $ticket_info['rbfw_start_datetime'] : '';
                                             $rbfw_end_datetime   = isset( $ticket_info['rbfw_end_datetime'] ) ? $ticket_info['rbfw_end_datetime'] : '';
+                                            $rbfw_start_time     = isset( $ticket_info['rbfw_start_time'] ) ? $ticket_info['rbfw_start_time'] : '';
+                                            $rbfw_end_time       = isset( $ticket_info['rbfw_end_time'] ) ? $ticket_info['rbfw_end_time'] : '';
                                             if ( ! empty( $ticket_info['rbfw_id'] ) ) {
                                                 $rbfw_row_item_ids[] = (string) $ticket_info['rbfw_id'];
                                             }
                                         }
                                     }
+                                    // Day-wise bookings carry no real time; drop it from the columns.
+                                    // The booking is "timed" only when it has a real START time — the end
+                                    // time can be a duration artifact, so gate it on the start too.
+                                    $rbfw_ol_is_timed  = rbfw_booking_has_time( $rbfw_start_time );
+                                    $rbfw_ol_start_fmt = $rbfw_ol_is_timed ? 'F j, Y g:i a' : 'F j, Y';
+                                    $rbfw_ol_end_fmt   = ( $rbfw_ol_is_timed && rbfw_booking_has_time( $rbfw_end_time ) ) ? 'F j, Y g:i a' : 'F j, Y';
                                     $rbfw_is_pro = function_exists( 'rbfw_pro_tab_menu_list' );
                                     ?>
                                     <tr class="order-row rbfw_ol_row" data-order="<?php echo esc_attr( strtolower( (string) $wc_order_id ) ); ?>" data-name="<?php echo esc_attr( strtolower( (string) $billing_name ) ); ?>" data-phone="<?php echo esc_attr( strtolower( (string) $billing_phone ) ); ?>" data-email="<?php echo esc_attr( strtolower( (string) $billing_email ) ); ?>" data-item="<?php echo esc_attr( implode( ' ', array_unique( $rbfw_row_item_ids ) ) ); ?>" data-status="<?php echo esc_attr( $status ); ?>" data-start="<?php echo esc_attr( ! empty( $rbfw_start_datetime ) ? gmdate( 'Y-m-d', strtotime( $rbfw_start_datetime ) ) : '' ); ?>">
                                         <td class="rbfw_ol_td_order" data-th="<?php esc_attr_e( 'Order', 'booking-and-rental-manager-for-woocommerce' ); ?>">#<?php echo esc_html( $wc_order_id ); ?></td>
                                         <td class="rbfw_ol_td_name" data-th="<?php esc_attr_e( 'Billing Name', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( $billing_name ); ?></td>
                                         <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Order Created', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( get_the_date( 'F j, Y' ) . ' ' . get_the_time() ); ?></td>
-                                        <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Booking Start', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( ! empty( $rbfw_start_datetime ) ? date_i18n( 'F j, Y g:i a', strtotime( $rbfw_start_datetime ) ) : '—' ); ?></td>
-                                        <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Booking End', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( ! empty( $rbfw_end_datetime ) ? date_i18n( 'F j, Y g:i a', strtotime( $rbfw_end_datetime ) ) : '—' ); ?></td>
+                                        <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Booking Start', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( ! empty( $rbfw_start_datetime ) ? date_i18n( $rbfw_ol_start_fmt, strtotime( $rbfw_start_datetime ) ) : '—' ); ?></td>
+                                        <td class="rbfw_ol_td_date" data-th="<?php esc_attr_e( 'Booking End', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo esc_html( ! empty( $rbfw_end_datetime ) ? date_i18n( $rbfw_ol_end_fmt, strtotime( $rbfw_end_datetime ) ) : '—' ); ?></td>
                                         <td data-th="<?php esc_attr_e( 'Status', 'booking-and-rental-manager-for-woocommerce' ); ?>"><span class="rbfw_ol_badge rbfw_ol_badge_<?php echo esc_attr( $status ); ?>"><?php echo esc_html( ucfirst( $status ) ); ?></span></td>
                                         <td class="rbfw_ol_td_total" data-th="<?php esc_attr_e( 'Total', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo wp_kses_post( wc_price( $total_price ) ); ?></td>
                                         <td class="rbfw_ol_td_action" data-th="<?php esc_attr_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?>">

--- a/lib/classes/class-thankyou-page.php
+++ b/lib/classes/class-thankyou-page.php
@@ -104,7 +104,7 @@
 							$rent_type       = $ticket_info['rbfw_rent_type'];
 							$rbfw_start_time = ! empty( $ticket_info['rbfw_start_time'] ) ? $ticket_info['rbfw_start_time'] : '';
 							$rbfw_end_time   = ! empty( $ticket_info['rbfw_end_time'] ) ? $ticket_info['rbfw_end_time'] : '';
-							if ( $rent_type == 'resort' || ( empty( $rbfw_start_time ) && empty( $rbfw_end_time ) ) ) {
+							if ( $rent_type == 'resort' || ! rbfw_booking_has_time( $rbfw_start_time ) ) {
 								$rbfw_start_datetime = rbfw_get_datetime( $ticket_info['rbfw_start_datetime'], 'date-text' );
 								$rbfw_end_datetime   = rbfw_get_datetime( $ticket_info['rbfw_end_datetime'], 'date-text' );
 							} elseif ( $rent_type == 'bike_car_sd' || $rent_type == 'appointment' ) {

--- a/templates/cart_page.php
+++ b/templates/cart_page.php
@@ -356,7 +356,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
         <?php if ( ! empty( $start_datetime )): ?>
             <tr>
                 <th>
-                    <?php if(($start_time)){ ?>
+                    <?php if( rbfw_booking_has_time($start_time) ){ ?>
 
                         <?php
                         if($rbfw->get_option_trans('rbfw_text_start_date_and_time', 'rbfw_basic_translation_settings') && want_loco_translate()=='no'){
@@ -380,7 +380,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
                 </th>
                 <td>
                     <?php echo esc_html(rbfw_get_datetime($start_datetime,'date-text')) ; ?>
-                    <?php if(($start_time)){
+                    <?php if( rbfw_booking_has_time($start_time) ){
                         echo ' @'.esc_html(gmdate(get_option('time_format'), strtotime($start_time)));
                     } ?>
                 </td>
@@ -390,7 +390,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
         <?php if ( ! empty( $end_datetime )): ?>
             <tr>
                 <th>
-                    <?php if(($end_time)){ ?>
+                    <?php if( rbfw_booking_has_time($start_time) && rbfw_booking_has_time($end_time) ){ ?>
 
                         <?php
                         if($rbfw->get_option_trans('rbfw_text_end_date_and_time', 'rbfw_basic_translation_settings') && want_loco_translate()=='no'){
@@ -414,7 +414,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
                 </th>
                 <td>
                     <?php echo esc_html(rbfw_get_datetime($end_datetime,'date-text')) ; ?>
-                    <?php if(($end_time)){
+                    <?php if( rbfw_booking_has_time($start_time) && rbfw_booking_has_time($end_time) ){
                         echo ' @'.esc_html(gmdate(get_option('time_format'), strtotime($end_time)));
                     } ?>
                 </td>
@@ -613,7 +613,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
             </tr>
         <?php } ?>
 
-        <?php if ( !empty($start_datetime) && !empty($start_time)){ ?>
+        <?php if ( !empty($start_datetime) && rbfw_booking_has_time($start_time)){ ?>
             <tr>
                 <th>
                     <?php
@@ -643,7 +643,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
 
 
 
-        <?php if (!empty($end_datetime) && !empty($end_time)){ ?>
+        <?php if (!empty($end_datetime) && rbfw_booking_has_time($start_time) && rbfw_booking_has_time($end_time)){ ?>
             <tr>
                 <th>
                     <?php
@@ -907,7 +907,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
         <?php if ( ! empty( $start_datetime )): ?>
             <tr>
                 <th>
-                    <?php if(($start_time)){ ?>
+                    <?php if( rbfw_booking_has_time($start_time) ){ ?>
 
                         <?php
                         if($rbfw->get_option_trans('rbfw_text_start_date_and_time', 'rbfw_basic_translation_settings') && want_loco_translate()=='no'){
@@ -933,7 +933,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
                 </th>
                 <td>
                     <?php echo esc_html(rbfw_date_format($start_datetime)) ; ?>
-                    <?php if(($start_time)){
+                    <?php if( rbfw_booking_has_time($start_time) ){
                         echo ' @'.esc_html(gmdate(get_option('time_format'), strtotime($start_time)));
                     } ?>
                 </td>
@@ -943,7 +943,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
         <?php if ( ! empty( $end_datetime )): ?>
             <tr>
                 <th>
-                    <?php if(($end_time)){ ?>
+                    <?php if( rbfw_booking_has_time($start_time) && rbfw_booking_has_time($end_time) ){ ?>
 
                         <?php
                         if($rbfw->get_option_trans('rbfw_text_end_date_and_time', 'rbfw_basic_translation_settings') && want_loco_translate()=='no'){
@@ -969,7 +969,7 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
                 </th>
                 <td>
                     <?php echo esc_html(rbfw_date_format($end_datetime)) ; ?>
-                    <?php if(($end_time)){
+                    <?php if( rbfw_booking_has_time($start_time) && rbfw_booking_has_time($end_time) ){
                         echo ' @'.esc_html(gmdate(get_option('time_format'), strtotime($end_time)));
                     } ?>
                 </td>

--- a/templates/template_segment/single_day_info.php
+++ b/templates/template_segment/single_day_info.php
@@ -61,7 +61,13 @@ if(isset($_POST['post_id'])){
         $datetime_string = $result . ' ' . $selected_time;
         $timestamp = strtotime($datetime_string);
 
-        $wp_datetime = date_i18n( get_option('date_format') . ' ' . get_option('time_format'), $timestamp );
+        // Day-wise rentals carry no meaningful time — omit it so the summary
+        // doesn't show a misleading "12:00 am" when no time was actually picked.
+        $rbfw_selected_format = rbfw_booking_has_time( $selected_time )
+            ? get_option('date_format') . ' ' . get_option('time_format')
+            : get_option('date_format');
+
+        $wp_datetime = date_i18n( $rbfw_selected_format, $timestamp );
 
 
 


### PR DESCRIPTION


Two fixes bundled on one branch.

1) Fatal: duplicate method in Pricing.php
   PR #730 re-added RBFW_Pricing::render_pricing_save_errors_notice() that
   was already present on main, so the class declared it twice and the
   plugin fatal-errored on load ("Cannot redeclare ..."). Removed the
   duplicate copy; a single declaration (next to the constructor hook)
   remains.

2) Day-wise (non-hourly) bookings showed a bogus time
   Day-basis rentals store no real time — the value is empty or a midnight
   placeholder ("00:00"/"00:00:00"), and for duration packages the END time
   can be a mere artifact (e.g. a "2 hour" rental stores 02:00 with no start
   time). These surfaced as a misleading "12:00 am" / "2:00 am" in the UI.

   Rule: a booking is "timed" only when it has a real START time (that is
   what gets set when the customer actually picks a time/slot). The end time
   is never trusted on its own; when there is no start time, hide both.

   - inc/rbfw_functions.php: add rbfw_booking_has_time() helper (guarded).
   - inc/rbfw_order_meta.php: Edit Order modal hides the Start/End Time inputs for day-wise orders (values preserved via hidden inputs so a save never mutates stored time data); order-detail panels and the stored/AJAX display formats go date-only, anchored on the start time.
   - templates/template_segment/single_day_info.php: frontend "You selected" summary shows date only when no time was picked.
   - Frontend/RBFW_Woocommerse.php: order line-item meta (Start/End Date and Time) date-only for day-wise; also fixes the old '!= 00:00' check which wrongly treated an empty string as timed.
   - templates/cart_page.php: cart Start/End time gates use the helper.
   - lib/classes/class-thankyou-page.php: thank-you page date-only branch anchored on the start time.
   - lib/classes/class-admin-menu.php: Order List Booking Start/End columns date-only for day-wise bookings.

   Genuinely timed (hourly) bookings are unaffected and still show times.