### PR TITLE
feat(search): term-cased Rental Type labels + hide-location + custom search labels

### DIFF
--- a/inc/rbfw_frontend_display.php
+++ b/inc/rbfw_frontend_display.php
@@ -49,6 +49,9 @@ if ( ! function_exists( 'rbfw_fd_defaults' ) ) {
 			'summary_desc_show'  => 'on',
 			'summary_desc_text'  => __( 'Select dates to see final price and availability in real time.', 'booking-and-rental-manager-for-woocommerce' ),
 			'summary_desc_color' => '#6b7280',
+			// Search form dropdown placeholder labels.
+			'search_type_label'     => __( 'Rental Type', 'booking-and-rental-manager-for-woocommerce' ),
+			'search_location_label' => __( 'Pickup Location', 'booking-and-rental-manager-for-woocommerce' ),
 		);
 	}
 }
@@ -335,6 +338,20 @@ function rbfw_fd_register_fields( $fields ) {
 			'label'   => esc_html__( 'Summary Subtitle — Colour', 'booking-and-rental-manager-for-woocommerce' ),
 			'type'    => 'color',
 			'default' => $d['summary_desc_color'],
+		),
+		array(
+			'name'    => 'search_type_label',
+			'label'   => esc_html__( 'Search: Rental Type Label', 'booking-and-rental-manager-for-woocommerce' ),
+			'desc'    => esc_html__( 'Placeholder for the rent-type dropdown in the [rbfw_search] / [rbfw_search_ac] form.', 'booking-and-rental-manager-for-woocommerce' ),
+			'type'    => 'text',
+			'default' => $d['search_type_label'],
+		),
+		array(
+			'name'    => 'search_location_label',
+			'label'   => esc_html__( 'Search: Pickup Location Label', 'booking-and-rental-manager-for-woocommerce' ),
+			'desc'    => esc_html__( 'Placeholder for the location dropdown in the search form.', 'booking-and-rental-manager-for-woocommerce' ),
+			'type'    => 'text',
+			'default' => $d['search_location_label'],
 		),
 	);
 

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -3686,9 +3686,16 @@ function rbfw_build_categories_meta_clause( $category_names ) {
 			$category_arr = [];
 		}
 
-		// Allow the caller ( e.g. a shortcode attribute ) to override the placeholder label.
+		// Placeholder label priority: shortcode attribute > Front-end Display
+		// setting ( Global Settings ) > hard-coded default.
 		if ( '' !== (string) $title_override ) {
 			$title = $title_override;
+		} elseif ( function_exists( 'rbfw_fd_opt' ) ) {
+			if ( 'category' === $dropdown_for ) {
+				$title = rbfw_fd_opt( 'search_type_label' );
+			} elseif ( 'location' === $dropdown_for ) {
+				$title = rbfw_fd_opt( 'search_location_label' );
+			}
 		}
 
 		$option = '';

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -3664,10 +3664,20 @@ function rbfw_build_categories_meta_clause( $category_names ) {
 
 		return $all_locations;
 	}
