### PR TITLE
feat(inventory): Edit Stock action on the Inventory admin page

### DIFF
--- a/admin/css/rbfw_inventory.css
+++ b/admin/css/rbfw_inventory.css
@@ -536,6 +536,64 @@
 }
 .rbfw_inv_cat_title svg.rbfw_inv_ic { font-size: 13px; color: var(--rbfw-text-3); }
 
+/* Two side-by-side row actions (View Details / Edit Stock) */
+.rbfw_inv .rbfw_inv_stock_actions { display: flex; gap: 6px; }
+.rbfw_inv .rbfw_inv_edit_btn { display: inline-flex; align-items: center; gap: 4px; }
+.rbfw_inv .rbfw_inv_edit_btn svg.rbfw_inv_ic { font-size: 11px; }
+
+/* Edit Stock form */
+.rbfw_inv_modal .rbfw_inv_qty_input {
+    width: 90px;
+    max-width: 100%;
+    padding: 5px 8px;
+    border: 1px solid var(--rbfw-border);
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--rbfw-text-1);
+    text-align: right;
+}
+.rbfw_inv_modal .rbfw_inv_qty_input:focus { outline: none; border-color: var(--rbfw-accent); box-shadow: 0 0 0 2px var(--rbfw-accent-lt); }
+.rbfw_inv_modal .rbfw_inv_qty_input_flat { width: 100%; text-align: left; font-size: 15px; padding: 9px 12px; }
+
+.rbfw_inv_edit_stock_msg { margin: 10px 0 0; font-size: 12px; font-weight: 600; min-height: 1em; }
+.rbfw_inv_edit_stock_msg.rbfw_inv_msg_success { color: var(--rbfw-green); }
+.rbfw_inv_edit_stock_msg.rbfw_inv_msg_error { color: #DC2626; }
+
+.rbfw_inv_modal_foot {
+    padding: 14px 20px;
+    border-top: 1px solid var(--rbfw-border);
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    flex-shrink: 0;
+}
+/* Scoped to .rbfw_inv_modal_foot (2-class specificity) so this reliably beats
+   .rbfw_inv_modal_close's 30x30 icon-box sizing — the Cancel button reuses
+   that class only to hook the existing close-modal click handler, and must
+   not inherit its header-icon dimensions (was squashing "Cancel" to 30px
+   wide, overlapping the Save button next to it). */
+.rbfw_inv_modal_foot .rbfw_inv_modal_btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: auto;
+    height: 34px;
+    padding: 0 16px;
+    font-size: 12px;
+    font-weight: 700;
+    border-radius: 7px;
+    cursor: pointer;
+    border: 1px solid transparent;
+}
+.rbfw_inv_modal_foot .rbfw_inv_modal_btn svg.rbfw_inv_ic { font-size: 14px; }
+.rbfw_inv_modal_foot .rbfw_inv_modal_btn_ghost { background: #fff; border-color: var(--rbfw-border); color: var(--rbfw-text-2); }
+.rbfw_inv_modal_foot .rbfw_inv_modal_btn_ghost:hover { background: var(--rbfw-bg); }
+.rbfw_inv_modal_foot .rbfw_inv_modal_btn_primary { background: var(--rbfw-accent); color: #fff; }
+.rbfw_inv_modal_foot .rbfw_inv_modal_btn_primary:hover { opacity: .9; color: #fff; }
+.rbfw_inv_modal_foot .rbfw_inv_modal_btn_primary:disabled { opacity: .6; cursor: not-allowed; }
+
 /* =========================================================================
    Responsive
    ========================================================================= */

--- a/admin/js/mkb-admin.js
+++ b/admin/js/mkb-admin.js
@@ -840,6 +840,93 @@
                 }
             });
         });
