### PR TITLE
fix(editor): show Location section for every rent type (classic + modern)

### DIFF
--- a/admin/js/mkb-admin.js
+++ b/admin/js/mkb-admin.js
@@ -378,8 +378,8 @@
             } else if (item_type == 'appointment') {
                 jQuery('.rbfw_bike_car_sd_wrapper').show();
                 jQuery('.rbfw_general_price_config_wrapper').addClass('rbfw-d-none');
-                jQuery('.mp_tab_menu li[data-target-tabs="#rbfw_location_config"]').hide();
-                jQuery('.mp_tab_item[data-target-tabs="#rbfw_location_config"]').hide();
+                jQuery('.mp_tab_menu li[data-target-tabs="#rbfw_location_config"]').show();
+                jQuery('.mp_tab_item[data-target-tabs="#rbfw_location_config"]').show();
                 jQuery('.rbfw_switch_extra_service_qty').hide();
                 jQuery('li[data-target-tabs="#rbfw_variations"]').hide();
                 jQuery('.rbfw_switch_md_type_item_qty').hide();
@@ -419,8 +419,8 @@
                 jQuery('table.wprently_fee-table td:nth-child(3)').hide();
 
             } else if (item_type == 'resort') {
-                jQuery('.mp_tab_menu li[data-target-tabs="#rbfw_location_config"]').hide();
-                jQuery('.mp_tab_item[data-target-tabs="#rbfw_location_config"]').hide();
+                jQuery('.mp_tab_menu li[data-target-tabs="#rbfw_location_config"]').show();
+                jQuery('.mp_tab_item[data-target-tabs="#rbfw_location_config"]').show();
                 jQuery('.rbfw_switch_extra_service_qty').hide();
                 jQuery('li[data-target-tabs="#rbfw_variations"]').hide();
                 jQuery('.rbfw_switch_md_type_item_qty').hide();

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -2048,10 +2048,9 @@
             var _invShow = (type !== 'resort' && type !== 'bike_car_sd' && type !== 'appointment');
             $pricing.find('.rbfw-me-inventory-card').toggleClass('rbfw-me-hidden', !_invShow);
 
-            // Location card (Advanced step): mirror the classic editor, which hides
-            // the Location tab for resort / appointment.
-            var _locShow = (type !== 'resort' && type !== 'appointment');
-            $wrap.find('.rbfw-me-location-card').toggleClass('rbfw-me-hidden', !_locShow);
+            // Location card (Advanced step): available for every rent type
+            // ( multi-location feature ).
+            $wrap.find('.rbfw-me-location-card').removeClass('rbfw-me-hidden');
 
             if (typeof window.rbfwMdsSyncPanelForRentType === 'function') {
                 window.rbfwMdsSyncPanelForRentType(type, $pricing);

--- a/admin/settings/Location.php
+++ b/admin/settings/Location.php
@@ -89,9 +89,9 @@
 			}
 
 			public function add_tab_menu($rbfw_id) {
-                $rbfw_item_type         = get_post_meta( $rbfw_id, 'rbfw_item_type', true ) ? get_post_meta( $rbfw_id, 'rbfw_item_type', true ) : 'bike_car_sd';
+				// Location is available for every rent type ( multi-location feature ).
 				?>
-                <li data-target-tabs="#rbfw_location_config" <?php echo ( $rbfw_item_type == 'resort' || $rbfw_item_type == 'appointment' )?'style="display:none"':'' ?>>
+                <li data-target-tabs="#rbfw_location_config">
                     <i class="fas fa-location-dot"></i><?php esc_html_e( 'Location', 'booking-and-rental-manager-for-woocommerce' ); ?>
                 </li>
 				<?php

--- a/admin/views/rbfw-modern-editor.php
+++ b/admin/views/rbfw-modern-editor.php
@@ -379,12 +379,10 @@
 			<div class="rbfw-me-panel" data-panel="advanced">
 
 				<?php
-				// Location Configuration (pick-up / drop-off). The classic editor
-				// hides this tab for resort / appointment; mirror that here, with
-				// applyType() in the JS keeping it in sync on live type changes.
+				// Location Configuration (pick-up / drop-off) is available for every
+				// rent type ( multi-location feature ).
 				if ( class_exists( 'RBFW_Location' ) ) :
-					$rbfw_me_loc_type   = get_post_meta( $post_id, 'rbfw_item_type', true ) ?: 'bike_car_sd';
-					$rbfw_me_loc_hidden = in_array( $rbfw_me_loc_type, [ 'resort', 'appointment' ], true );
+					$rbfw_me_loc_hidden = false;
 				?>
 				<div class="rbfw-me-card rbfw-me-location-card<?php echo $rbfw_me_loc_hidden ? ' rbfw-me-hidden' : ''; ?>">
 					<div class="rbfw-me-card__head">


### PR DESCRIPTION
## Problem
The **Location Configuration** section didn't show in either editor for **resort** and **appointment** items — it was intentionally hidden for those two rent types, so locations couldn't be configured for them. (For all other types it already showed correctly — verified by rendering.)

## Fix
With the multi-location feature applying to **all rent types**, the resort/appointment exclusion is removed in all four places that gated it:

| File | Change |
|---|---|
| `admin/settings/Location.php` | Classic tab no longer emits `display:none` |
| `admin/js/mkb-admin.js` | Classic JS now **shows** the tab on resort/appointment (was hiding) |
| `admin/views/rbfw-modern-editor.php` | Modern card no longer starts hidden (`$rbfw_me_loc_hidden = false`) |
| `admin/js/rbfw-modern-editor.js` | `applyType()` always shows the Location card |

## Verified
- Resort + appointment items now render a **visible** Location tab (was `display:none`).
- Other rent types unchanged.
- PHP + JS lint clean (`php -l`, `node --check`).

## Note
The **appointment** frontend already renders pickup/drop-off (it uses the single-day form). If the **resort** front-end booking form should also surface these locations, that's a small follow-up on `resort-registration.php` — happy to add it if you want.