### PR TITLE
feat(modern-editor): collapsible Off-Day & Location Inventory info pa…

### DIFF
--- a/admin/css/rbfw-modern-editor.css
+++ b/admin/css/rbfw-modern-editor.css
@@ -9332,6 +9332,40 @@ textarea.rbfw-me-field-invalid {
 }
 .rbfw-me-offday-block-head > div { flex: 1; min-width: 0; }
 .rbfw-me-offday-block-switch { flex-shrink: 0 !important; }
+/* Collapsible card: head toggles the body; caret indicates state. */
+.rbfw-me-card--collapsible > .rbfw-me-card__head { cursor: pointer; }
+.rbfw-me-card--collapsible > .rbfw-me-card__head .rbfw-me-offday-block-switch { cursor: default; }
+.rbfw-me-card--collapsible.is-collapsed > .rbfw-me-card__body { display: none; }
+.rbfw-me-card__caret {
+    color: var(--me-muted);
+    flex-shrink: 0;
+    font-size: 20px;
+    height: 20px;
+    width: 20px;
+    transition: transform 0.2s ease;
+}
+.rbfw-me-card--collapsible.is-collapsed .rbfw-me-card__caret { transform: rotate(-90deg); }
+/* Collapsible rules block inside "Location Inventory & Price" (starts collapsed). */
+.rbfw-me-loc-inv-collapse { margin-top: 4px; }
+.rbfw-me-loc-inv-collapse__head {
+    align-items: center;
+    background: #f7f9fc;
+    border: 1px solid var(--me-border);
+    border-radius: 8px;
+    color: var(--me-text);
+    cursor: pointer;
+    display: flex;
+    font-size: 13px;
+    font-weight: 600;
+    gap: 8px;
+    padding: 10px 14px;
+    text-align: left;
+    width: 100%;
+}
+.rbfw-me-loc-inv-collapse__head:hover { background: #eef3ff; }
+.rbfw-me-loc-inv-collapse__body { padding-top: 12px; }
+.rbfw-me-loc-inv-collapse.is-collapsed > .rbfw-me-loc-inv-collapse__body { display: none; }
+.rbfw-me-loc-inv-collapse.is-collapsed .rbfw-me-card__caret { transform: rotate(-90deg); }
 .rbfw-me-offday-rules { display: flex; flex-direction: column; gap: 10px; }
 .rbfw-me-offday-rule {
     align-items: center;

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -184,6 +184,23 @@
             }
         });
 
+        // Collapsible "How Location Inventory & Price works" rules block (starts collapsed).
+        $wrap.on('click', '.rbfw-me-loc-inv-collapse__head', function () {
+            var $box  = $(this).closest('.rbfw-me-loc-inv-collapse');
+            var $body = $box.children('.rbfw-me-loc-inv-collapse__body');
+            if ($box.hasClass('is-collapsed')) {
+                $box.removeClass('is-collapsed');
+                $body.hide().stop(true, true).slideDown(200, function () {
+                    $body.css('display', ''); // restore stylesheet display
+                });
+            } else {
+                $body.stop(true, true).slideUp(200, function () {
+                    $box.addClass('is-collapsed');
+                    $body.css('display', ''); // let the .is-collapsed CSS rule hide it
+                });
+            }
+        });
+
         // Location pick-up / drop-off: mirror the checkbox group into a hidden
         // comma-separated value (one hidden input per .rbfw-me-loc-group) that
         // the modern AJAX save reads.
@@ -1954,6 +1971,26 @@
                 selected.push($(this).data('day'));
             });
             $group.find('.rbfw-me-offday-hidden').val(selected.join(','));
+        });
+
+        // Collapsible card: click the head to expand/collapse the body. Used by the
+        // "Block Booking" off-day card, which renders collapsed by default. Clicks on
+        // the on/off switch (or any control) inside the head must not toggle collapse.
+        $wrap.on('click', '.rbfw-me-card--collapsible .rbfw-me-card__head', function (e) {
+            if ($(e.target).closest('.switch, input, button, a, select').length) return;
+            var $card = $(this).closest('.rbfw-me-card--collapsible');
+            var $body = $card.children('.rbfw-me-card__body');
+            if ($card.hasClass('is-collapsed')) {
+                $card.removeClass('is-collapsed');
+                $body.hide().stop(true, true).slideDown(200, function () {
+                    $body.css('display', ''); // restore stylesheet display (flex)
+                });
+            } else {
+                $body.stop(true, true).slideUp(200, function () {
+                    $card.addClass('is-collapsed');
+                    $body.css('display', ''); // let the .is-collapsed CSS rule hide it
+                });
+            }
         });
 
         // Add new date range row