+
+        /* Edit Stock: opens the same modal shell with an editable form,
+           tailored per rent type (flat qty / variations / per-rent-type /
+           per-room), and saves back to the exact meta the item editor uses. */
+        jQuery(document).on('click', '.rbfw_stock_edit_details', function (e) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            jQuery("#rbfw_stock_view_result_wrap").mage_modal({
+                escapeClose: false,
+                clickClose: false,
+                showClose: true
+            });
+
+            let data_id = jQuery(this).attr('data-id');
+
+            jQuery.ajax({
+                type: 'POST',
+                url: rbfw_ajax_url,
+                data: {
+                    'action' : 'rbfw_get_stock_edit_form',
+                    'data_id' : data_id,
+                    'nonce' : rbfw_ajax_admin.nonce_get_stock_edit_form
+                },
+                beforeSend: function() {
+                    jQuery('#rbfw_stock_view_result_inner_wrap').empty();
+                    jQuery('#rbfw_stock_view_result_inner_wrap').html('<i class="fas fa-spinner fa-spin rbfw_rp_loader"></i>');
+                },
+                success: function (response) {
+                    jQuery('#rbfw_stock_view_result_inner_wrap').html(response);
+                }
+            });
+        });
+
+        jQuery(document).on('submit', '.rbfw_inv_edit_stock_form', function (e) {
+            e.preventDefault();
+
+            let $form = jQuery(this);
+            let $msg = $form.find('.rbfw_inv_edit_stock_msg');
+            let $save = $form.find('.rbfw_inv_edit_stock_save');
+            let post_id = $form.data('post-id');
+
+            $msg.text('').removeClass('rbfw_inv_msg_error rbfw_inv_msg_success');
+            $save.prop('disabled', true);
+
+            jQuery.ajax({
+                type: 'POST',
+                url: rbfw_ajax_url,
+                dataType: 'json',
+                data: $form.serialize() + '&action=rbfw_update_inventory_stock&post_id=' + encodeURIComponent(post_id) + '&nonce=' + encodeURIComponent(rbfw_ajax_admin.nonce_update_inventory_stock),
+                success: function (response) {
+                    if (response && response.success) {
+                        $msg.text(rbfwInvI18n && rbfwInvI18n.stock_saved ? rbfwInvI18n.stock_saved : 'Stock updated.').addClass('rbfw_inv_msg_success');
+
+                        let newTotal = response.data && typeof response.data.total !== 'undefined' ? parseFloat(response.data.total) : null;
+                        let $row = jQuery('.rbfw_stock_view_details[data-id="' + post_id + '"]').closest('tr.rbfw_inv_row');
+
+                        if (newTotal !== null && $row.length) {
+                            let $pill = $row.find('.rbfw_inv_stock_wrap .rbfw_inv_pill').first();
+                            let soldQty = parseFloat($row.find('.rbfw_inv_qty_badge').first().text()) || 0;
+                            let remaining = newTotal - soldQty;
+
+                            $pill.removeClass('full zero');
+                            if (newTotal <= 0 || remaining <= 0) {
+                                $pill.addClass('zero');
+                            } else if (remaining >= newTotal) {
+                                $pill.addClass('full');
+                            }
+                            $pill.text(remaining + '/' + newTotal);
+                        }
+
+                        setTimeout(function () {
+                            if (jQuery.mage_modal && typeof jQuery.mage_modal.isActive === 'function' && jQuery.mage_modal.isActive()) {
+                                jQuery.mage_modal.close();
+                            }
+                        }, 700);
+                    } else {
+                        let errMsg = (response && response.data && typeof response.data === 'string') ? response.data : 'Something went wrong. Please try again.';
+                        $msg.text(errMsg).addClass('rbfw_inv_msg_error');
+                        $save.prop('disabled', false);
+                    }
+                },
+                error: function () {
+                    $msg.text('Something went wrong. Please try again.').addClass('rbfw_inv_msg_error');
+                    $save.prop('disabled', false);
+                }
+            });
+        });
         /* end inventory filter and view details */
 
 

