### PR TITLE
feat(location): multi-location inventory & price for every rental type

### DIFF
--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -10,6 +10,7 @@ if (!class_exists('RBFW_Woocommerce')) {
         {
             add_filter( 'woocommerce_add_to_cart_validation', array($this , 'rbfw_prevent_duplicate_cart_item'), 10, 2 );
             add_filter( 'woocommerce_add_to_cart_validation', array($this , 'rbfw_validate_availability_add_to_cart'), 20, 3 );
+            add_filter( 'woocommerce_add_to_cart_validation', array($this , 'rbfw_validate_location_stock'), 25, 3 );
             add_filter( 'woocommerce_add_cart_item_data',array($this ,  'rbfw_add_info_to_cart_item'), 90, 3 );
             add_action( 'woocommerce_before_calculate_totals', array($this ,  'rbfw_set_new_cart_price'), 90 );
             add_filter( 'woocommerce_get_item_data', array($this ,  'rbfw_show_cart_items') , 90, 2 );
@@ -154,6 +155,86 @@ if (!class_exists('RBFW_Woocommerce')) {
                     wc_print_notices();
                     wp_die();
                 }
+                return false;
+            }
+
+            return $passed;
+        }
+
+        /**
+         * Location-wise stock gate at add-to-cart.
+         *
+         * Runs only for items with Location Inventory enabled: the submitted
+         * pickup location must be one of the configured locations, and the
+         * requested quantity may not exceed that location's remaining stock
+         * for the booked dates (rbfw_location_remaining_stock). Global stock
+         * is still enforced by the existing availability validators — this is
+         * an additional, per-location cap.
+         */
+        public function rbfw_validate_location_stock( $passed, $product_id, $quantity = 1 ) {
+            if ( ! $passed || ! function_exists( 'rbfw_get_location_inventory' ) ) {
+                return $passed;
+            }
+
+            $linked_rbfw_id = get_post_meta( $product_id, 'link_rbfw_id', true ) ? get_post_meta( $product_id, 'link_rbfw_id', true ) : $product_id;
+            $rbfw_id        = rbfw_check_product_exists( $linked_rbfw_id ) ? $linked_rbfw_id : $product_id;
+
+            $conf = rbfw_get_location_inventory( $rbfw_id );
+            if ( empty( $conf ) ) {
+                return $passed;
+            }
+
+            // phpcs:disable WordPress.Security.NonceVerification.Missing -- read-only look at the booking submit; nonce is enforced by the cart build.
+            $pickup_point = isset( $_POST['rbfw_pickup_point'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_pickup_point'] ) ) : '';
+            // Booked dates: md/multi-items post rbfw_pickup_(start|end)_date,
+            // resort posts rbfw_(start|end)_datetime, single-day posts
+            // rbfw_bikecarsd_selected_date.
+            $start_date   = isset( $_POST['rbfw_pickup_start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_pickup_start_date'] ) ) : '';
+            if ( '' === $start_date && isset( $_POST['rbfw_start_datetime'] ) ) {
+                $start_date = sanitize_text_field( wp_unslash( $_POST['rbfw_start_datetime'] ) );
+            }
+            if ( '' === $start_date && isset( $_POST['rbfw_bikecarsd_selected_date'] ) ) {
+                $start_date = sanitize_text_field( wp_unslash( $_POST['rbfw_bikecarsd_selected_date'] ) );
+            }
+            $end_date = isset( $_POST['rbfw_pickup_end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_pickup_end_date'] ) ) : '';
+            if ( '' === $end_date && isset( $_POST['rbfw_end_datetime'] ) ) {
+                $end_date = sanitize_text_field( wp_unslash( $_POST['rbfw_end_datetime'] ) );
+            }
+            if ( '' === $end_date ) {
+                $end_date = $start_date;
+            }
+            /* Duration-based forms (multiple_items) post no end date — derive
+               it from durationType/durationQty, mirroring the cart build. */
+            if ( $end_date === $start_date && isset( $_POST['durationType'] ) && '' !== $start_date ) {
+                $d_type = sanitize_text_field( wp_unslash( $_POST['durationType'] ) );
+                $d_qty  = isset( $_POST['durationQty'] ) ? max( 1, absint( wp_unslash( $_POST['durationQty'] ) ) ) : 1;
+                $d_days = 'hourly' === $d_type ? 0 : ( 'daily' === $d_type ? $d_qty : ( 'weekly' === $d_type ? $d_qty * 7 : $d_qty * 30 ) );
+                $d_ts   = strtotime( $start_date );
+                if ( $d_ts && $d_days > 0 ) {
+                    $end_date = gmdate( 'Y-m-d', $d_ts + $d_days * DAY_IN_SECONDS );
+                }
+            }
+            $qty = isset( $_POST['rbfw_item_quantity'] ) ? max( 1, absint( wp_unslash( $_POST['rbfw_item_quantity'] ) ) ) : 1;
+            // phpcs:enable WordPress.Security.NonceVerification.Missing
+
+            if ( '' === $pickup_point || ! isset( $conf[ $pickup_point ] ) ) {
+                wc_add_notice( __( 'Please choose a location before booking.', 'booking-and-rental-manager-for-woocommerce' ), 'error' );
+                return false;
+            }
+
+            $remaining = rbfw_location_remaining_stock( $rbfw_id, $pickup_point, $start_date, $end_date );
+            if ( null !== $remaining && $qty > $remaining ) {
+                $term = get_term_by( 'slug', $pickup_point, 'rbfw_item_location' );
+                $name = $term && ! is_wp_error( $term ) ? $term->name : ucwords( str_replace( '-', ' ', $pickup_point ) );
+                wc_add_notice(
+                    sprintf(
+                        /* translators: 1: location name, 2: remaining units */
+                        __( 'Only %2$d unit(s) are available at %1$s for the selected dates.', 'booking-and-rental-manager-for-woocommerce' ),
+                        $name,
+                        $remaining
+                    ),
+                    'error'
+                );
                 return false;
             }
 
@@ -666,6 +747,7 @@ if (!class_exists('RBFW_Woocommerce')) {
 
                 $rbfw_pickup_point                               = isset( $sd_input_data_sabitized['rbfw_pickup_point'] ) ? $sd_input_data_sabitized['rbfw_pickup_point'] : '';
                 $rbfw_dropoff_point                              = isset( $sd_input_data_sabitized['rbfw_dropoff_point'] ) ? $sd_input_data_sabitized['rbfw_dropoff_point'] : '';
+                list( $rbfw_management_info, $rbfw_management_price ) = rbfw_apply_location_charge( $rbfw_id, $rbfw_pickup_point, $rbfw_management_info, $rbfw_management_price );
                 $rbfw_bikecarsd_ticket_info                      = $rbfw_bikecarsd->rbfw_bikecarsd_ticket_info( $rbfw_id, $rbfw_start_datetime, $end_date, $rbfw_type_info, $rbfw_service_info, $rbfw_bikecarsd_selected_time, $rbfw_regf_info, $rbfw_pickup_point, $rbfw_dropoff_point, $end_time, $rbfw_item_quantity , $bikecarsd_selected_date , $rbfw_management_info , $rbfw_management_price);
 
                 $sub_total_price                                 = apply_filters( 'rbfw_cart_base_price', $sub_total_price );
@@ -743,6 +825,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $prepared_management_info = $this->rbfw_prepare_multi_item_fees_from_post( $rbfw_id, $rbfw_management_info_all, $sub_total_price );
                 $rbfw_management_info     = $prepared_management_info['items'];
                 $rbfw_management_price    = $prepared_management_info['total'];
+                list( $rbfw_management_info, $rbfw_management_price ) = rbfw_apply_location_charge( $rbfw_id, $rbfw_pickup_point, $rbfw_management_info, $rbfw_management_price );
 
 
 
@@ -941,6 +1024,8 @@ if (!class_exists('RBFW_Woocommerce')) {
                     }
                 }
 
+
+                list( $rbfw_management_info, $rbfw_management_price ) = rbfw_apply_location_charge( $rbfw_id, $rbfw_pickup_point, $rbfw_management_info, $rbfw_management_price );
 
                 $discount_amount = 0;
                 if ( function_exists( 'rbfw_get_discount_array' ) ) {

--- a/admin/RBFW_Modern_Editor.php
+++ b/admin/RBFW_Modern_Editor.php
@@ -784,6 +784,11 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 			}
 			update_post_meta( $post_id, 'rbfw_dropoff_data', $dropoff_data );
 
+			/* Location inventory & price (shared field names with the classic panel) */
+			if ( class_exists( 'RBFW_Location' ) && method_exists( 'RBFW_Location', 'save_location_inventory_from_post' ) ) {
+				RBFW_Location::save_location_inventory_from_post( $post_id );
+			}
+
 			/* Categories (taxonomy) */
 			if ( isset( $_POST['rbfw_categories'] ) ) {
 				$cats = rbfw_sanitize_rent_type_categories( wp_unslash( $_POST['rbfw_categories'] ) );

--- a/admin/css/rbfw-modern-editor.css
+++ b/admin/css/rbfw-modern-editor.css
@@ -9367,3 +9367,20 @@ textarea.rbfw-me-field-invalid {
     padding: 10px 14px;
 }
 .rbfw-me-offday-rules-note .dashicons { color: #2f5eff; flex-shrink: 0; font-size: 16px; height: 16px; width: 16px; }
+
+/* ── Location Inventory & Price (Location panel) ── */
+.rbfw-me-loc-inv-rows { margin-top: 4px; }
+.rbfw-me-loc-inv-grid {
+    align-items: center;
+    display: grid;
+    gap: 10px 14px;
+    grid-template-columns: minmax(140px, 1.4fr) 1fr 1fr;
+}
+.rbfw-me-loc-inv-head {
+    color: #6a727e;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+}
+.rbfw-me-loc-inv-name { color: #1f2733; font-size: 13px; font-weight: 600; }

--- a/admin/settings/Location.php
+++ b/admin/settings/Location.php
@@ -310,6 +310,65 @@
 					$locations,
 					$dropoff_slugs
 				);
+
+				self::render_modern_location_inventory( $post_id, $locations );
+			}
+
+			/**
+			 * Modern editor: "Location Inventory & Price" block — toggle + one
+			 * stock/price row per location (same field names as the classic
+			 * panel; collectFormData() posts them as the same arrays).
+			 */
+			private static function render_modern_location_inventory( int $post_id, array $locations ): void {
+				$enabled = get_post_meta( $post_id, 'rbfw_enable_location_inventory', true ) === 'on';
+				$rows    = self::location_inventory_rows( $post_id );
+				?>
+				<div class="rbfw-me-field rbfw-me-field--toggle-row">
+					<div class="rbfw-me-field__info">
+						<strong><?php esc_html_e( 'Location Inventory & Price', 'booking-and-rental-manager-for-woocommerce' ); ?></strong>
+						<span class="rbfw-me-field__desc"><?php esc_html_e( 'Customers choose a pick-up location first; each location has its own stock and price added to the booking total.', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+					</div>
+					<label class="rbfw-me-toggle">
+						<input type="checkbox" name="rbfw_enable_location_inventory" value="on" <?php checked( $enabled ); ?> class="rbfw-me-toggle__input rbfw-me-toggle--reveal" data-reveals=".rbfw-me-loc-inv-rows" />
+						<span class="rbfw-me-toggle__ui" aria-hidden="true"></span>
+					</label>
+				</div>
+				<div class="rbfw-me-loc-inv-rows<?php echo $enabled ? '' : ' rbfw-me-hidden'; ?>">
+					<?php if ( empty( $locations ) ) : ?>
+						<p class="rbfw-me-loc-empty"><?php esc_html_e( 'No locations yet — add one above.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+					<?php else : ?>
+						<div class="rbfw-me-loc-inv-grid">
+							<div class="rbfw-me-loc-inv-head"><?php esc_html_e( 'Location', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+							<div class="rbfw-me-loc-inv-head"><?php esc_html_e( 'Stock', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+							<div class="rbfw-me-loc-inv-head"><?php esc_html_e( 'Price', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+							<?php foreach ( $locations as $loc ) :
+								$slug  = $loc['value'];
+								$stock = isset( $rows[ $slug ]['stock'] ) ? (int) $rows[ $slug ]['stock'] : '';
+								$price = isset( $rows[ $slug ]['price'] ) ? (float) $rows[ $slug ]['price'] : '';
+								?>
+								<div class="rbfw-me-loc-inv-name"><?php echo esc_html( $loc['name'] ); ?></div>
+								<div><input type="number" min="0" step="1" class="rbfw-me-input" name="rbfw_loc_inv_stock[<?php echo esc_attr( $slug ); ?>]" value="<?php echo esc_attr( $stock ); ?>" placeholder="0"></div>
+								<div><input type="number" min="0" step="0.01" class="rbfw-me-input" name="rbfw_loc_inv_price[<?php echo esc_attr( $slug ); ?>]" value="<?php echo esc_attr( $price ); ?>" placeholder="0"></div>
+							<?php endforeach; ?>
+						</div>
+						<p class="rbfw-me-field__desc"><?php esc_html_e( 'Fill in stock/price only for the locations you offer — empty rows are ignored. Works on its own; the Pick-up/Drop-off switches above are a separate, simpler dropdown feature.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+					<?php endif; ?>
+
+					<div class="rbfw-me-offday-rules rbfw-me-loc-inv-rules">
+						<?php foreach ( self::location_inventory_rules() as $rule ) : ?>
+							<div class="rbfw-me-offday-rule">
+								<span class="rbfw-me-offday-rule__badge"><?php echo esc_html( $rule[0] ); ?></span>
+								<span class="rbfw-me-offday-rule__text"><?php echo esc_html( $rule[1] ); ?></span>
+								<span class="dashicons dashicons-yes-alt rbfw-me-offday-rule__check"></span>
+							</div>
+						<?php endforeach; ?>
+					</div>
+					<p class="rbfw-me-offday-rules-note">
+						<span class="dashicons dashicons-info-outline"></span>
+						<?php esc_html_e( 'When disabled, the booking form works without the location step — no location stock caps and no location charge.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+					</p>
+				</div>
+				<?php
 			}
 
 			/**
@@ -397,6 +456,8 @@
 					<?php do_action( 'rbfw_location_config_before', $post_id ); ?>
 					<?php $this->panel_header( 'Pick-up Location Configuration', 'Here you can set location.' ); ?>
 					<?php $this->pickup_location_config( $post_id ); ?>
+					<?php $this->panel_header( 'Location Inventory & Price', 'Set stock and price per location. Customers choose a location first on the booking form; its stock caps the quantity and its price is added to the total. Works on its own — the Pick-up/Drop-off switches are a separate, simpler dropdown feature.' ); ?>
+					<?php $this->location_inventory_config( $post_id ); ?>
 					<?php $this->panel_header( 'Drop-off Location Configuration', 'Here you can set drop off location.' ); ?>
 					<?php $this->drop_off_location_config( $post_id ); ?>
 					<?php do_action( 'rbfw_location_config_after', $post_id ); ?>
@@ -532,6 +593,164 @@
 				<?php
 			}
 
+			/**
+			 * Saved location-inventory rows (raw, unfiltered by pickup selection).
+			 * slug => [ 'stock' => int, 'price' => float ].
+			 */
+			public static function location_inventory_rows( $post_id ) {
+				$rows = get_post_meta( $post_id, 'rbfw_location_inventory', true );
+				return is_array( $rows ) ? $rows : array();
+			}
+
+			/**
+			 * Conditional rules per rental type / pricing mode — how the
+			 * booking dates arrive in each mode and how the location cards
+			 * react. Shown in both editors so admins understand the
+			 * dates-first → location flow for every item type they sell.
+			 *
+			 * @return array[] Each row: [ mode badge, rule text ].
+			 */
+			public static function location_inventory_rules() {
+				return array(
+					array(
+						__( 'Multi Day', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Pickup & return date pickers — the location cards activate once both dates are chosen; availability is calculated over the whole range', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+					array(
+						__( 'Hourly / Time', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Hourly rates and time pickers use the same dates — stock is counted per day, so times never reduce it further', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+					array(
+						__( 'Fixed Dates', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Items with a fixed event start/end (date picker turned off) activate the location cards automatically on page load', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+					array(
+						__( 'From Search', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Dates carried over from the search page also activate the cards automatically', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+					array(
+						__( 'Single Day', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Clicking a date on the availability calendar activates the cards (Appointment items included)', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+					array(
+						__( 'Timely Stock', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Single-day items with timely inventory use their own Rental Start Date field — the cards follow right after it', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+					array(
+						__( 'Multiple Items', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Duration bookings (hourly / daily / weekly / monthly × quantity) derive the end date from the duration — changing it re-checks location stock', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+					array(
+						__( 'Resort', 'booking-and-rental-manager-for-woocommerce' ),
+						__( 'Check-in & check-out dates drive the cards, shown before the Check Availability step', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+				);
+			}
+
+			/**
+			 * Classic editor: "Location Inventory & Price" panel — a toggle plus one
+			 * stock/price row per location. Rows are keyed by the same
+			 * sanitize_title( term name ) value the pickup selection uses, so a row
+			 * only takes effect when its location is also selected for pick-up.
+			 */
+			public function location_inventory_config( $post_id ) {
+				$enabled   = get_post_meta( $post_id, 'rbfw_enable_location_inventory', true ) === 'on';
+				$rows      = self::location_inventory_rows( $post_id );
+				$locations = $this->rbfw_get_location_list();
+				?>
+                <section>
+                    <div>
+                        <label><?php esc_html_e( 'Enable Location Inventory & Price', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                        <p><?php esc_html_e( 'Customers must choose a pick-up location before booking; each location has its own stock and price.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+                    </div>
+                    <label class="switch">
+                        <input type="checkbox" name="rbfw_enable_location_inventory" value="on" <?php checked( $enabled ); ?>>
+                        <span class="slider round"></span>
+                    </label>
+                </section>
+                <section>
+                    <div class="rbfw_loc_inv_rules" style="width:100%;">
+						<?php foreach ( self::location_inventory_rules() as $rule ) : ?>
+                            <div style="display:flex;align-items:center;gap:12px;background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:10px 14px;margin-bottom:8px;">
+                                <span style="background:#eef3ff;border:1px solid #dbe4ff;border-radius:6px;color:#2f5eff;flex-shrink:0;font-size:11px;font-weight:700;padding:3px 9px;white-space:nowrap;"><?php echo esc_html( $rule[0] ); ?></span>
+                                <span style="flex:1;font-size:13px;"><?php echo esc_html( $rule[1] ); ?></span>
+                                <span class="dashicons dashicons-yes-alt" style="color:#16a34a;flex-shrink:0;"></span>
+                            </div>
+						<?php endforeach; ?>
+                        <p style="background:#eef3ff;border-radius:6px;color:#4a5568;font-size:12.5px;margin:10px 0 0;padding:9px 13px;">
+                            <span class="dashicons dashicons-info-outline" style="color:#2f5eff;font-size:15px;height:15px;width:15px;vertical-align:middle;"></span>
+							<?php esc_html_e( 'When disabled, the booking form works without the location step — no location stock caps and no location charge.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+                        </p>
+                    </div>
+                </section>
+				<?php if ( empty( $locations ) ) : ?>
+                    <section><div><p><?php esc_html_e( 'No locations yet — add locations above first.', 'booking-and-rental-manager-for-woocommerce' ); ?></p></div></section>
+				<?php else : ?>
+                    <section>
+                        <table class="form-table rbfw_loc_inv_table" style="width:100%;border-collapse:collapse;">
+                            <thead>
+                            <tr>
+                                <th style="text-align:left;padding:6px 8px;"><?php esc_html_e( 'Location', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                <th style="text-align:left;padding:6px 8px;"><?php esc_html_e( 'Stock', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                                <th style="text-align:left;padding:6px 8px;"><?php esc_html_e( 'Price', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+							<?php foreach ( $locations as $loc ) :
+								$slug  = $loc['value'];
+								$stock = isset( $rows[ $slug ]['stock'] ) ? (int) $rows[ $slug ]['stock'] : '';
+								$price = isset( $rows[ $slug ]['price'] ) ? (float) $rows[ $slug ]['price'] : '';
+								?>
+                                <tr>
+                                    <td style="padding:6px 8px;"><?php echo esc_html( $loc['name'] ); ?></td>
+                                    <td style="padding:6px 8px;"><input type="number" min="0" step="1" name="rbfw_loc_inv_stock[<?php echo esc_attr( $slug ); ?>]" value="<?php echo esc_attr( $stock ); ?>" placeholder="0"></td>
+                                    <td style="padding:6px 8px;"><input type="number" min="0" step="0.01" name="rbfw_loc_inv_price[<?php echo esc_attr( $slug ); ?>]" value="<?php echo esc_attr( $price ); ?>" placeholder="0"></td>
+                                </tr>
+							<?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </section>
+				<?php endif;
+			}
+
+			/**
+			 * Persist the location-inventory fields from a submitted editor form.
+			 * Shared by the classic save_post handler and the modern editor's
+			 * AJAX save (both post the same field names).
+			 */
+			public static function save_location_inventory_from_post( $post_id ) {
+				// phpcs:disable WordPress.Security.NonceVerification.Missing -- callers verify their own nonce.
+				$enable = ( isset( $_POST['rbfw_enable_location_inventory'] ) && $_POST['rbfw_enable_location_inventory'] === 'on' ) ? 'on' : 'off';
+				update_post_meta( $post_id, 'rbfw_enable_location_inventory', $enable );
+
+				$stocks = ( isset( $_POST['rbfw_loc_inv_stock'] ) && is_array( $_POST['rbfw_loc_inv_stock'] ) )
+					? array_map( 'sanitize_text_field', wp_unslash( $_POST['rbfw_loc_inv_stock'] ) ) : array();
+				$prices = ( isset( $_POST['rbfw_loc_inv_price'] ) && is_array( $_POST['rbfw_loc_inv_price'] ) )
+					? array_map( 'sanitize_text_field', wp_unslash( $_POST['rbfw_loc_inv_price'] ) ) : array();
+				// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+				if ( empty( $stocks ) && empty( $prices ) ) {
+					return; // fields not rendered in this submit — leave saved rows alone
+				}
+
+				$rows = array();
+				foreach ( $stocks as $slug => $stock ) {
+					$slug = sanitize_title( $slug );
+					if ( '' === $slug ) {
+						continue;
+					}
+					$price = isset( $prices[ $slug ] ) ? (float) $prices[ $slug ] : 0;
+					if ( '' === $stock && $price <= 0 ) {
+						continue; // untouched row
+					}
+					$rows[ $slug ] = array(
+						'stock' => max( 0, (int) $stock ),
+						'price' => max( 0, $price ),
+					);
+				}
+				update_post_meta( $post_id, 'rbfw_location_inventory', $rows );
+			}
+
 			public function settings_save( $post_id ) {
 				if ( ! isset( $_POST['rbfw_ticket_type_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['rbfw_ticket_type_nonce'] ) ), 'rbfw_ticket_type_nonce' ) ) {
 					return;
@@ -579,6 +798,8 @@
 					} elseif ( empty( $dropoff_data_arr ) && $old_rbfw_dropoff_data ) {
 						delete_post_meta( $post_id, 'rbfw_dropoff_data', $old_rbfw_dropoff_data );
 					}
+
+					self::save_location_inventory_from_post( $post_id );
 				}
 			}
 		}

--- a/assets/mp_script/rbfw_script.js
+++ b/assets/mp_script/rbfw_script.js
@@ -799,3 +799,180 @@ function fee_management(sub_total_price,total_days=1,quantity=1){
         document.addEventListener('DOMContentLoaded', rbfwArrangeBookingForm);
     }
 })();
+
+/* ── Pickup-location chooser cards (Location Inventory & Price) ──
+ * The cards block (templates/forms/location-cards.php) is the first child of
+ * the booking form; CSS gates every later sibling until a card is chosen.
+ * Choosing a card writes the slug into the form's rbfw_pickup_point field
+ * (kept two-way in sync with the classic dropdown) and caps the quantity
+ * controls to the location's remaining stock. The location charge itself is
+ * applied server-side at add-to-cart (rbfw_apply_location_charge), so
+ * nothing here affects the authoritative price.
+ */
+jQuery(function ($) {
+    var $wrap = $('#rbfw_loc_cards_wrap');
+    if (!$wrap.length) return;
+    var $form = $wrap.closest('form.mp_rbfw_ticket_form');
+    if (!$form.length) return;
+
+    function rbfwLocPointField() {
+        var $select = $form.find('select[name="rbfw_pickup_point"]');
+        if ($select.length) return $select;
+        var $hidden = $form.find('input[name="rbfw_pickup_point"]');
+        if (!$hidden.length) {
+            $hidden = $('<input>', { type: 'hidden', name: 'rbfw_pickup_point' }).appendTo($form);
+        }
+        return $hidden;
+    }
+
+    function rbfwLocCapQuantity(stock) {
+        if (isNaN(stock) || stock < 1) return;
+        // select-based quantity (md and friends)
+        $form.find('#rbfw_item_quantity_md, select[name="rbfw_item_quantity"]').each(function () {
+            var $sel = $(this);
+            $sel.find('option').each(function () {
+                var v = parseInt($(this).val(), 10);
+                if (!isNaN(v)) $(this).prop('disabled', v > stock);
+            });
+            var cur = parseInt($sel.val(), 10);
+            if (!isNaN(cur) && cur > stock) $sel.val(String(stock)).trigger('change');
+        });
+        // input-based quantity
+        $form.find('input[name="rbfw_item_quantity"]').each(function () {
+            var $inp = $(this);
+            $inp.attr('max', stock);
+            var cur = parseInt($inp.val() || '1', 10);
+            if (cur > stock) $inp.val(stock).trigger('change');
+        });
+    }
+
+    $wrap.on('click', '.rbfw_loc_card', function () {
+        var $card = $(this);
+        if ($wrap.hasClass('rbfw_loc_waitdates')) return; // dates first — stock is date-wise
+        if ($card.is(':disabled') || $card.hasClass('rbfw_loc_card_soldout')) return;
+
+        $wrap.find('.rbfw_loc_card').removeClass('rbfw_loc_card_selected');
+        $card.addClass('rbfw_loc_card_selected');
+        $wrap.removeClass('rbfw_loc_pending');
+
+        var loc = String($card.data('loc'));
+        var $field = rbfwLocPointField();
+        if ($field.is('select') && !$field.find('option[value="' + loc + '"]').length) {
+            $field.append($('<option>', { value: loc, text: $card.find('.rbfw_loc_card_name').text() }));
+        }
+        if ($field.val() !== loc) $field.val(loc).trigger('change');
+
+        rbfwLocCapQuantity(parseInt($card.data('stock'), 10));
+    });
+
+    // Keep the cards in sync if the classic dropdown is used directly.
+    $form.on('change', 'select[name="rbfw_pickup_point"]', function () {
+        var $card = $wrap.find('.rbfw_loc_card[data-loc="' + String($(this).val()) + '"]');
+        if ($card.length && !$card.hasClass('rbfw_loc_card_selected')) $card.trigger('click');
+    });
+
+    /* Date-aware stock refresh: whenever the customer picks/changes booking
+     * dates, re-fetch each location's remaining stock for that exact range
+     * and update the card badges. A selected card that becomes sold out is
+     * deselected and the form re-gated. */
+    function rbfwLocApplyStock($card, left) {
+        left = parseInt(left, 10);
+        if (isNaN(left)) return;
+        var txtAvail = $wrap.data('txt-available') || '%d unit(s) available';
+        var txtSold  = $wrap.data('txt-soldout') || 'Sold out';
+        var $stockEl = $card.find('.rbfw_loc_card_stock');
+
+        $card.attr('data-stock', left).data('stock', left);
+        if (left <= 0) {
+            $card.addClass('rbfw_loc_card_soldout').prop('disabled', true);
+            $stockEl.text(txtSold);
+            if ($card.hasClass('rbfw_loc_card_selected')) {
+                $card.removeClass('rbfw_loc_card_selected');
+                $wrap.addClass('rbfw_loc_pending');
+                rbfwLocPointField().val('').trigger('change');
+            }
+        } else {
+            $card.removeClass('rbfw_loc_card_soldout').prop('disabled', false);
+            $stockEl.text(txtAvail.replace('%d', left));
+            if ($card.hasClass('rbfw_loc_card_selected')) {
+                rbfwLocCapQuantity(left);
+            }
+        }
+    }
+
+    var rbfwLocStockTimer = null;
+    function rbfwLocRefreshStocks() {
+        if (typeof rbfw_ajax_front === 'undefined' || !rbfw_ajax_front.nonce_location_stock_info) return;
+        var post_id = $wrap.data('post-id');
+        if (!post_id) return;
+
+        var start = $form.find('input[name="rbfw_pickup_start_date"]').val()
+            || $form.find('input[name="rbfw_start_datetime"]').val()
+            || $form.find('input[name="rbfw_bikecarsd_selected_date"]').val() || '';
+        var end = $form.find('input[name="rbfw_pickup_end_date"]').val()
+            || $form.find('input[name="rbfw_end_datetime"]').val() || start;
+        if (!start) return;
+
+        // Duration-based forms (multiple_items): no end-date field — derive it
+        // from the chosen duration so availability covers the whole rental.
+        if (end === start && $form.find('[name="durationType"]').length) {
+            var dType = String($form.find('[name="durationType"]').val() || 'daily');
+            var dQty  = parseInt($form.find('[name="durationQty"]').val(), 10) || 1;
+            var dDays = dType === 'hourly' ? 0 : (dType === 'daily' ? dQty : (dType === 'weekly' ? dQty * 7 : dQty * 30));
+            var dEnd  = new Date(String(start).slice(0, 10) + 'T00:00:00');
+            if (!isNaN(dEnd.getTime()) && dDays > 0) {
+                dEnd.setDate(dEnd.getDate() + dDays);
+                end = dEnd.getFullYear() + '-' + ('0' + (dEnd.getMonth() + 1)).slice(-2) + '-' + ('0' + dEnd.getDate()).slice(-2);
+            }
+        }
+
+        clearTimeout(rbfwLocStockTimer);
+        rbfwLocStockTimer = setTimeout(function () {
+            jQuery.post(rbfw_ajax_front.rbfw_ajaxurl, {
+                action: 'rbfw_location_stock_info',
+                post_id: post_id,
+                start_date: start,
+                end_date: end,
+                nonce: rbfw_ajax_front.nonce_location_stock_info
+            }, function (res) {
+                if (!res || !res.success || !res.data) return;
+                // Dates are known now — activate the cards with date-exact stock.
+                if ($wrap.hasClass('rbfw_loc_waitdates')) {
+                    $wrap.removeClass('rbfw_loc_waitdates');
+                    var chooseTxt = $wrap.data('txt-note-choose');
+                    if (chooseTxt) $wrap.find('.rbfw_loc_cards_note').text(chooseTxt);
+                }
+                $wrap.removeClass('rbfw_loc_cards_error');
+                jQuery.each(res.data, function (slug, left) {
+                    var $card = $wrap.find('.rbfw_loc_card[data-loc="' + slug + '"]');
+                    if ($card.length) rbfwLocApplyStock($card, left);
+                });
+            });
+        }, 250);
+    }
+
+    $form.on('change',
+        'input[name="rbfw_pickup_start_date"], input[name="rbfw_pickup_end_date"], ' +
+        'input[name="rbfw_start_datetime"], input[name="rbfw_end_datetime"], ' +
+        'input[name="rbfw_bikecarsd_selected_date"], ' +
+        'select[name="durationType"], input[name="durationQty"]',
+        rbfwLocRefreshStocks
+    );
+
+    /* Some pricing modes arrive with dates already known — fixed event
+     * start/end (multi-day items with the date picker disabled render them
+     * as hidden inputs) or dates carried over from the search page. Activate
+     * the cards immediately in that case; rbfwLocRefreshStocks() is a no-op
+     * when no start date exists yet. */
+    rbfwLocRefreshStocks();
+
+    // Booking without a location: block the submit and point at the cards.
+    $form.on('submit', function (e) {
+        if (!$wrap.find('.rbfw_loc_card_selected').length) {
+            e.preventDefault();
+            $wrap.addClass('rbfw_loc_cards_error');
+            $wrap[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+            setTimeout(function () { $wrap.removeClass('rbfw_loc_cards_error'); }, 2500);
+        }
+    });
+});

--- a/css/rbfw_style.css
+++ b/css/rbfw_style.css
@@ -12464,3 +12464,143 @@ i.fas.fa-minus {
    ====================================================== */
 
 
+
+/* ── Pickup-location chooser cards (Location Inventory & Price) ── */
+.rbfw_loc_cards_wrap {
+    background: #f8f9fd;
+    border: 1px solid #e4e9f2;
+    border-radius: 14px;
+    margin-bottom: 22px;
+    padding: 18px 18px 14px;
+}
+.rbfw_loc_cards_head {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    margin-bottom: 14px;
+}
+.rbfw_loc_cards_title { color: #1f2733; font-size: 15px; font-weight: 700; }
+.rbfw_loc_cards_required {
+    background: #fff1f2;
+    border: 1px solid #ffd7db;
+    border-radius: 20px;
+    color: #e11d48;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: .4px;
+    padding: 3px 10px;
+    text-transform: uppercase;
+}
+.rbfw_loc_cards {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fill, minmax(min(230px, 100%), 1fr));
+}
+.rbfw_loc_card {
+    align-items: center;
+    background: #fff;
+    border: 2px solid #e4e9f2;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, .05);
+    cursor: pointer;
+    display: flex;
+    font-family: inherit;
+    gap: 12px;
+    padding: 14px;
+    position: relative;
+    text-align: left;
+    transition: border-color .16s, box-shadow .16s, transform .12s;
+    width: 100%;
+}
+.rbfw_loc_card:hover:not(:disabled) {
+    border-color: #7b6ff0;
+    box-shadow: 0 6px 16px rgba(123, 111, 240, .16);
+    transform: translateY(-1px);
+}
+.rbfw_loc_card_pin {
+    align-items: center;
+    background: linear-gradient(135deg, #7b6ff0 0%, #4f8ef7 100%);
+    border-radius: 10px;
+    color: #fff;
+    display: flex;
+    flex-shrink: 0;
+    height: 40px;
+    justify-content: center;
+    width: 40px;
+}
+.rbfw_loc_card_pin svg { height: 20px; width: 20px; }
+.rbfw_loc_card_body { display: flex; flex: 1; flex-direction: column; gap: 3px; min-width: 0; }
+.rbfw_loc_card_name { color: #1f2733; font-size: 14px; font-weight: 700; }
+.rbfw_loc_card_stock { color: #16a34a; font-size: 12px; font-weight: 600; }
+.rbfw_loc_card_price {
+    background: #eef3ff;
+    border-radius: 8px;
+    color: #2f5eff;
+    flex-shrink: 0;
+    font-size: 12.5px;
+    font-weight: 700;
+    padding: 5px 10px;
+    white-space: nowrap;
+}
+.rbfw_loc_card_price .woocommerce-Price-amount { font-weight: 700; }
+.rbfw_loc_card_price_free { background: #ecfdf5; color: #16a34a; }
+.rbfw_loc_card_check {
+    align-items: center;
+    background: #16a34a;
+    border-radius: 50%;
+    color: #fff;
+    display: none;
+    height: 22px;
+    justify-content: center;
+    position: absolute;
+    right: -8px;
+    top: -8px;
+    width: 22px;
+}
+.rbfw_loc_card_check svg { height: 12px; width: 12px; }
+.rbfw_loc_card_selected {
+    border-color: #7b6ff0 !important;
+    box-shadow: 0 8px 20px rgba(123, 111, 240, .22) !important;
+}
+.rbfw_loc_card_selected .rbfw_loc_card_check { display: flex; }
+.rbfw_loc_card_soldout { cursor: not-allowed; filter: grayscale(1); opacity: .55; }
+.rbfw_loc_card_soldout .rbfw_loc_card_stock { color: #e11d48; }
+.rbfw_loc_cards_note {
+    color: #6a727e;
+    font-size: 12.5px;
+    margin: 12px 0 0;
+}
+.rbfw_loc_cards_wrap:not(.rbfw_loc_pending) .rbfw_loc_cards_note { display: none; }
+
+/* Dates-first flow: availability is date-wise, so the cards wait (dimmed,
+   unclickable) until booking dates are chosen; then they activate with the
+   exact remaining stock for that range. The cards block sits right AFTER
+   the date fields in every booking form, and everything that follows it
+   stays locked until a location is chosen. */
+.rbfw_loc_cards_wrap.rbfw_loc_pending ~ * {
+    filter: grayscale(.15);
+    opacity: .45;
+    pointer-events: none;
+    user-select: none;
+}
+.rbfw_loc_cards_wrap.rbfw_loc_waitdates .rbfw_loc_card {
+    cursor: not-allowed;
+    opacity: .55;
+}
+.rbfw_loc_cards_wrap.rbfw_loc_waitdates .rbfw_loc_card_stock { color: #6a727e; }
+
+/* Booking attempted without choosing a location. */
+.rbfw_loc_cards_wrap.rbfw_loc_cards_error {
+    animation: rbfw-loc-shake .3s ease-in-out;
+    border-color: #e11d48;
+}
+.rbfw_loc_cards_wrap.rbfw_loc_cards_error .rbfw_loc_cards_note { color: #e11d48; font-weight: 600; }
+@keyframes rbfw-loc-shake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-5px); }
+    75% { transform: translateX(5px); }
+}
+
+/* The classic pickup dropdown is redundant while cards are active. */
+.rbfw_loc_cards_hide_select { display: none !important; }

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -376,6 +376,7 @@ if (! class_exists('RBFW_Dependencies')) {
 
 				wp_localize_script('jquery', 'rbfw_ajax_front', array(
 					'rbfw_ajaxurl' => admin_url('admin-ajax.php'),
+					'nonce_location_stock_info'        => wp_create_nonce('rbfw_location_stock_info_action'),
 					'nonce_check_resort_availibility'        => wp_create_nonce('rbfw_check_resort_availibility_action'),
 					'nonce_bikecarmd_ajax_price_calculation'        => wp_create_nonce('rbfw_bikecarmd_ajax_price_calculation_action'),
 					'nonce_multi_items_ajax_price_calculation'        => wp_create_nonce('rbfw_multi_items_ajax_price_calculation_action'),

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -2787,6 +2787,180 @@ add_action( 'woocommerce_thankyou', 'rbfw_update_order_status' );add_action( 'wo
 	function rbfw_block_offday_range_booking( $post_id ) {
 		return get_post_meta( $post_id, 'rbfw_block_offday_range_booking', true ) === 'off' ? 'off' : 'on';
 	}
+
+	/**
+	 * Location-wise inventory & price configuration for a rental item.
+	 *
+	 * Rows are stored in 'rbfw_location_inventory' keyed by the location slug
+	 * (sanitize_title of the rbfw_item_location term name — the same identity
+	 * used by rbfw_pickup_point everywhere else).
+	 *
+	 * Standalone feature: it only needs its own toggle. The classic Pick-up /
+	 * Drop-off Location switches are a separate use case (plain dropdowns
+	 * without stock/price) — when Location Inventory is on, choosing a card IS
+	 * the pickup choice, so the admin never configures the location twice.
+	 * Every saved row participates; the admin controls the offering simply by
+	 * filling in stock/price (empty rows are never saved).
+	 *
+	 * @param  int $post_id Rental item ID.
+	 * @return array<string,array> slug => [stock,price]; [] when the feature is off.
+	 */
+	function rbfw_get_location_inventory( $post_id ) {
+		if ( get_post_meta( $post_id, 'rbfw_enable_location_inventory', true ) !== 'on' ) {
+			return array();
+		}
+		$rows = get_post_meta( $post_id, 'rbfw_location_inventory', true );
+		if ( ! is_array( $rows ) || empty( $rows ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $rows as $slug => $row ) {
+			$slug = sanitize_title( $slug );
+			if ( '' === $slug || ! is_array( $row ) ) {
+				continue;
+			}
+			$out[ $slug ] = array(
+				'stock' => max( 0, (int) ( $row['stock'] ?? 0 ) ),
+				'price' => max( 0, (float) ( $row['price'] ?? 0 ) ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Units already booked at one pickup location over a date range.
+	 *
+	 * Walks the item's rbfw_inventory entries (which record rbfw_pickup_point
+	 * for bookings made after the location-inventory feature shipped), sums
+	 * per-day quantities for entries at $location whose booked dates overlap
+	 * the range, and returns the busiest day — the peak concurrent usage, the
+	 * same day-wise model the global stock check uses. Entries without a
+	 * recorded location (older bookings) count against global stock only.
+	 *
+	 * @param int    $post_id    Rental item ID.
+	 * @param string $location   Pickup-location slug.
+	 * @param string $start_date Y-m-d (defaults to today).
+	 * @param string $end_date   Y-m-d (defaults to $start_date).
+	 * @return int Peak booked units at that location within the range.
+	 */
+	function rbfw_location_sold_qty( $post_id, $location, $start_date = '', $end_date = '' ) {
+		$inventory = get_post_meta( $post_id, 'rbfw_inventory', true );
+		if ( ! is_array( $inventory ) || empty( $inventory ) || '' === $location ) {
+			return 0;
+		}
+
+		$start = strtotime( $start_date ?: current_time( 'Y-m-d' ) );
+		$end   = strtotime( $end_date ?: ( $start_date ?: current_time( 'Y-m-d' ) ) );
+		if ( ! $start || ! $end || $end < $start ) {
+			return 0;
+		}
+		$range = array();
+		for ( $t = $start, $guard = 0; $t <= $end && $guard < 366; $t += DAY_IN_SECONDS, $guard++ ) {
+			$range[ gmdate( 'd-m-Y', $t ) ] = 0;
+		}
+
+		$managed_statuses = rbfw_get_option( 'inventory_managed_order_status', 'rbfw_basic_gen_settings' );
+		$managed_statuses = is_array( $managed_statuses ) ? $managed_statuses : array( 'processing' => 'processing', 'completed' => 'completed' );
+		$based_on_return  = rbfw_get_option( 'inventory_based_on_return', 'rbfw_basic_gen_settings' );
+
+		foreach ( $inventory as $entry ) {
+			if ( ! is_array( $entry ) || empty( $entry['booked_dates'] ) || ! is_array( $entry['booked_dates'] ) ) {
+				continue;
+			}
+			if ( ( $entry['rbfw_pickup_point'] ?? '' ) !== $location ) {
+				continue;
+			}
+			$status = $entry['rbfw_order_status'] ?? '';
+			$counts = in_array( $status, $managed_statuses, true )
+				|| 'picked' === $status
+				|| ( 'yes' === $based_on_return && 'returned' === $status );
+			if ( ! $counts ) {
+				continue;
+			}
+			$qty = max( 0, (int) ( $entry['rbfw_item_quantity'] ?? 0 ) );
+			foreach ( $entry['booked_dates'] as $d ) {
+				if ( isset( $range[ $d ] ) ) {
+					$range[ $d ] += $qty;
+				}
+			}
+		}
+
+		return $range ? max( $range ) : 0;
+	}
+
+	/**
+	 * Remaining stock at one pickup location for a date range.
+	 *
+	 * @return int|null Remaining units, or null when the location has no
+	 *                  location-inventory row (feature off / unknown slug).
+	 */
+	function rbfw_location_remaining_stock( $post_id, $location, $start_date = '', $end_date = '' ) {
+		$conf = rbfw_get_location_inventory( $post_id );
+		if ( ! isset( $conf[ $location ] ) ) {
+			return null;
+		}
+		return max( 0, $conf[ $location ]['stock'] - rbfw_location_sold_qty( $post_id, $location, $start_date, $end_date ) );
+	}
+
+	/**
+	 * AJAX: date-aware remaining stock per location for the booking form's
+	 * location cards. Fired whenever the customer picks/changes dates so the
+	 * "N units available" badges reflect the actual booked range instead of
+	 * today. Public (nopriv) — read-only availability data.
+	 */
+	add_action( 'wp_ajax_rbfw_location_stock_info', 'rbfw_location_stock_info_ajax' );
+	add_action( 'wp_ajax_nopriv_rbfw_location_stock_info', 'rbfw_location_stock_info_ajax' );
+	function rbfw_location_stock_info_ajax() {
+		check_ajax_referer( 'rbfw_location_stock_info_action', 'nonce' );
+
+		$post_id    = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+		$start_date = isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : '';
+		$end_date   = isset( $_POST['end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) : '';
+
+		$conf = $post_id ? rbfw_get_location_inventory( $post_id ) : array();
+		if ( empty( $conf ) ) {
+			wp_send_json_error();
+		}
+
+		$out = array();
+		foreach ( $conf as $slug => $row ) {
+			$out[ $slug ] = rbfw_location_remaining_stock( $post_id, $slug, $start_date, $end_date );
+		}
+		wp_send_json_success( $out );
+	}
+
+	/**
+	 * Add the chosen pickup location's charge to the management-fee lines.
+	 *
+	 * Reuses the existing management-fee mechanism so the charge shows up in
+	 * the cart/checkout/receipt breakdown like any other fee line, and the
+	 * total stays server-authoritative.
+	 *
+	 * @param  int    $post_id          Rental item ID.
+	 * @param  string $pickup_point     Posted pickup-location slug.
+	 * @param  array  $management_info  Existing fee lines (label => info).
+	 * @param  float  $management_price Existing fee total.
+	 * @return array Updated [info, price].
+	 */
+	function rbfw_apply_location_charge( $post_id, $pickup_point, $management_info, $management_price ) {
+		$conf = rbfw_get_location_inventory( $post_id );
+		if ( isset( $conf[ $pickup_point ] ) && $conf[ $pickup_point ]['price'] > 0 ) {
+			$term  = get_term_by( 'slug', $pickup_point, 'rbfw_item_location' );
+			$name  = $term && ! is_wp_error( $term ) ? $term->name : ucwords( str_replace( '-', ' ', $pickup_point ) );
+			$price = $conf[ $pickup_point ]['price'];
+			$label = sprintf( /* translators: %s: pickup location name */ __( 'Location charge (%s)', 'booking-and-rental-manager-for-woocommerce' ), $name );
+
+			$management_info[ $label ] = array(
+				'price'      => $price,
+				'price_desc' => wc_price( $price ),
+				'refundable' => 'no',
+			);
+			$management_price         += $price;
+		}
+		return array( $management_info, $management_price );
+	}
+
 	function rbfw_off_dates( $post_id ) {
 		$off_dates       = [];
 		$off_date_ranges = get_post_meta( $post_id, 'rbfw_offday_range', true );

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -196,6 +196,8 @@ function rbfw_create_inventory_meta($ticket_info, $rbfw_id, $order_id, $order_st
     $order_array['rbfw_service_infos'] = $rbfw_service_infos;
     $order_array['rbfw_item_quantity'] = $rbfw_item_quantity;
     $order_array['rbfw_order_status'] = $rbfw_order_status;
+    /* Pickup location — lets rbfw_location_sold_qty() track location-wise stock. */
+    $order_array['rbfw_pickup_point'] = !empty($ticket_info['rbfw_pickup_point']) ? $ticket_info['rbfw_pickup_point'] : '';
 
     $rbfw_inventory_info[$order_id] = $order_array;
 

--- a/templates/forms/location-cards.php
+++ b/templates/forms/location-cards.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Pickup-location chooser cards — Location Inventory & Price feature.
+ *
+ * Included by every booking form template (single-day, multi-day,
+ * multi-items, resort). Renders nothing when the item has the feature off,
+ * so including it is always safe. Expects $post_id in scope.
+ *
+ * Selecting a card writes the location into the form's rbfw_pickup_point
+ * field (the classic dropdown is hidden while cards are active), caps the
+ * quantity input to the location's remaining stock and un-gates the rest of
+ * the form (see rbfw_script.js).
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+$rbfw_loc_inv_conf = function_exists( 'rbfw_get_location_inventory' ) ? rbfw_get_location_inventory( $post_id ) : array();
+if ( ! empty( $rbfw_loc_inv_conf ) ) :
+	/* Dates-first flow: availability is date-wise, so the cards start
+	   disabled ("Select dates first") and only activate — with exact
+	   remaining stock for the chosen range — once the customer picks the
+	   booking dates (rbfw_location_stock_info AJAX in rbfw_script.js). */
+	?>
+	<div
+		class="rbfw_loc_cards_wrap rbfw_loc_pending rbfw_loc_waitdates"
+		id="rbfw_loc_cards_wrap"
+		data-post-id="<?php echo esc_attr( $post_id ); ?>"
+		data-txt-available="<?php esc_attr_e( '%d unit(s) available', 'booking-and-rental-manager-for-woocommerce' ); ?>"
+		data-txt-soldout="<?php esc_attr_e( 'Sold out', 'booking-and-rental-manager-for-woocommerce' ); ?>"
+		data-txt-note-choose="<?php esc_attr_e( 'Please choose a location to continue your booking.', 'booking-and-rental-manager-for-woocommerce' ); ?>"
+	>
+		<div class="rbfw_loc_cards_head">
+			<span class="rbfw_loc_cards_title"><?php esc_html_e( 'Choose Your Location', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+			<span class="rbfw_loc_cards_required"><?php esc_html_e( 'Required', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+		</div>
+		<div class="rbfw_loc_cards">
+			<?php
+			foreach ( $rbfw_loc_inv_conf as $rbfw_loc_slug => $rbfw_loc_row ) :
+				$rbfw_loc_term = get_term_by( 'slug', $rbfw_loc_slug, 'rbfw_item_location' );
+				$rbfw_loc_name = $rbfw_loc_term && ! is_wp_error( $rbfw_loc_term ) ? $rbfw_loc_term->name : ucwords( str_replace( '-', ' ', $rbfw_loc_slug ) );
+				/* Only a configured stock of 0 is a hard sell-out up front —
+				   real availability is date-wise and filled in once dates are picked. */
+				$rbfw_soldout = $rbfw_loc_row['stock'] <= 0;
+				?>
+				<button
+					type="button"
+					class="rbfw_loc_card<?php echo $rbfw_soldout ? ' rbfw_loc_card_soldout' : ''; ?>"
+					data-loc="<?php echo esc_attr( $rbfw_loc_slug ); ?>"
+					data-price="<?php echo esc_attr( $rbfw_loc_row['price'] ); ?>"
+					data-stock=""
+					disabled
+				>
+					<span class="rbfw_loc_card_pin" aria-hidden="true">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 21s7-5.1 7-11a7 7 0 1 0-14 0c0 5.9 7 11 7 11z"/><circle cx="12" cy="10" r="2.6"/></svg>
+					</span>
+					<span class="rbfw_loc_card_body">
+						<span class="rbfw_loc_card_name"><?php echo esc_html( $rbfw_loc_name ); ?></span>
+						<span class="rbfw_loc_card_stock">
+							<?php
+							if ( $rbfw_soldout ) {
+								esc_html_e( 'Sold out', 'booking-and-rental-manager-for-woocommerce' );
+							} else {
+								esc_html_e( 'Select dates first', 'booking-and-rental-manager-for-woocommerce' );
+							}
+							?>
+						</span>
+					</span>
+					<span class="rbfw_loc_card_price<?php echo $rbfw_loc_row['price'] > 0 ? '' : ' rbfw_loc_card_price_free'; ?>">
+						<?php
+						if ( $rbfw_loc_row['price'] > 0 ) {
+							echo wp_kses_post( '+ ' . wc_price( $rbfw_loc_row['price'] ) );
+						} else {
+							esc_html_e( 'Free', 'booking-and-rental-manager-for-woocommerce' );
+						}
+						?>
+					</span>
+					<span class="rbfw_loc_card_check" aria-hidden="true">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5 9-11"/></svg>
+					</span>
+				</button>
+			<?php endforeach; ?>
+		</div>
+		<p class="rbfw_loc_cards_note"><?php esc_html_e( 'Please select your booking dates first — availability is date-wise.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+	</div>
+<?php endif; ?>

--- a/templates/forms/multi-day-registration.php
+++ b/templates/forms/multi-day-registration.php
@@ -535,6 +535,8 @@ $rbfw_buffer_time = get_post_meta( $rbfw_id, 'rbfw_buffer_time', true ) ? maybe_
                         <input type="hidden" name="rbfw_pickup_end_time" id="dropoff_time" value="<?php echo esc_html($rbfw_event_end_time); ?>"/>
                     <?php } ?>
 
+                    <?php include RBFW_TEMPLATE_PATH . 'forms/location-cards.php'; ?>
+
 
                     <?php if ($rbfw_enable_md_type_item_qty == 'yes' && $item_stock_quantity > 0) { ?>
                         <div class="item rbfw_quantity_md">

--- a/templates/forms/multi-items-registration.php
+++ b/templates/forms/multi-items-registration.php
@@ -414,7 +414,9 @@ $_rbfw_mi_price_unit = ( ! empty( $auto_selected_pricing_type ) && isset( $_rbfw
                         </div>
                         <input type="hidden" class="rbfw_duration_md" name="rbfw_duration_md">
                     </div>
-                    
+
+                    <?php include RBFW_TEMPLATE_PATH . 'forms/location-cards.php'; ?>
+
                     <?php  if(!empty($multiple_items_info)){ ?>
 
                         <div class="item rbfw_resourse_md" style="display: none">

--- a/templates/forms/resort-registration.php
+++ b/templates/forms/resort-registration.php
@@ -285,6 +285,8 @@
                     </div>
                 </div>
 
+                <?php include RBFW_TEMPLATE_PATH . 'forms/location-cards.php'; ?>
+
                 <div class="item">
                     <a class="rbfw_chk_availability_btn rbfw-avail-btn-disabled"
                        title="<?php esc_attr_e('Please select check-in and check-out dates','booking-and-rental-manager-for-woocommerce'); ?>">

--- a/templates/forms/single-day-registration.php
+++ b/templates/forms/single-day-registration.php
@@ -133,6 +133,8 @@
                         </div>
                     </div>
 
+                    <?php include RBFW_TEMPLATE_PATH . 'forms/location-cards.php'; ?>
+
                     <div class="rbfw-bikecarsd-result-wrap">
                         <div class="rbfw-bikecarsd-result-loader"></div>
                         <div class="rbfw-bikecarsd-result">
@@ -185,6 +187,12 @@
 
                         </div>
                     </div>
+
+                    <?php
+                    /* Timely-inventory mode has its own Rental Start Date field
+                       above; the location cards follow it (dates → location). */
+                    include RBFW_TEMPLATE_PATH . 'forms/location-cards.php';
+                    ?>
 
                     <label class="rbfw-single-right-heading">
                         <?php esc_html_e('Rental Duration', 'booking-and-rental-manager-for-woocommerce'); ?>


### PR DESCRIPTION
Locations previously carried no stock and no price: the rbfw_item_location taxonomy fed a plain pickup/drop-off dropdown, inventory entries never recorded which location a booking came from, and every location implicitly shared the item's single global stock pool. This adds a full location-wise inventory & pricing layer on top of that system, working for every rental type and pricing mode.

DATA MODEL (per rental item)
- rbfw_enable_location_inventory ('on'/'off'): feature toggle. Standalone — the classic Pick-up/Drop-off Location switches remain a separate, simpler dropdown use case; with this feature on, choosing a location card IS the pickup choice (the admin never configures locations twice).
- rbfw_location_inventory: rows keyed by location slug (sanitize_title of the term name, the same identity rbfw_pickup_point uses everywhere), each row = stock (units at that location) + price (charge added to the booking total; 0 = free). Only filled-in rows participate; empty rows are never saved.
- Inventory entries (rbfw_inventory) now record rbfw_pickup_point, so location-wise sold units can be counted per day. Older entries without a location keep counting against global stock only.

ADMIN (both editors, Location section)
- 'Location Inventory & Price' panel: enable switch + one Location / Stock / Price row per location. Classic tab and modern editor share one save helper (RBFW_Location::save_location_inventory_from_post) and the same field names, so both save paths stay in sync.
- A visible rules card lists the conditional rules per rental type / pricing mode (Multi Day, Hourly/Time, Fixed Dates, From Search, Single Day, Timely Stock, Multiple Items, Resort) so admins understand exactly how the dates-first flow behaves for each item type. Rules come from one shared method (location_inventory_rules) rendered by both editors.

FRONTEND (all four booking forms, card-block design)
- New shared partial templates/forms/location-cards.php renders a 'Choose Your Location' card grid (map-pin icon, location name, availability badge, price badge '+ X' / 'Free', selected check, sold-out state) styled to match the plugin frontend. Renders nothing when the feature is off.
- Dates-first flow, because availability is date-wise: cards start disabled ('Select dates first'); when the customer picks dates they activate with the exact remaining stock for that range; everything below the cards stays dimmed/locked until a location is chosen. Placement per form: multi-day after the date/duration block, multi-items after the duration summary, resort after the check-in/check-out card, single-day after the availability calendar AND inside the timely-inventory branch (which has its own Rental Start Date field and previously had no cards at all).
- Selecting a card writes the existing rbfw_pickup_point field (two-way synced with the classic dropdown when present, auto-created hidden input when not), so cart, order and email pipelines keep working unchanged. It also caps the quantity controls (select or input variants) to the location's remaining stock.
- Per-mode date detection: pickup/return pickers (md incl. hourly + time pickers), resort check-in/out, single-day calendar clicks, timely-stock date field, and duration-based multiple_items where the end date is derived from durationType x durationQty (changing the duration re-checks stock). Items with fixed event dates or dates prefilled from the search page activate the cards automatically on page load.
- Submitting without a location is blocked client-side (card block shakes, scrolls into view) on top of the server-side validation.

SERVER (authoritative price + stock)
- rbfw_apply_location_charge() injects the chosen location's price into the existing management-fee pipeline in all three add-to-cart branches, so it appears as its own 'Location charge (Name)' line in cart, checkout and receipts and the total stays server-computed.
- New woocommerce_add_to_cart_validation gate: for items with the feature on, the posted location must be configured and the quantity may not exceed rbfw_location_remaining_stock() for the booked dates (end date derived for duration-based forms, mirroring the cart build).
- rbfw_location_sold_qty() walks the item's inventory entries for one location, sums per-day quantities over the requested range (honouring the Inventory Managed Order Status setting plus picked/returned rules) and returns the busiest day — the same day-wise peak model the global stock check uses, which is why a July booking frees the unit again in August.
- New public AJAX endpoint rbfw_location_stock_info (nonce-protected, read-only) returns per-location remaining stock for an exact date range; the cards call it on every date/duration change.

Verified headless end-to-end on the live dev site: card gating both before and after date selection, date-exact badges (a placed order reduced Dhaka Hub 5 -> 4 for its booked dates only), quantity caps, sold-out handling, the 'Location charge' fee line on a real Cash-on-Delivery order, and regression passes across the multi-day and single-day (hourly) flows.