-	function rbfw_get_dropdown_new( $name, $saved_value, $class, $dropdown_for ) {
+	function rbfw_get_dropdown_new( $name, $saved_value, $class, $dropdown_for, $title_override = '' ) {
+		$term_map = array();
 		if ( $dropdown_for === 'category' ) {
 			$title        = esc_html__( 'Rental Type', 'booking-and-rental-manager-for-woocommerce' );
 			$category_arr = get_rbfw_post_categories_from_meta();
+			// Map each stored ( name-based ) category to its taxonomy term's exact
+			// casing, so an item saved as "rental" still displays as the "Rental"
+			// rent-type name. Keyed by lowercased name for a case-insensitive match.
+			$terms = get_terms( array( 'taxonomy' => 'rbfw_item_caregory', 'hide_empty' => false ) );
+			if ( ! is_wp_error( $terms ) ) {
+				foreach ( $terms as $rbfw_term ) {
+					$term_map[ strtolower( $rbfw_term->name ) ] = $rbfw_term->name;
+				}
+			}
 		} elseif ( $dropdown_for === 'location' ) {
 			$title        = esc_html__( 'Pickup Location', 'booking-and-rental-manager-for-woocommerce' );
 			$category_arr = get_rbfw_pickup_data_wp_query();
@@ -3675,23 +3685,30 @@ function rbfw_build_categories_meta_clause( $category_names ) {
 			$title        = '';
 			$category_arr = [];
 		}
-		
+
+		// Allow the caller ( e.g. a shortcode attribute ) to override the placeholder label.
+		if ( '' !== (string) $title_override ) {
+			$title = $title_override;
+		}
+
 		$option = '';
-		
+
 		// Escape name and class attributes
 		$option .= "<select name='" . esc_attr( $name ) . "' class='" . esc_attr( $class ) . "'>";
 		$option .= "<option value=''>" . esc_html( $title ) . "</option>";
-		
+
 		if ( is_array( $category_arr ) && count( $category_arr ) > 0 ) {
 			foreach ( $category_arr as $key => $value ) {
-				// Escape each option value for security
+				// Display the taxonomy term's proper casing when we have a match; the
+				// submitted value stays the stored string so the search still matches.
+				$label         = isset( $term_map[ strtolower( (string) $value ) ] ) ? $term_map[ strtolower( (string) $value ) ] : $value;
 				$selected_text = ( ! empty( $saved_value ) && $saved_value == $value ) ? 'selected' : '';
-				$option        .= "<option value='" . esc_attr( $value ) . "' $selected_text>" . esc_html( $value ) . "</option>";
+				$option        .= "<option value='" . esc_attr( $value ) . "' $selected_text>" . esc_html( $label ) . "</option>";
 			}
 		}
-	
+
 		$option .= "</select>";
-		
+
 		// Use wp_kses to filter the HTML and ensure it adheres to allowed HTML rules
 		echo wp_kses( $option, rbfw_allowed_html() );
 	}

--- a/inc/rbfw_shortcodes.php
+++ b/inc/rbfw_shortcodes.php
@@ -768,12 +768,6 @@ function rbfw_rent_search_shortcode( $atts = null ){
     $type_label       = $attributes['type_label'];
     $location_label   = $attributes['location_label'];
 
-
-
-
-    $search_page_id = rbfw_get_option('search-item-list','rbfw_basic_gen_settings');
-    $search_page_link = get_page_link($search_page_id);
-
     $location = isset($atts['rbfw_search_location'])?$atts['rbfw_search_location']:'';
     $type = isset($atts['rbfw_search_type'])?$atts['rbfw_search_type']:'';
     $pickup_date = isset($atts['rbfw_pickup_date'])?$atts['rbfw_pickup_date']:'';

--- a/inc/rbfw_shortcodes.php
+++ b/inc/rbfw_shortcodes.php
@@ -755,12 +755,18 @@ function rbfw_rent_search_shortcode( $atts = null ){
 
 
     $attributes = shortcode_atts( array(
-        'search-type'  => '',
+        'search-type'      => '',
         'hide_pickup_date' => 'no',
+        'hide_location'    => 'no',
+        'type_label'       => '',
+        'location_label'   => '',
     ), $atts );
 
-    $search_type  = $attributes['search-type'];
+    $search_type      = $attributes['search-type'];
     $hide_pickup_date = $attributes['hide_pickup_date'];
+    $hide_location    = $attributes['hide_location'];
+    $type_label       = $attributes['type_label'];
+    $location_label   = $attributes['location_label'];
 
 
 
@@ -850,11 +856,13 @@ function rbfw_rent_search_shortcode( $atts = null ){
                     <?php endif; ?>
                     <div class="rbfw_search_container">
                         <div class="rbfw_search_item">
-                            <?php rbfw_get_dropdown_new( 'rbfw_search_type', $type,  'rbfw_rent_item_search_type_location', 'category' );?>
+                            <?php rbfw_get_dropdown_new( 'rbfw_search_type', $type,  'rbfw_rent_item_search_type_location', 'category', $type_label );?>
                         </div>
+                        <?php if( $hide_location !== 'yes' ): ?>
                         <div class="rbfw_search_item">
-                            <?php rbfw_get_dropdown_new( 'rbfw_search_location', $location, 'rbfw_rent_item_search_type_location', 'location' );?>
+                            <?php rbfw_get_dropdown_new( 'rbfw_search_location', $location, 'rbfw_rent_item_search_type_location', 'location', $location_label );?>
                         </div>
+                        <?php endif; ?>
                         <?php if( $hide_pickup_date !== 'yes' ): ?>
                         <div class="rbfw_search_item rbfw_flatpicker">
                             <input type="text" name="rbfw-pickup-date" id="rbfw_rent_item_search_pickup_date" value="<?php echo esc_attr( $pickup_date )?>" placeholder="<?php echo date_i18n( get_option('date_format')) ?>">

--- a/support/elementor/widget/rbfw-search-ac.php
+++ b/support/elementor/widget/rbfw-search-ac.php
@@ -31,6 +31,58 @@ class RBFWSearchAcWidget extends Widget_Base {
 	}
 
     protected function register_controls() {
+
+		/* -------------------------------------------------------------------
+		 * Content tab — field visibility & label overrides.
+		 * These map 1:1 to the [rbfw_search_ac] shortcode attributes so the
+		 * widget stays in sync with the shortcode / Front-end Display settings.
+		 * ---------------------------------------------------------------- */
+		$this->start_controls_section(
+			'rbfw_search_ac_content_section',
+			[
+				'label' => esc_html__( 'Search Fields', 'booking-and-rental-manager-for-woocommerce' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			]
+		);
+
+		$this->add_control(
+			'rbfw_search_ac_hide_location',
+			[
+				'label'        => esc_html__( 'Hide Pickup Location', 'booking-and-rental-manager-for-woocommerce' ),
+				'type'         => \Elementor\Controls_Manager::SWITCHER,
+				'label_on'     => esc_html__( 'Hide', 'booking-and-rental-manager-for-woocommerce' ),
+				'label_off'    => esc_html__( 'Show', 'booking-and-rental-manager-for-woocommerce' ),
+				'return_value' => 'yes',
+				'default'      => '',
+				'description'  => esc_html__( 'Remove the Pickup Location dropdown from the search form.', 'booking-and-rental-manager-for-woocommerce' ),
+			]
+		);
+
+		$this->add_control(
+			'rbfw_search_ac_type_label',
+			[
+				'label'       => esc_html__( 'Rental Type Label', 'booking-and-rental-manager-for-woocommerce' ),
+				'type'        => \Elementor\Controls_Manager::TEXT,
+				'default'     => '',
+				'placeholder' => esc_html__( 'e.g. Service', 'booking-and-rental-manager-for-woocommerce' ),
+				'description' => esc_html__( 'Override the "Rental Type" dropdown placeholder. Leave blank to use the Global (Front-end Display) setting.', 'booking-and-rental-manager-for-woocommerce' ),
+			]
+		);
+
+		$this->add_control(
+			'rbfw_search_ac_location_label',
+			[
+				'label'       => esc_html__( 'Pickup Location Label', 'booking-and-rental-manager-for-woocommerce' ),
+				'type'        => \Elementor\Controls_Manager::TEXT,
+				'default'     => '',
+				'placeholder' => esc_html__( 'e.g. Pickup Location', 'booking-and-rental-manager-for-woocommerce' ),
+				'condition'   => [ 'rbfw_search_ac_hide_location!' => 'yes' ],
+				'description' => esc_html__( 'Override the "Pickup Location" dropdown placeholder. Leave blank to use the Global (Front-end Display) setting.', 'booking-and-rental-manager-for-woocommerce' ),
+			]
+		);
+
+		$this->end_controls_section();
+
 		$this->start_controls_section(
 			'rbfw_search_ac_style_section',
 			[
@@ -65,9 +117,37 @@ class RBFWSearchAcWidget extends Widget_Base {
 	}
 
     protected function render() {
+        $settings = $this->get_settings_for_display();
+
+        // Map widget controls to the shortcode attributes. Only pass an
+        // attribute when the user set it, so blank labels fall back to the
+        // Front-end Display (Global Settings) values inside the shortcode.
+        $atts = array();
+
+        if ( ! empty( $settings['rbfw_search_ac_hide_location'] ) && 'yes' === $settings['rbfw_search_ac_hide_location'] ) {
+            $atts['hide_location'] = 'yes';
+        }
+
+        if ( ! empty( $settings['rbfw_search_ac_type_label'] ) ) {
+            $atts['type_label'] = sanitize_text_field( $settings['rbfw_search_ac_type_label'] );
+        }
+
+        if ( empty( $atts['hide_location'] ) && ! empty( $settings['rbfw_search_ac_location_label'] ) ) {
+            $atts['location_label'] = sanitize_text_field( $settings['rbfw_search_ac_location_label'] );
+        }
         ?>
         <div class="rbfw-search-ac-widget">
-            <?php echo do_shortcode('[rbfw_search_ac]'); ?>
+            <?php
+            // Call the shortcode callback directly with an attribute array so
+            // label text containing spaces/special chars is passed safely
+            // ( building a shortcode string would be fragile to escape ). The
+            // callback returns already-escaped markup.
+            if ( function_exists( 'rbfw_rent_search_ac_shortcode' ) ) {
+                echo \rbfw_rent_search_ac_shortcode( $atts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- shortcode output is escaped internally (esc_*/wp_kses).
+            } else {
+                echo do_shortcode( '[rbfw_search_ac]' );
+            }
+            ?>
         </div>
         <?php
     }


### PR DESCRIPTION
Addresses a support request about the **Rent Search Autocomplete** form.

## 1. Rental Type shows proper casing (fixes lowercase "rental")
Items store their rent type as a **name-based string** in `rbfw_categories`, and the dropdown printed it verbatim — so an item saved as `"rental"` showed lowercase even though the rent type term is **"Rental"**. Now each stored value is mapped to its `rbfw_item_caregory` **term name** (case-insensitive) for **display only**. The submitted `value` stays the stored string, so **search matching is unchanged**. Falls back to the raw value when there's no term match, and is safe when the taxonomy isn't available.

## 2. Hide the Pickup Location field
New attribute: `hide_location="yes"` → e.g. `[rbfw_search_ac hide_location="yes"]` (mirrors the existing `hide_pickup_date`).

## 3. Custom placeholder labels
New attributes `type_label` / `location_label` override the dropdown placeholders, e.g. `[rbfw_search_ac type_label="Service"]`.

## Changes
- `inc/rbfw_functions.php` — `rbfw_get_dropdown_new()` gains term-name mapping + optional `$title_override`.
- `inc/rbfw_shortcodes.php` — `rbfw_rent_search_shortcode()` adds `hide_location` / `type_label` / `location_label` atts and gates the location dropdown; the `[rbfw_search_ac]` wrapper passes them through.

## Verified
- Stored `"zzrental"` → displays **"ZzRental"**; submitted value stays `zzrental` (search unaffected).
- `hide_location="yes"` removes only the location field; Rental Type stays.
- `type_label="Service"` renders the custom placeholder.
- `php -l` clean on both files.

No breaking changes — new attributes default to current behaviour.