--- a/admin/js/mkb-admin.js
+++ b/admin/js/mkb-admin.js
@@ -893,12 +893,11 @@
                     if (response && response.success) {
                         $msg.text(rbfwInvI18n && rbfwInvI18n.stock_saved ? rbfwInvI18n.stock_saved : 'Stock updated.').addClass('rbfw_inv_msg_success');
 
-                        let newTotal = response.data && typeof response.data.total !== 'undefined' ? parseFloat(response.data.total) : null;
                         let $row = jQuery('.rbfw_stock_view_details[data-id="' + post_id + '"]').closest('tr.rbfw_inv_row');
 
-                        if (newTotal !== null && $row.length) {
-                            let $pill = $row.find('.rbfw_inv_stock_wrap .rbfw_inv_pill').first();
-                            let soldQty = parseFloat($row.find('.rbfw_inv_qty_badge').first().text()) || 0;
+                        function refreshPill($pill, $soldBadge, newTotal) {
+                            if (newTotal === null || !$pill.length) { return; }
+                            let soldQty = parseFloat($soldBadge.text()) || 0;
                             let remaining = newTotal - soldQty;
 
                             $pill.removeClass('full zero');
@@ -908,6 +907,22 @@
                                 $pill.addClass('full');
                             }
                             $pill.text(remaining + '/' + newTotal);
+                        }
+
+                        if ($row.length) {
+                            let newTotal = response.data && typeof response.data.total !== 'undefined' ? parseFloat(response.data.total) : null;
+                            refreshPill(
+                                $row.find('.rbfw_inv_stock_wrap .rbfw_inv_pill').first(),
+                                $row.find('.rbfw_inv_qty_badge').first(),
+                                newTotal
+                            );
+
+                            let newEsTotal = response.data && typeof response.data.es_total !== 'undefined' ? parseFloat(response.data.es_total) : null;
+                            refreshPill(
+                                $row.find('.rbfw_inv_td_es_stock .rbfw_inv_pill').first(),
+                                $row.find('.rbfw_inv_td_es_sold .rbfw_inv_qty_badge').first(),
+                                newEsTotal
+                            );
                         }
 
                         setTimeout(function () {

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -175,6 +175,8 @@ if (! class_exists('RBFW_Dependencies')) {
 				'nonce_delete_time_slot'        => wp_create_nonce('rbfw_delete_time_slot_action'),
 				'nonce_get_stock_by_filter'        => wp_create_nonce('rbfw_get_stock_by_filter_action'),
 				'nonce_get_stock_details'        => wp_create_nonce('rbfw_get_stock_details_action'),
+				'nonce_get_stock_edit_form'        => wp_create_nonce('rbfw_get_stock_edit_form_action'),
+				'nonce_update_inventory_stock'        => wp_create_nonce('rbfw_update_inventory_stock_action'),
 				'nonce_faq_data_save'        => wp_create_nonce('rbfw_faq_data_save_action'),
 				'nonce_faq_delete_item'        => wp_create_nonce('rbfw_faq_delete_item_action'),
 				'nonce_faq_data_update'        => wp_create_nonce('rbfw_faq_data_update_action'),

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -1365,8 +1365,8 @@ function rbfw_inventory_page_table($query, $date = null, $start_time = null, $en
 
 
                     <td class="rbfw_text_center" data-th="<?php esc_attr_e('Item Sold Qty','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_qty_badge <?php echo esc_attr( $sold_item_qty > 0 ? 'rbfw_inv_qty_pos' : 'rbfw_inv_qty_zero' ); ?>"><?php echo esc_html($sold_item_qty); ?></span></td>
-                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Extra Service Stock','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_pill <?php echo esc_attr( $es_state ); ?>"><?php echo esc_html($remaining_es_stock); ?>/<?php echo esc_html($total_es_qty); ?></span></td>
-                    <td class="rbfw_text_center" data-th="<?php esc_attr_e('Extra Service Sold Qty','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_qty_badge <?php echo esc_attr( $sold_es_qty > 0 ? 'rbfw_inv_qty_pos' : 'rbfw_inv_qty_zero' ); ?>"><?php echo esc_html($sold_es_qty); ?></span></td>
+                    <td class="rbfw_text_center rbfw_inv_td_es_stock" data-th="<?php esc_attr_e('Extra Service Stock','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_pill <?php echo esc_attr( $es_state ); ?>"><?php echo esc_html($remaining_es_stock); ?>/<?php echo esc_html($total_es_qty); ?></span></td>
+                    <td class="rbfw_text_center rbfw_inv_td_es_sold" data-th="<?php esc_attr_e('Extra Service Sold Qty','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_qty_badge <?php echo esc_attr( $sold_es_qty > 0 ? 'rbfw_inv_qty_pos' : 'rbfw_inv_qty_zero' ); ?>"><?php echo esc_html($sold_es_qty); ?></span></td>
                     <td class="rbfw_text_center" data-th="<?php esc_attr_e('Category Service','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_pill <?php echo esc_attr( $cat_state ); ?>"><?php echo esc_html( $cat_stock ); ?>/<?php echo esc_html( $cat_total ); ?></span></td>
                     <td class="rbfw_text_center" data-th="<?php esc_attr_e('Category Service Sold Qty','booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw_inv_qty_badge <?php echo esc_attr( $cat_sold > 0 ? 'rbfw_inv_qty_pos' : 'rbfw_inv_qty_zero' ); ?>"><?php echo esc_html( $cat_sold ); ?></span></td>
                 </tr>
@@ -1815,6 +1815,9 @@ function rbfw_get_stock_edit_form() {
     $rbfw_item_stock_quantity_timely = get_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', true );
     $rbfw_item_stock_quantity_timely = ( $rbfw_item_stock_quantity_timely !== '' && $rbfw_item_stock_quantity_timely !== false ) ? $rbfw_item_stock_quantity_timely : 0;
 
+    $rbfw_extra_service_data = get_post_meta( $post_id, 'rbfw_extra_service_data', true );
+    $rbfw_extra_service_data = ! empty( $rbfw_extra_service_data ) ? $rbfw_extra_service_data : [];
+
     $modal_title = get_the_title( $post_id );
     ?>
     <div class="rbfw_inv_modal">
@@ -1911,6 +1914,23 @@ function rbfw_get_stock_edit_form() {
                         <input type="number" min="0" step="any" class="rbfw_inv_qty_input rbfw_inv_qty_input_flat" name="qty[flat]" value="<?php echo esc_attr( $rbfw_item_stock_quantity ); ?>">
                     </div>
 
+                <?php endif; ?>
+
+                <?php if ( ! empty( $rbfw_extra_service_data ) ) : ?>
+                    <div class="rbfw_inv_modal_section">
+                        <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('sparkles'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Extra Services', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                        <table class="rbfw_inv_mini_table">
+                            <thead><tr><th><?php esc_html_e( 'Service Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e( 'Stock Qty', 'booking-and-rental-manager-for-woocommerce' ); ?></th></tr></thead>
+                            <tbody>
+                            <?php foreach ( $rbfw_extra_service_data as $i => $service ) : ?>
+                                <tr>
+                                    <td><?php echo esc_html( $service['service_name'] ?? '' ); ?></td>
+                                    <td class="rbfw_inv_qty_cell"><input type="number" min="0" step="any" class="rbfw_inv_qty_input" name="qty[extra_service][<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $service['service_qty'] ?? 0 ); ?>"></td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
                 <?php endif; ?>
 
                 <p class="rbfw_inv_edit_stock_msg" role="alert" aria-live="polite"></p>
@@ -2018,10 +2038,26 @@ function rbfw_update_inventory_stock() {
         update_post_meta( $post_id, 'rbfw_item_stock_quantity', $flat );
     }
 
+    /* Extra services are a flat, rent-type-independent list, so this always
+     * runs alongside whichever item-stock shape applied above. */
+    if ( isset( $qty['extra_service'] ) && is_array( $qty['extra_service'] ) ) {
+        $extra_service_data = get_post_meta( $post_id, 'rbfw_extra_service_data', true );
+        $extra_service_data = is_array( $extra_service_data ) ? $extra_service_data : [];
+
+        foreach ( $qty['extra_service'] as $i => $value ) {
+            $i = absint( $i );
+            if ( isset( $extra_service_data[ $i ] ) ) {
+                $extra_service_data[ $i ]['service_qty'] = rbfw_inv_sanitize_qty( $value );
+            }
+        }
+        update_post_meta( $post_id, 'rbfw_extra_service_data', $extra_service_data );
+    }
+
     $totals = rbfw_inventory_item_stock_totals( $post_id );
 
     wp_send_json_success( array(
-        'total' => $totals['item_stock'],
+        'total'    => $totals['item_stock'],
+        'es_total' => $totals['es_qty'],
     ) );
 }
 

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -2,6 +2,8 @@
 
 add_action('wp_ajax_rbfw_get_stock_details', 'rbfw_get_stock_details');
 add_action('wp_ajax_rbfw_get_stock_by_filter', 'rbfw_get_stock_by_filter');
+add_action('wp_ajax_rbfw_get_stock_edit_form', 'rbfw_get_stock_edit_form');
+add_action('wp_ajax_rbfw_update_inventory_stock', 'rbfw_update_inventory_stock');
 
 
 function rbfw_add_order_meta_data($meta_data = array(), $ticket_info = array()) {
@@ -1342,14 +1344,22 @@ function rbfw_inventory_page_table($query, $date = null, $start_time = null, $en
                     <td class="rbfw_text_center" data-th="<?php esc_attr_e('Item Stock','booking-and-rental-manager-for-woocommerce'); ?>">
                         <span class="rbfw_inv_stock_wrap">
                             <span class="rbfw_inv_pill <?php echo esc_attr( $item_state ); ?>"><?php echo esc_html( $remaining_item_stock ); ?>/<?php echo esc_html( $rbfw_item_stock_quantity ); ?></span>
-                            <a
-                                class="rbfw_inv_view_btn rbfw_stock_view_details"
-                                data-request="closing"
-                                data-date="<?php echo esc_attr( $current_date ); ?>"
-                                data-id="<?php echo esc_attr( get_the_ID() ); ?>"
-                            >
-                                <?php esc_html_e( 'View Details', 'booking-and-rental-manager-for-woocommerce' ); ?>
-                            </a>
+                            <span class="rbfw_inv_stock_actions">
+                                <a
+                                    class="rbfw_inv_view_btn rbfw_stock_view_details"
+                                    data-request="closing"
+                                    data-date="<?php echo esc_attr( $current_date ); ?>"
+                                    data-id="<?php echo esc_attr( get_the_ID() ); ?>"
+                                >
+                                    <?php esc_html_e( 'View Details', 'booking-and-rental-manager-for-woocommerce' ); ?>
+                                </a>
+                                <a
+                                    class="rbfw_inv_view_btn rbfw_inv_edit_btn rbfw_stock_edit_details"
+                                    data-id="<?php echo esc_attr( get_the_ID() ); ?>"
+                                >
+                                    <?php echo rbfw_inv_icon('pencil'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Edit Stock', 'booking-and-rental-manager-for-woocommerce' ); ?>
+                                </a>
+                            </span>
                         </span>
                     </td>
 
@@ -1735,6 +1745,285 @@ function rbfw_get_stock_details(){
             <?php
             wp_die();
         }
+
+/**
+ * Sanitize a posted stock-quantity value.
+ *
+ * Mirrors what the classic item editor accepts (plain sanitize_text_field,
+ * no forced int-cast — rbfw_resort_room_data's qty field ships with
+ * step=".01", so it can legitimately be a decimal). Non-numeric input and
+ * negative numbers are clamped to 0.
+ *
+ * @param mixed $value Raw posted value.
+ * @return int|float
+ */
+function rbfw_inv_sanitize_qty( $value ) {
+    $value = sanitize_text_field( wp_unslash( (string) $value ) );
+    if ( ! is_numeric( $value ) ) {
+        return 0;
+    }
+    $number = $value + 0; // Numeric string -> int or float, matching its precision.
+    return $number < 0 ? 0 : $number;
+}
+
+/**
+ * AJAX: render the "Edit Stock" form for the Inventory admin page.
+ *
+ * The Item Stock column shows one merged number, but the underlying meta
+ * shape differs per rent type (a single flat quantity, a per-variation-value
+ * quantity, a per-rent-type quantity for bike_car_sd/appointment, or a
+ * per-room quantity for resort). This renders the correct editable shape for
+ * the item so saving here writes to the exact same meta keys/indexes the
+ * classic + modern item editors read — the item editor and this page never
+ * fall out of sync.
+ */
+function rbfw_get_stock_edit_form() {
+
+    check_ajax_referer( 'rbfw_get_stock_edit_form_action', 'nonce' );
+
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        wp_send_json_error( 'Unauthorized access', 403 );
+    }
+
+    $post_id = isset( $_POST['data_id'] ) ? absint( $_POST['data_id'] ) : 0;
+
+    if ( ! $post_id || get_post_type( $post_id ) !== 'rbfw_item' || ! current_user_can( 'edit_post', $post_id ) ) {
+        wp_send_json_error( 'Unauthorized access', 403 );
+    }
+
+    $rent_type = get_post_meta( $post_id, 'rbfw_item_type', true );
+    $rent_type = ! empty( $rent_type ) ? $rent_type : '';
+
+    $rbfw_enable_variations = get_post_meta( $post_id, 'rbfw_enable_variations', true );
+    $rbfw_enable_variations = ! empty( $rbfw_enable_variations ) ? $rbfw_enable_variations : 'no';
+
+    $manage_inventory_as_timely = get_post_meta( $post_id, 'manage_inventory_as_timely', true );
+    $manage_inventory_as_timely = ! empty( $manage_inventory_as_timely ) ? $manage_inventory_as_timely : 'off';
+
+    $rbfw_variations_data = get_post_meta( $post_id, 'rbfw_variations_data', true );
+    $rbfw_variations_data = ! empty( $rbfw_variations_data ) ? $rbfw_variations_data : [];
+
+    $rbfw_resort_room_data = get_post_meta( $post_id, 'rbfw_resort_room_data', true );
+    $rbfw_resort_room_data = ! empty( $rbfw_resort_room_data ) ? $rbfw_resort_room_data : [];
+
+    $rbfw_bike_car_sd_data = get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true );
+    $rbfw_bike_car_sd_data = ! empty( $rbfw_bike_car_sd_data ) ? $rbfw_bike_car_sd_data : [];
+
+    $rbfw_item_stock_quantity = get_post_meta( $post_id, 'rbfw_item_stock_quantity', true );
+    $rbfw_item_stock_quantity = ( $rbfw_item_stock_quantity !== '' && $rbfw_item_stock_quantity !== false ) ? $rbfw_item_stock_quantity : 0;
+
+    $rbfw_item_stock_quantity_timely = get_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', true );
+    $rbfw_item_stock_quantity_timely = ( $rbfw_item_stock_quantity_timely !== '' && $rbfw_item_stock_quantity_timely !== false ) ? $rbfw_item_stock_quantity_timely : 0;
+
+    $modal_title = get_the_title( $post_id );
+    ?>
+    <div class="rbfw_inv_modal">
+        <div class="rbfw_inv_modal_head">
+            <div class="rbfw_inv_modal_icon"><?php echo rbfw_inv_icon('pencil'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+            <div class="rbfw_inv_modal_title_wrap">
+                <div class="rbfw_inv_modal_title"><?php echo esc_html( $modal_title ); ?></div>
+                <div class="rbfw_inv_modal_sub"><?php esc_html_e( 'Edit Stock', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+            </div>
+            <a href="#" class="rbfw_inv_modal_close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>"><?php echo rbfw_inv_icon('x'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></a>
+        </div>
+
+        <form class="rbfw_inv_edit_stock_form" data-post-id="<?php echo esc_attr( $post_id ); ?>">
+            <div class="rbfw_inv_modal_body">
+
+                <?php if ( $rent_type === 'resort' ) : ?>
+
+                    <div class="rbfw_inv_modal_section">
+                        <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('bed'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Room Stock', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                        <?php if ( ! empty( $rbfw_resort_room_data ) ) : ?>
+                            <table class="rbfw_inv_mini_table">
+                                <thead><tr><th><?php esc_html_e( 'Room Type', 'booking-and-rental-manager-for-woocommerce' ); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e( 'Stock Qty', 'booking-and-rental-manager-for-woocommerce' ); ?></th></tr></thead>
+                                <tbody>
+                                <?php foreach ( $rbfw_resort_room_data as $i => $room ) : ?>
+                                    <tr>
+                                        <td><?php echo esc_html( $room['room_type'] ?? '' ); ?></td>
+                                        <td class="rbfw_inv_qty_cell"><input type="number" min="0" step="any" class="rbfw_inv_qty_input" name="qty[room][<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $room['rbfw_room_available_qty'] ?? 0 ); ?>"></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        <?php else : ?>
+                            <div class="rbfw_inv_empty_modal_note"><?php esc_html_e( 'No rooms configured. Add rooms in the item editor first.', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                        <?php endif; ?>
+                    </div>
+
+                <?php elseif ( $rent_type === 'bike_car_sd' || $rent_type === 'appointment' ) : ?>
+
+                    <?php if ( $manage_inventory_as_timely === 'on' ) : ?>
+                        <div class="rbfw_inv_modal_section">
+                            <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('clock'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Timely Stock', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                            <input type="number" min="0" step="any" class="rbfw_inv_qty_input rbfw_inv_qty_input_flat" name="qty[timely]" value="<?php echo esc_attr( $rbfw_item_stock_quantity_timely ); ?>">
+                        </div>
+                    <?php else : ?>
+                        <div class="rbfw_inv_modal_section">
+                            <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('car'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Rent Type Stock', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                            <?php if ( ! empty( $rbfw_bike_car_sd_data ) ) : ?>
+                                <table class="rbfw_inv_mini_table">
+                                    <thead><tr><th><?php esc_html_e( 'Rent Type', 'booking-and-rental-manager-for-woocommerce' ); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e( 'Stock Qty', 'booking-and-rental-manager-for-woocommerce' ); ?></th></tr></thead>
+                                    <tbody>
+                                    <?php foreach ( $rbfw_bike_car_sd_data as $i => $sd ) : ?>
+                                        <tr>
+                                            <td><?php echo esc_html( $sd['rent_type'] ?? '' ); ?></td>
+                                            <td class="rbfw_inv_qty_cell"><input type="number" min="0" step="any" class="rbfw_inv_qty_input" name="qty[sd][<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $sd['qty'] ?? 0 ); ?>"></td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                    </tbody>
+                                </table>
+                            <?php else : ?>
+                                <div class="rbfw_inv_empty_modal_note"><?php esc_html_e( 'No rent types configured. Add them in the item editor first.', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                            <?php endif; ?>
+                        </div>
+                    <?php endif; ?>
+
+                <?php elseif ( $rbfw_enable_variations === 'yes' ) : ?>
+
+                    <?php if ( ! empty( $rbfw_variations_data ) ) : ?>
+                        <?php foreach ( $rbfw_variations_data as $field_i => $group ) : ?>
+                            <div class="rbfw_inv_modal_section">
+                                <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('clone'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php echo esc_html( $group['field_label'] ?? '' ); ?></div>
+                                <?php if ( ! empty( $group['value'] ) ) : ?>
+                                    <table class="rbfw_inv_mini_table">
+                                        <thead><tr><th><?php esc_html_e( 'Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th><th class="rbfw_inv_ta_r"><?php esc_html_e( 'Stock Qty', 'booking-and-rental-manager-for-woocommerce' ); ?></th></tr></thead>
+                                        <tbody>
+                                        <?php foreach ( $group['value'] as $value_i => $value ) : ?>
+                                            <tr>
+                                                <td><?php echo esc_html( $value['name'] ?? '' ); ?></td>
+                                                <td class="rbfw_inv_qty_cell"><input type="number" min="0" step="any" class="rbfw_inv_qty_input" name="qty[variation][<?php echo esc_attr( $field_i ); ?>][<?php echo esc_attr( $value_i ); ?>]" value="<?php echo esc_attr( $value['quantity'] ?? 0 ); ?>"></td>
+                                            </tr>
+                                        <?php endforeach; ?>
+                                        </tbody>
+                                    </table>
+                                <?php endif; ?>
+                            </div>
+                        <?php endforeach; ?>
+                    <?php else : ?>
+                        <div class="rbfw_inv_empty_modal_note"><?php esc_html_e( 'No variations configured. Add them in the item editor first.', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                    <?php endif; ?>
+
+                <?php else : ?>
+
+                    <div class="rbfw_inv_modal_section">
+                        <div class="rbfw_inv_section_label"><?php echo rbfw_inv_icon('box'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Stock Quantity', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                        <input type="number" min="0" step="any" class="rbfw_inv_qty_input rbfw_inv_qty_input_flat" name="qty[flat]" value="<?php echo esc_attr( $rbfw_item_stock_quantity ); ?>">
+                    </div>
+
+                <?php endif; ?>
+
+                <p class="rbfw_inv_edit_stock_msg" role="alert" aria-live="polite"></p>
+            </div>
+            <div class="rbfw_inv_modal_foot">
+                <button type="button" class="rbfw_inv_modal_btn rbfw_inv_modal_btn_ghost rbfw_inv_modal_close"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+                <button type="submit" class="rbfw_inv_modal_btn rbfw_inv_modal_btn_primary rbfw_inv_edit_stock_save"><?php echo rbfw_inv_icon('check'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Save Changes', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+            </div>
+        </form>
+    </div>
+    <?php
+    wp_die();
+}
+
+/**
+ * AJAX: persist stock quantities edited from the Inventory admin page.
+ *
+ * Re-derives the rent type / variations / timely flags from post meta
+ * (never trusts the client for that), then writes only the quantity field
+ * inside the existing stored row for that shape — every other field on the
+ * row (rent_type, price, room description, variation name, etc.) is left
+ * untouched, so this can never corrupt data the item editor owns. This keeps
+ * the Inventory page and the item editor reading/writing the exact same
+ * meta, so a change here always reflects on the item and vice versa.
+ */
+function rbfw_update_inventory_stock() {
+
+    check_ajax_referer( 'rbfw_update_inventory_stock_action', 'nonce' );
+
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        wp_send_json_error( 'Unauthorized access', 403 );
+    }
+
+    $post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+    if ( ! $post_id || get_post_type( $post_id ) !== 'rbfw_item' || ! current_user_can( 'edit_post', $post_id ) ) {
+        wp_send_json_error( 'Unauthorized access', 403 );
+    }
+
+    $rent_type = get_post_meta( $post_id, 'rbfw_item_type', true );
+    $rent_type = ! empty( $rent_type ) ? $rent_type : '';
+
+    $rbfw_enable_variations = get_post_meta( $post_id, 'rbfw_enable_variations', true );
+    $rbfw_enable_variations = ! empty( $rbfw_enable_variations ) ? $rbfw_enable_variations : 'no';
+
+    $manage_inventory_as_timely = get_post_meta( $post_id, 'manage_inventory_as_timely', true );
+    $manage_inventory_as_timely = ! empty( $manage_inventory_as_timely ) ? $manage_inventory_as_timely : 'off';
+
+    $qty = isset( $_POST['qty'] ) && is_array( $_POST['qty'] ) ? $_POST['qty'] : [];
+
+    if ( $rent_type === 'resort' ) {
+
+        $room_data = get_post_meta( $post_id, 'rbfw_resort_room_data', true );
+        $room_data = is_array( $room_data ) ? $room_data : [];
+        $posted    = isset( $qty['room'] ) && is_array( $qty['room'] ) ? $qty['room'] : [];
+
+        foreach ( $posted as $i => $value ) {
+            $i = absint( $i );
+            if ( isset( $room_data[ $i ] ) ) {
+                $room_data[ $i ]['rbfw_room_available_qty'] = rbfw_inv_sanitize_qty( $value );
+            }
+        }
+        update_post_meta( $post_id, 'rbfw_resort_room_data', $room_data );
+
+    } elseif ( $rent_type === 'bike_car_sd' || $rent_type === 'appointment' ) {
+
+        if ( $manage_inventory_as_timely === 'on' ) {
+            $timely = isset( $qty['timely'] ) ? rbfw_inv_sanitize_qty( $qty['timely'] ) : 0;
+            update_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', $timely );
+        } else {
+            $sd_data = get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true );
+            $sd_data = is_array( $sd_data ) ? $sd_data : [];
+            $posted  = isset( $qty['sd'] ) && is_array( $qty['sd'] ) ? $qty['sd'] : [];
+
+            foreach ( $posted as $i => $value ) {
+                $i = absint( $i );
+                if ( isset( $sd_data[ $i ] ) ) {
+                    $sd_data[ $i ]['qty'] = rbfw_inv_sanitize_qty( $value );
+                }
+            }
+            update_post_meta( $post_id, 'rbfw_bike_car_sd_data', $sd_data );
+        }
+    } elseif ( $rbfw_enable_variations === 'yes' ) {
+
+        $variations_data = get_post_meta( $post_id, 'rbfw_variations_data', true );
+        $variations_data = is_array( $variations_data ) ? $variations_data : [];
+        $posted          = isset( $qty['variation'] ) && is_array( $qty['variation'] ) ? $qty['variation'] : [];
+
+        foreach ( $posted as $field_i => $values ) {
+            $field_i = absint( $field_i );
+            if ( ! is_array( $values ) || ! isset( $variations_data[ $field_i ]['value'] ) || ! is_array( $variations_data[ $field_i ]['value'] ) ) {
+                continue;
+            }
+            foreach ( $values as $value_i => $value ) {
+                $value_i = absint( $value_i );
+                if ( isset( $variations_data[ $field_i ]['value'][ $value_i ] ) ) {
+                    $variations_data[ $field_i ]['value'][ $value_i ]['quantity'] = rbfw_inv_sanitize_qty( $value );
+                }
+            }
+        }
+        update_post_meta( $post_id, 'rbfw_variations_data', $variations_data );
+
+    } else {
+        $flat = isset( $qty['flat'] ) ? rbfw_inv_sanitize_qty( $qty['flat'] ) : 0;
+        update_post_meta( $post_id, 'rbfw_item_stock_quantity', $flat );
+    }
+
+    $totals = rbfw_inventory_item_stock_totals( $post_id );
+
+    wp_send_json_success( array(
+        'total' => $totals['item_stock'],
+    ) );
+}
 
 /* =====================================================================
  * Server-side availability validation (prevents double-booking).


### PR DESCRIPTION
## Summary
- Adds an **Edit Stock** button next to each row's stock pill on the Inventory admin page (`edit.php?post_type=rbfw_item&page=rbfw_inventory`), so admins no longer have to open the item editor just to change stock.
- The edit modal renders the correct editable shape per rent type:
  - Flat items → single stock-quantity field
  - Variations enabled → one qty field per variation value
  - Bike/Car Single Day & Appointment → per-rent-type qty, or a single timely-stock field when "manage inventory as timely" is on
  - Resort → one qty field per room
- Saving re-derives rent type / variations / timely flags from post meta server-side (never trusted from the client), and only overwrites the quantity field inside the existing stored row — every other field (price, rent type label, room description, variation name, etc.) is preserved untouched. The Inventory page and the item editor read/write the exact same meta keys, so changes always stay in sync in both directions.
- Fixes a CSS collision (found via screenshot during testing) where the Cancel button reused `.rbfw_inv_modal_close` to hook the existing close-modal handler, but also inherited that class's 30×30 header-icon-button sizing — squashing the "Cancel" label and visually overlapping the Save button.

## Test plan
- [x] `php -l` clean on all changed PHP files
- [x] `node --check` clean on `mkb-admin.js`
- [x] WP-CLI functional test: created test items covering all 5 stock shapes (flat, variations, SD non-timely, SD timely, resort), verified the edit form renders the correct fields/values for each
- [x] WP-CLI functional test: saved updated quantities for each shape, verified `rbfw_inventory_item_stock_totals()` reflects the new totals and non-qty fields (rent_type, price, room description, variation name) are byte-for-byte preserved
- [x] Security test: rejects non-`rbfw_item` post IDs, nonexistent post IDs, invalid nonces, and logged-out/unauthorized users
- [ ] Manual click-through in wp-admin (screenshot confirmed modal opens and renders correctly; footer overlap now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)