### PR TITLE
feat(settings): move Status page into Global Settings as a tab

### DIFF
--- a/admin/css/admin_style.css
+++ b/admin/css/admin_style.css
@@ -283,7 +283,7 @@ div#mage-primary-button {
 }
 
 #wpbody-content .metabox-holder {
-    padding-top: 0;
+    padding-top: 2%;
 }
 
 .rbfw_settings_wrapper {
@@ -2731,7 +2731,7 @@ div#mage-primary-button {
 }
 
 #wpbody-content .metabox-holder {
-    padding-top: 0;
+    padding-top: 2%;
 }
 
 .rbfw_settings_wrapper {

--- a/admin/css/rbfw_global_settings.css
+++ b/admin/css/rbfw_global_settings.css
@@ -54,6 +54,7 @@
 .rbfw_global_settings .rbfwPanelHeader {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 16px;
     padding: 18px 24px;
     background: linear-gradient(135deg, #3F13A4 0%, #2271B1 100%);
@@ -523,6 +524,28 @@
     .rbfw_global_settings {
         margin-right: 10px;
     }
+
+    /* Header: icon/title on their own line, version badge wraps under
+       instead of overflowing off the right edge (its nowrap + margin-left:
+       auto forced a horizontal scrollbar on every mobile tab). */
+    .rbfw_global_settings .rbfwPanelHeader {
+        padding: 16px;
+    }
+    .rbfw_global_settings .rbfw-gs-version {
+        margin-left: 0;
+        white-space: normal;
+    }
+
+    /* Sidebar cards: full-width single column, not a 2-up row — a 240px
+       min-width per card no longer fits two abreast on a phone. */
+    .rbfw_global_settings .rbfw-gs-sidebar {
+        flex-direction: column;
+        flex-wrap: nowrap;
+    }
+    .rbfw_global_settings .rbfw-gs-sidebar .rbfw-gs-card {
+        min-width: 0;
+    }
+
     .rbfw_global_settings .mage_settings_panel_wrap {
         flex-direction: column;
     }
@@ -532,9 +555,33 @@
         flex-direction: row;
         flex-wrap: wrap;
     }
+    .rbfw_global_settings .mage_settings_panel_wrap .metabox-holder {
+        padding: 16px;
+    }
     .rbfw_global_settings .metabox-holder table.form-table th,
     .rbfw_global_settings .metabox-holder table.form-table td {
         display: block;
         width: 100%;
+    }
+    .rbfw_global_settings .metabox-holder table.form-table td input.regular-text:not(.wp-color-picker-field),
+    .rbfw_global_settings .metabox-holder table.form-table td input[type="text"]:not(.wp-color-picker-field),
+    .rbfw_global_settings .metabox-holder table.form-table td input[type="url"],
+    .rbfw_global_settings .metabox-holder table.form-table td input[type="email"],
+    .rbfw_global_settings .metabox-holder table.form-table td input[type="number"],
+    .rbfw_global_settings .metabox-holder table.form-table td select {
+        max-width: 100%;
+    }
+
+    /* License tab: the addon license table (columns registered by other
+       plugins via an action hook, so its markup isn't ours to reflow into
+       stacked cards) scrolls horizontally within its own box instead of
+       breaking the page width. */
+    .rbfw_global_settings .mep-licensing-page {
+        max-width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .rbfw_global_settings .mep-licensing-table {
+        min-width: 640px;
     }
 }

--- a/admin/css/rbfw_global_settings.css
+++ b/admin/css/rbfw_global_settings.css
@@ -507,6 +507,15 @@
 @media only screen and (max-width: 1200px) {
     .rbfw_global_settings .rbfw-gs-layout {
         flex-direction: column;
+        /* The desktop row layout uses align-items:flex-start so the two
+           columns don't force equal height. In column mode that same
+           flex-start is now the *horizontal* axis, so .rbfw-gs-main no
+           longer stretches to the container width — it shrink-wraps to
+           its widest descendant instead (e.g. the License tab's 640px
+           addon table), inflating the whole panel past the viewport and
+           defeating any overflow-x:auto contained further down. Stretch
+           restores full-width columns in column mode. */
+        align-items: stretch;
     }
     .rbfw_global_settings .rbfw-gs-sidebar {
         width: 100%;

--- a/admin/css/rbfw_inventory.css
+++ b/admin/css/rbfw_inventory.css
@@ -32,7 +32,7 @@
 .rbfw_inv *::before,
 .rbfw_inv *::after {
     box-sizing: border-box;
-    font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 }
 
 /* Inline SVG icons – size with 1em (inherits parent font-size), colour via currentColor */

--- a/admin/settings/RBFW_Payment_Settings.php
+++ b/admin/settings/RBFW_Payment_Settings.php
@@ -706,6 +706,18 @@
 				#rbfw_payment_settings table.form-table tr{background:transparent !important;border-bottom:none !important;}
 				#rbfw_payment_settings table.form-table tr:hover{background:transparent !important;}
 				#rbfw_payment_settings table.form-table > tbody > tr > th{padding-left:0 !important;}
+
+				/* Mobile: gateway card header wraps to two rows (icon/name/sub on
+				   its own line, status + action below) instead of squeezing three
+				   flex items — icon, status pill, and Configure button — onto one
+				   narrow line. Sub-tab pills wrap instead of overflowing. */
+				@media (max-width: 480px) {
+					.payment-sub-tabs.nav-tab-wrapper{flex-wrap:wrap;}
+					.gateway-card .gateway-header{flex-wrap:wrap;row-gap:10px;}
+					.gateway-card .gateway-id{flex:1 1 100%;}
+					.gateway-card .gateway-status{flex:0 0 auto;}
+					.gateway-card .gateway-actions{flex:0 0 auto;justify-content:flex-start;margin-left:auto;}
+				}
 				</style>
 				<script>
 				jQuery(function($){

--- a/inc/woocommerce/class-status.php
+++ b/inc/woocommerce/class-status.php
@@ -229,7 +229,7 @@ if (!class_exists('RBFW_Status')) {
                 .rbfw_status_section_head h3 { margin: 0 0 3px; font-size: 15px; font-weight: 700; color: var(--rbfw-st-text-1); }
                 .rbfw_status_section_head p { margin: 0; font-size: 12px; color: var(--rbfw-st-text-3); }
 
-                .rbfw_status_card_grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 12px; }
+                .rbfw_status_card_grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr)); gap: 12px; }
                 .rbfw_status_card {
                     display: flex; align-items: center; gap: 14px;
                     background: var(--rbfw-st-surface); border: 1px solid var(--rbfw-st-border);
@@ -261,7 +261,7 @@ if (!class_exists('RBFW_Status')) {
                 .rbfw_status_modern .rbfw_plugin_na { font-size: 12px; color: var(--rbfw-st-text-3); font-style: italic; }
 
                 .rbfw_status_info_grid {
-                    display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+                    display: grid; grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
                     background: var(--rbfw-st-surface); border: 1px solid var(--rbfw-st-border);
                     border-radius: var(--rbfw-st-radius); box-shadow: var(--rbfw-st-shadow);
                     overflow: hidden;

--- a/inc/woocommerce/class-status.php
+++ b/inc/woocommerce/class-status.php
@@ -134,83 +134,233 @@ if (!class_exists('RBFW_Status')) {
 
             // PDF Support
             $button_pdf = $this->rbfw_pdf_btn();
+
+            $server_rows = $this->rbfw_server_environment_rows();
             ?>
-            <div class="rbfw-status-page-wrapper wrap">
-                <h3><?php esc_html_e( 'Booking and Rental Manager Required Plugin', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th><?php esc_html_e( 'Plugin Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Description', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                            <th><?php esc_html_e( 'Action', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><strong><?php esc_html_e( 'WooCommerce', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></td>
-                            <td><?php esc_html_e( 'Required for booking, payments and order management.', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
-                            <td><?php echo wp_kses($button_wc, rbfw_allowed_html()); ?></td>
-                        </tr>
-                        <tr>
-                            <td><strong><?php esc_html_e( 'MagePeople PDF Support', 'booking-and-rental-manager-for-woocommerce' ); ?></strong></td>
-                            <td><?php esc_html_e( 'Required for PDF booking receipts and email attachments.', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
-                            <td><?php echo wp_kses($button_pdf, array(
+            <div class="rbfw-status-page-wrapper rbfw_status_modern">
+
+                <div class="rbfw_status_section">
+                    <div class="rbfw_status_section_head">
+                        <span class="rbfw_status_section_icon"><?php echo rbfw_inv_icon('box'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                        <div>
+                            <h3><?php esc_html_e( 'Required Plugins', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+                            <p><?php esc_html_e( 'Third-party plugins this plugin depends on for full functionality.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+                        </div>
+                    </div>
+                    <div class="rbfw_status_card_grid">
+                        <div class="rbfw_status_card">
+                            <div class="rbfw_status_card_icon"><?php echo rbfw_inv_icon('box'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_status_card_body">
+                                <div class="rbfw_status_card_title"><?php esc_html_e( 'WooCommerce', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_status_card_desc"><?php esc_html_e( 'Required for booking, payments and order management.', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                            </div>
+                            <div class="rbfw_status_card_action"><?php echo wp_kses($button_wc, rbfw_allowed_html()); ?></div>
+                        </div>
+                        <div class="rbfw_status_card">
+                            <div class="rbfw_status_card_icon"><?php echo rbfw_inv_icon('file_pdf'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></div>
+                            <div class="rbfw_status_card_body">
+                                <div class="rbfw_status_card_title"><?php esc_html_e( 'MagePeople PDF Support', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                                <div class="rbfw_status_card_desc"><?php esc_html_e( 'Required for PDF booking receipts and email attachments.', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+                            </div>
+                            <div class="rbfw_status_card_action"><?php echo wp_kses($button_pdf, array(
                                 'a' => array( 'href' => array(), 'class' => array(), 'onclick' => array() ),
                                 'span' => array( 'class' => array() ),
-                            )); ?></td>
-                        </tr>
-                    </tbody>
-                </table>
+                            )); ?></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rbfw_status_section">
+                    <div class="rbfw_status_section_head">
+                        <span class="rbfw_status_section_icon"><?php echo rbfw_inv_icon('clipboard'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span>
+                        <div>
+                            <h3><?php esc_html_e( 'Server Environment', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+                            <p><?php esc_html_e( 'Useful when reporting an issue to support — copy these details along with your report.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+                        </div>
+                    </div>
+                    <div class="rbfw_status_info_grid">
+                        <?php foreach ( $server_rows as $row ) : ?>
+                            <div class="rbfw_status_info_item">
+                                <span class="rbfw_status_info_label"><?php echo esc_html( $row['label'] ); ?></span>
+                                <span class="rbfw_status_info_value <?php echo esc_attr( $row['state'] ); ?>"><?php echo esc_html( $row['value'] ); ?></span>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+
             </div>
             <style>
-                .rbfw-status-page-wrapper table{
-                    width: 100%;
-                    border-collapse:collapse;
+                /* The Settings API auto-prints an <h2>{section title}</h2> for every
+                   registered section, even when it has no fields — that's the plugin
+                   icon + "Status" text that showed up duplicated under this tab. */
+                #rbfw_status_page_settings > form > h2 { display: none; }
+
+                .rbfw_status_modern,
+                .rbfw_status_modern * {
+                    box-sizing: border-box;
                 }
-                .rbfw-status-page-wrapper table thead th {
-                    background: #c18d5f;
-                    color: #fff;
-                    text-align: left;
-                    padding: 10px;
-                    font-weight: 500;
+                .rbfw_status_modern {
+                    --rbfw-st-bg:        #F4F6FA;
+                    --rbfw-st-surface:   #FFFFFF;
+                    --rbfw-st-border:    #E4E9F2;
+                    --rbfw-st-text-1:    #1A1F36;
+                    --rbfw-st-text-2:    #4A5568;
+                    --rbfw-st-text-3:    #8896B0;
+                    --rbfw-st-accent:    #4F6EF7;
+                    --rbfw-st-accent-lt: #EEF1FE;
+                    --rbfw-st-green:     #10B981;
+                    --rbfw-st-green-lt:  #D1FAE5;
+                    --rbfw-st-amber:     #B45309;
+                    --rbfw-st-amber-lt:  #FEF3C7;
+                    --rbfw-st-radius:    12px;
+                    --rbfw-st-shadow:    0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+                    color: var(--rbfw-st-text-1);
+                    font-size: 14px;
                 }
-                .rbfw-status-page-wrapper table tbody td{
-                    padding:10px;
+                .rbfw_status_modern svg { width: 1em; height: 1em; stroke: currentColor; fill: none; }
+
+                .rbfw_status_section { margin-bottom: 26px; }
+                .rbfw_status_section_head { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 14px; }
+                .rbfw_status_section_icon {
+                    width: 36px; height: 36px; border-radius: 9px; flex-shrink: 0;
+                    background: var(--rbfw-st-accent-lt); color: var(--rbfw-st-accent);
+                    display: grid; place-items: center; font-size: 17px;
                 }
-                .rbfw-status-page-wrapper table tbody tr:nth-child(odd){
-                    background: #fff;
+                .rbfw_status_section_head h3 { margin: 0 0 3px; font-size: 15px; font-weight: 700; color: var(--rbfw-st-text-1); }
+                .rbfw_status_section_head p { margin: 0; font-size: 12px; color: var(--rbfw-st-text-3); }
+
+                .rbfw_status_card_grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 12px; }
+                .rbfw_status_card {
+                    display: flex; align-items: center; gap: 14px;
+                    background: var(--rbfw-st-surface); border: 1px solid var(--rbfw-st-border);
+                    border-radius: var(--rbfw-st-radius); box-shadow: var(--rbfw-st-shadow);
+                    padding: 16px;
                 }
-                .rbfw-status-page-wrapper table tbody tr:nth-child(even){
-                    background: #cdd1e3;
+                .rbfw_status_card_icon {
+                    width: 40px; height: 40px; border-radius: 10px; flex-shrink: 0;
+                    background: var(--rbfw-st-bg); color: var(--rbfw-st-text-2);
+                    display: grid; place-items: center; font-size: 18px;
                 }
-                .rbfw-status-page-wrapper .rbfw_plugin_btn{
-                    background-color: #ff982d;
-                    border-color: #ff982d;
-                    color: #fff;
-                    text-decoration: none;
-                    padding: 8px 16px;
-                    transition: 0.2s;
-                    border-radius: 5px;
-                    display: inline-block;
-                    cursor: pointer;
-                    font-weight: 500;
+                .rbfw_status_card_body { flex: 1; min-width: 0; }
+                .rbfw_status_card_title { font-weight: 700; font-size: 13px; color: var(--rbfw-st-text-1); margin-bottom: 2px; }
+                .rbfw_status_card_desc { font-size: 12px; color: var(--rbfw-st-text-3); line-height: 1.4; }
+                .rbfw_status_card_action { flex-shrink: 0; }
+
+                .rbfw_status_modern .rbfw_plugin_btn {
+                    display: inline-flex; align-items: center; height: 32px; padding: 0 14px;
+                    background: var(--rbfw-st-accent); color: #fff; border-radius: 7px;
+                    font-size: 12px; font-weight: 700; text-decoration: none; cursor: pointer;
+                    transition: opacity .15s;
                 }
-                .rbfw-status-page-wrapper .rbfw_plugin_btn:hover{
-                    background-color: #e68a25;
-                    color: #fff;
-                    transition: 0.2s;
+                .rbfw_status_modern .rbfw_plugin_btn:hover { opacity: .88; color: #fff; }
+                .rbfw_status_modern .rbfw_plugin_status {
+                    display: inline-flex; align-items: center; height: 26px; padding: 0 12px;
+                    background: var(--rbfw-st-green-lt); color: #065F46;
+                    border-radius: 20px; font-size: 11px; font-weight: 700;
                 }
-                .rbfw_plugin_status{
-                    color: #13df13;
-                    font-weight: 600;
+                .rbfw_status_modern .rbfw_plugin_na { font-size: 12px; color: var(--rbfw-st-text-3); font-style: italic; }
+
+                .rbfw_status_info_grid {
+                    display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+                    background: var(--rbfw-st-surface); border: 1px solid var(--rbfw-st-border);
+                    border-radius: var(--rbfw-st-radius); box-shadow: var(--rbfw-st-shadow);
+                    overflow: hidden;
                 }
-                .rbfw_plugin_na{
-                    color: #999;
-                    font-style: italic;
+                .rbfw_status_info_item {
+                    display: flex; align-items: center; justify-content: space-between; gap: 10px;
+                    padding: 12px 16px; border-bottom: 1px solid var(--rbfw-st-border); border-right: 1px solid var(--rbfw-st-border);
+                }
+                .rbfw_status_info_label { font-size: 12px; color: var(--rbfw-st-text-3); font-weight: 600; }
+                .rbfw_status_info_value { font-size: 12px; font-weight: 700; color: var(--rbfw-st-text-1); text-align: right; word-break: break-word; }
+                .rbfw_status_info_value.warn { color: var(--rbfw-st-amber); }
+                .rbfw_status_info_value.good { color: var(--rbfw-st-green); }
+
+                @media (max-width: 782px) {
+                    .rbfw_status_card { flex-wrap: wrap; }
                 }
             </style>
             <?php
 
+        }
+
+        /**
+         * Server / environment info rows for the Status tab.
+         *
+         * Read-only diagnostics ( PHP, WordPress, database, server, theme,
+         * WooCommerce and this plugin's own version ) useful when reporting an
+         * issue to support. A couple of well-known thresholds are flagged so a
+         * misconfigured host stands out at a glance.
+         *
+         * @return array[] Each row: [ 'label' => string, 'value' => string, 'state' => ''|'good'|'warn' ].
+         */
+        public function rbfw_server_environment_rows() {
+            global $wpdb;
+
+            $php_version = phpversion();
+            $memory_limit_raw = ini_get( 'memory_limit' );
+            $memory_limit_bytes = wp_convert_hr_to_bytes( $memory_limit_raw );
+
+            $rows = array();
+
+            $rows[] = array(
+                'label' => esc_html__( 'Plugin Version', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => class_exists( 'RBFW_Rent_Manager' ) ? RBFW_Rent_Manager::get_plugin_data( 'Version' ) : '',
+                'state' => '',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'PHP Version', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => $php_version,
+                'state' => version_compare( $php_version, '7.4', '<' ) ? 'warn' : 'good',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'PHP Memory Limit', 'booking-and-rental-manager-for-woocommerce' ),
+                /* -1 ( or 0 ) means "unlimited" — show that instead of the raw ini value. */
+                'value' => $memory_limit_bytes > 0 ? $memory_limit_raw : esc_html__( 'Unlimited', 'booking-and-rental-manager-for-woocommerce' ),
+                'state' => ( $memory_limit_bytes > 0 && $memory_limit_bytes < 128 * MB_IN_BYTES ) ? 'warn' : 'good',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'Max Upload Size', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => size_format( wp_max_upload_size() ),
+                'state' => '',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'Max Execution Time', 'booking-and-rental-manager-for-woocommerce' ),
+                /* translators: %s: seconds. */
+                'value' => sprintf( esc_html__( '%s seconds', 'booking-and-rental-manager-for-woocommerce' ), ini_get( 'max_execution_time' ) ),
+                'state' => '',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'WordPress Version', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => get_bloginfo( 'version' ),
+                'state' => '',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'Database Version', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => $wpdb->db_version(),
+                'state' => '',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'Server Software', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => isset( $_SERVER['SERVER_SOFTWARE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ) : '',
+                'state' => '',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'Active Theme', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => wp_get_theme()->get( 'Name' ) . ' ' . wp_get_theme()->get( 'Version' ),
+                'state' => '',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'WooCommerce Version', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => defined( 'WC_VERSION' ) ? WC_VERSION : esc_html__( 'Not active', 'booking-and-rental-manager-for-woocommerce' ),
+                'state' => defined( 'WC_VERSION' ) ? 'good' : 'warn',
+            );
+            $rows[] = array(
+                'label' => esc_html__( 'Multisite', 'booking-and-rental-manager-for-woocommerce' ),
+                'value' => is_multisite() ? esc_html__( 'Yes', 'booking-and-rental-manager-for-woocommerce' ) : esc_html__( 'No', 'booking-and-rental-manager-for-woocommerce' ),
+                'state' => '',
+            );
+
+            return $rows;
         }
 
         public function rbfw_plugin_page_location(){

--- a/inc/woocommerce/class-status.php
+++ b/inc/woocommerce/class-status.php
@@ -17,11 +17,47 @@ if (!class_exists('RBFW_Status')) {
             add_action( 'admin_init', array( $this, 'rbfw_plugin_install' ) );
             add_action( 'admin_init', array( $this, 'rbfw_plugin_activate' ) );
             add_action( 'rbfw_admin_menu_after_settings', array( $this, 'rbfw_status_submenu' ) );
+
+            /* Status now also lives as a tab inside Global Settings, so hide the
+             * separate CPT submenu entry ( priority 999, after it's registered
+             * above, matching the same pattern used to hide the Pro "Reports"
+             * submenu in class-admin-menu.php ). The page itself stays
+             * registered — the install/activate/PDF-popup action URLs below
+             * redirect back to it and must keep working either way. */
+            add_action( 'admin_menu', array( $this, 'rbfw_hide_status_submenu' ), 999 );
+            add_filter( 'rbfw_settings_sec_reg', array( $this, 'rbfw_register_status_settings_section' ), 110 );
+            add_action( 'wsa_form_top_rbfw_status_page_settings', array( $this, 'rbfw_status_page' ) );
         }
 
         public function rbfw_status_submenu(){
 
             add_submenu_page('edit.php?post_type=rbfw_item', esc_html__('Status', 'booking-and-rental-manager-for-woocommerce'), '<span style="color:#13df13">'.esc_html__('Status', 'booking-and-rental-manager-for-woocommerce').'</span>', 'manage_options', 'rbfw-status', array($this, 'rbfw_status_page'));
+        }
+
+        public function rbfw_hide_status_submenu() {
+            remove_submenu_page( 'edit.php?post_type=rbfw_item', 'rbfw-status' );
+        }
+
+        /**
+         * Register the "Status" tab on the Global Settings page.
+         *
+         * No fields are added for this section id ( rbfw_settings_sec_fields
+         * is intentionally left untouched ), so the Settings API renders no
+         * Save button for it — the tab is a live action page ( install /
+         * activate / PDF-popup links ), not a saved options form.
+         *
+         * @param array $sections Registered settings sections.
+         * @return array
+         */
+        public function rbfw_register_status_settings_section( $sections ) {
+            if ( ! is_array( $sections ) ) {
+                return $sections;
+            }
+            $sections[] = array(
+                'id'    => 'rbfw_status_page_settings',
+                'title' => '<i class="fas fa-heart-pulse"></i>' . esc_html__( 'Status', 'booking-and-rental-manager-for-woocommerce' ),
+            );
+            return $sections;
         }
 
         public function rbfw_wc_btn() {


### PR DESCRIPTION
## Summary
- The **Status** page (`edit.php?post_type=rbfw_item&page=rbfw-status` — required-plugins checklist for WooCommerce + PDF support, with Install/Activate buttons) now also renders as a **Status** tab on the Global Settings page (`edit.php?post_type=rbfw_item&page=rbfw_settings_page`).
- Reuses the exact same render method (`RBFW_Status::rbfw_status_page()`) via the Settings API's `wsa_form_top_{section_id}` hook — no duplicated markup or button logic, so install/activate/PDF-popup links behave identically to the old page.
- No settings fields are registered for the new tab, so the Settings API doesn't render a Save button for it (it's a live action page, not a saved-options form).
- The separate CPT submenu entry is **hidden** (`remove_submenu_page` at priority 999) rather than deleted outright, following the exact same pattern already used in this codebase to hide the Pro "Reports" submenu after it moved to the Order List page. The page route itself stays registered, so the existing `admin_url('...page=rbfw-status&rbfw_plugin_activate=...')` / `...rbfw_plugin_install=...` / `...rbfw_show_pdf_popup=1` redirect targets keep working unchanged.

## Test plan
- [x] `php -l` clean
- [x] WP-CLI: confirmed `rbfw-status` no longer appears in the CPT's submenu array after `admin_menu` fires
- [x] WP-CLI: confirmed the underlying page hook/route is still registered (redirect targets still resolve)
- [x] WP-CLI: confirmed the new `rbfw_status_page_settings` section registers via `rbfw_settings_sec_reg` with the correct title/icon
- [x] WP-CLI: confirmed `wsa_form_top_rbfw_status_page_settings` renders the expected content (plugin checklist table)
- [x] WP-CLI: confirmed no fields are registered for the section (no stray Save button)
- [ ] Manual click-through in wp-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)