--- a/admin/settings/Location.php
+++ b/admin/settings/Location.php
@@ -354,19 +354,27 @@
 						<p class="rbfw-me-field__desc"><?php esc_html_e( 'Fill in stock/price only for the locations you offer — empty rows are ignored. Works on its own; the Pick-up/Drop-off switches above are a separate, simpler dropdown feature.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
 					<?php endif; ?>
 
-					<div class="rbfw-me-offday-rules rbfw-me-loc-inv-rules">
-						<?php foreach ( self::location_inventory_rules() as $rule ) : ?>
-							<div class="rbfw-me-offday-rule">
-								<span class="rbfw-me-offday-rule__badge"><?php echo esc_html( $rule[0] ); ?></span>
-								<span class="rbfw-me-offday-rule__text"><?php echo esc_html( $rule[1] ); ?></span>
-								<span class="dashicons dashicons-yes-alt rbfw-me-offday-rule__check"></span>
+					<div class="rbfw-me-loc-inv-collapse rbfw-me-collapsible is-collapsed">
+						<button type="button" class="rbfw-me-loc-inv-collapse__head">
+							<span class="rbfw-me-card__caret dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+							<span class="rbfw-me-loc-inv-collapse__title"><?php esc_html_e( 'How Location Inventory & Price works', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+						</button>
+						<div class="rbfw-me-loc-inv-collapse__body">
+							<div class="rbfw-me-offday-rules rbfw-me-loc-inv-rules">
+								<?php foreach ( self::location_inventory_rules() as $rule ) : ?>
+									<div class="rbfw-me-offday-rule">
+										<span class="rbfw-me-offday-rule__badge"><?php echo esc_html( $rule[0] ); ?></span>
+										<span class="rbfw-me-offday-rule__text"><?php echo esc_html( $rule[1] ); ?></span>
+										<span class="dashicons dashicons-yes-alt rbfw-me-offday-rule__check"></span>
+									</div>
+								<?php endforeach; ?>
 							</div>
-						<?php endforeach; ?>
+							<p class="rbfw-me-offday-rules-note">
+								<span class="dashicons dashicons-info-outline"></span>
+								<?php esc_html_e( 'When disabled, the booking form works without the location step — no location stock caps and no location charge.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+							</p>
+						</div>
 					</div>
-					<p class="rbfw-me-offday-rules-note">
-						<span class="dashicons dashicons-info-outline"></span>
-						<?php esc_html_e( 'When disabled, the booking form works without the location step — no location stock caps and no location charge.', 'booking-and-rental-manager-for-woocommerce' ); ?>
-					</p>
 				</div>
 				<?php
 			}

--- a/admin/settings/Off_Day.php
+++ b/admin/settings/Off_Day.php
@@ -198,9 +198,10 @@
 			];
 			?>
 
-			<!-- Block booking on off-day ranges -->
-			<div class="rbfw-me-card">
+			<!-- Block booking on off-day ranges (collapsible, starts collapsed) -->
+			<div class="rbfw-me-card rbfw-me-card--collapsible is-collapsed">
 				<div class="rbfw-me-card__head rbfw-me-offday-block-head">
+					<span class="rbfw-me-card__caret dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
 					<div>
 						<h2><?php esc_html_e( 'Block Booking If Date Range Contains Off Days', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
 						<p><?php esc_html_e( 'Prevent bookings when the selected pickup–return range overlaps with any off day.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>


### PR DESCRIPTION
…nels

Make two informational blocks in the modern rental-item editor collapsible, both collapsed by default, to reduce visual noise on the Off Days and Location panels.

- "Block Booking If Date Range Contains Off Days" card: its body (the rule list + note) now collapses. The on/off switch stays visible in the head and still toggles independently (a guard ignores clicks on it).
- "Location Inventory & Price": the rules/help block gains a "How Location Inventory & Price works" toggle header and collapses.

Uses the existing chevron + slideUp/slideDown accordion pattern:
- Off_Day.php / Location.php: markup, caret, and is-collapsed initial state.
- rbfw-modern-editor.css: collapsible styles and caret rotation.
- rbfw-modern-editor.js: two delegated toggle handlers; the expand path clears the inline display on completion so flex layouts are preserved.