### PR TITLE
feat(inventory): add "By Location" tab to the Inventory page

### DIFF
--- a/admin/css/rbfw_inventory.css
+++ b/admin/css/rbfw_inventory.css
@@ -807,3 +807,82 @@
     .rbfw_inv_stats { grid-template-columns: 1fr; }
     .rbfw_inv .rbfw_inv_filter_group { flex: 1 1 100%; }
 }
+
+/* ── By Item / By Location tabs ─────────────────────────────── */
+.rbfw_inv_hidden { display: none !important; }
+.rbfw_inv .rbfw_inv_tabs {
+    display: inline-flex;
+    gap: 4px;
+    margin: 0 0 18px;
+    padding: 4px;
+    background: var(--rbfw-accent-lt);
+    border-radius: var(--rbfw-radius-sm);
+}
+.rbfw_inv .rbfw_inv_tab {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+    color: var(--rbfw-text-2);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 8px 18px;
+    transition: background .15s ease, color .15s ease;
+}
+.rbfw_inv .rbfw_inv_tab:hover { color: var(--rbfw-accent); }
+.rbfw_inv .rbfw_inv_tab.active {
+    background: var(--rbfw-surface);
+    color: var(--rbfw-accent);
+    box-shadow: var(--rbfw-shadow-sm);
+}
+
+/* ── By Location: grouped cards ─────────────────────────────── */
+.rbfw_inv_loc_group {
+    background: var(--rbfw-surface);
+    border: 1px solid var(--rbfw-border);
+    border-radius: var(--rbfw-radius);
+    box-shadow: var(--rbfw-shadow-sm);
+    margin-bottom: 18px;
+    overflow: hidden;
+}
+.rbfw_inv_loc_head {
+    align-items: center;
+    background: linear-gradient(180deg, #FAFBFD 0%, #FFF 100%);
+    border-bottom: 1px solid var(--rbfw-border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: space-between;
+    padding: 14px 18px;
+}
+.rbfw_inv_loc_head_main { align-items: center; display: flex; gap: 10px; min-width: 0; }
+.rbfw_inv_loc_title { color: var(--rbfw-text-1); font-size: 15px; font-weight: 700; }
+.rbfw_inv_loc_count {
+    background: var(--rbfw-accent-lt);
+    border-radius: 20px;
+    color: var(--rbfw-accent);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 3px 10px;
+}
+.rbfw_inv_loc_head_stats { color: var(--rbfw-text-2); display: flex; flex-wrap: wrap; font-size: 12.5px; gap: 16px; }
+.rbfw_inv_loc_num { color: var(--rbfw-text-1); font-weight: 700; margin-left: 4px; }
+.rbfw_inv_avail_badge {
+    border-radius: 20px;
+    display: inline-block;
+    font-weight: 600;
+    min-width: 28px;
+    padding: 2px 10px;
+}
+.rbfw_inv_avail_badge.is_in  { background: var(--rbfw-green-lt); color: var(--rbfw-green); }
+.rbfw_inv_avail_badge.is_out { background: var(--rbfw-amber-lt); color: var(--rbfw-amber); }
+.rbfw_inv_loc_empty {
+    background: var(--rbfw-surface);
+    border: 1px dashed var(--rbfw-border);
+    border-radius: var(--rbfw-radius);
+    color: var(--rbfw-text-3);
+    padding: 40px 20px;
+    text-align: center;
+}
+.rbfw_inv_loc_table_wrap.rbfw_inv_loading { opacity: .5; pointer-events: none; }

--- a/admin/js/rbfw_inventory.js
+++ b/admin/js/rbfw_inventory.js
@@ -128,6 +128,55 @@
         paginate();
         observeTable();
 
+        /* ── Inventory tabs: By Item / By Location ─────────────── */
+        var $tabs   = $('.rbfw_inv_tabs .rbfw_inv_tab');
+        var $panels = $('.rbfw_inv_tab_panel');
+        $tabs.on('click', function () {
+            var tab = $(this).data('tab');
+            $tabs.removeClass('active');
+            $(this).addClass('active');
+            $panels.each(function () {
+                $(this).toggleClass('rbfw_inv_hidden', $(this).data('panel') !== tab);
+            });
+            /* Persist the choice in the URL so a reload lands on the same tab. */
+            if (window.history && window.history.replaceState && typeof window.URL === 'function') {
+                try {
+                    var url = new URL(window.location.href);
+                    url.searchParams.set('inv_tab', tab);
+                    window.history.replaceState(null, '', url.toString());
+                } catch (e) {}
+            }
+        });
+
+        /* ── By Location: own date filter (leaves the item filter untouched) ── */
+        var LOC = (typeof window.rbfwInvLoc === 'object' && window.rbfwInvLoc) ? window.rbfwInvLoc : null;
+
+        function locFilter() {
+            if (!LOC) { return; }
+            var $wrap = $('.rbfw_inv_loc_table_wrap');
+            var date  = $('.rbfw_inv_loc_date').val() || '';
+            var end   = $('.rbfw_inv_loc_end_date').val() || '';
+            $wrap.addClass('rbfw_inv_loading');
+            $.post(LOC.ajaxurl, {
+                action: 'rbfw_get_location_stock_by_filter',
+                nonce: LOC.nonce,
+                selected_date: date,
+                start_date: end ? date : '',
+                end_date: end || ''
+            }).done(function (html) {
+                $wrap.html(html);
+            }).always(function () {
+                $wrap.removeClass('rbfw_inv_loading');
+            });
+        }
+
+        $('.rbfw_inv_loc_filter_btn').on('click', locFilter);
+        $('.rbfw_inv_loc_reset_btn').on('click', function () {
+            $('.rbfw_inv_loc_end_date').val('');
+            if (LOC && LOC.today) { $('.rbfw_inv_loc_date').val(LOC.today); }
+            locFilter();
+        });
+
         /* Custom close button inside the redesigned modal. */
         $(document).on('click', '.rbfw_inv_modal_close', function (e) {
             e.preventDefault();

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -116,6 +116,12 @@ if (! class_exists('RBFW_Dependencies')) {
 					'showing_all' => __( 'Showing %s entries', 'booking-and-rental-manager-for-woocommerce' ),
 					'stock_saved' => __( 'Saved!', 'booking-and-rental-manager-for-woocommerce' ),
 				) );
+				/* "By Location" inventory tab: own AJAX date filter. */
+				wp_localize_script( 'rbfw-inventory', 'rbfwInvLoc', array(
+					'ajaxurl' => admin_url( 'admin-ajax.php' ),
+					'nonce'   => wp_create_nonce( 'rbfw_get_location_stock_action' ),
+					'today'   => current_time( 'Y-m-d' ),
+				) );
 			}
 
 			/* Time Slots page only: modern redesign stylesheet (inline-SVG icons, primary + secondary). */

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -1063,6 +1063,21 @@ function rbfw_inventory_page(){
             </div>
         </div>
 
+        <?php
+        /* Remember the chosen tab across reloads: the JS mirrors the selection
+         * into the ?inv_tab= query param, which we honour here so the page
+         * re-renders on the same tab (no flash of the wrong panel). */
+        $rbfw_inv_active_tab = ( isset( $_GET['inv_tab'] ) && 'location' === sanitize_key( wp_unslash( $_GET['inv_tab'] ) ) ) ? 'location' : 'item';
+        ?>
+        <!-- Tab switcher: By Item (existing table) / By Location -->
+        <div class="rbfw_inv_tabs">
+            <button type="button" class="rbfw_inv_tab <?php echo 'item' === $rbfw_inv_active_tab ? 'active' : ''; ?>" data-tab="item"><?php esc_html_e( 'By Item', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+            <button type="button" class="rbfw_inv_tab <?php echo 'location' === $rbfw_inv_active_tab ? 'active' : ''; ?>" data-tab="location"><?php esc_html_e( 'By Location', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+        </div>
+
+        <!-- By Item panel -->
+        <div class="rbfw_inv_tab_panel <?php echo 'item' === $rbfw_inv_active_tab ? '' : 'rbfw_inv_hidden'; ?>" data-panel="item">
+
         <!-- Filter bar -->
         <div class="rbfw_inv_filters rbfw_inventory_page_filter">
             <div class="rbfw_inv_filter_group rbfw_inventory_filter_input_group">
@@ -1102,6 +1117,34 @@ function rbfw_inventory_page(){
                 <div class="rbfw_inv_pager"></div>
             </div>
         </div>
+        </div><!-- /By Item panel -->
+
+        <!-- By Location panel -->
+        <div class="rbfw_inv_tab_panel <?php echo 'location' === $rbfw_inv_active_tab ? '' : 'rbfw_inv_hidden'; ?>" data-panel="location">
+            <div class="rbfw_inv_filters rbfw_inv_loc_filters">
+                <div class="rbfw_inv_filter_group">
+                    <label><?php esc_html_e( 'Date', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                    <input type="date" class="rbfw_inv_loc_date" value="<?php echo esc_attr( current_time( 'Y-m-d' ) ); ?>">
+                </div>
+                <div class="rbfw_inv_filter_group">
+                    <label><?php esc_html_e( 'End Date (optional)', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
+                    <input type="date" class="rbfw_inv_loc_end_date" value="">
+                </div>
+                <div class="rbfw_inv_filter_actions">
+                    <button type="button" class="rbfw_inv_btn rbfw_inv_btn_primary rbfw_inv_loc_filter_btn">
+                        <?php echo rbfw_inv_icon( 'filter' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Filter', 'booking-and-rental-manager-for-woocommerce' ); ?>
+                    </button>
+                    <button type="button" class="rbfw_inv_btn rbfw_inv_btn_reset rbfw_inv_loc_reset_btn">
+                        <?php echo rbfw_inv_icon( 'x' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?> <?php esc_html_e( 'Reset', 'booking-and-rental-manager-for-woocommerce' ); ?>
+                    </button>
+                </div>
+            </div>
+            <div class="rbfw_inv_card">
+                <div class="rbfw_inv_loc_table_wrap">
+                    <?php echo wp_kses( rbfw_inventory_location_table( $query ), rbfw_allowed_html() ); ?>
+                </div>
+            </div>
+        </div>
     </div>
     <div id="rbfw_stock_view_result_wrap">
         <div id="rbfw_stock_view_result_inner_wrap"></div>
@@ -1121,6 +1164,169 @@ function rbfw_inventory_page(){
         </div>
     </div>
     <?php
+}
+
+/**
+ * Location-wise inventory table for the Inventory page's "By Location" tab.
+ *
+ * Groups every rental item that has Location Inventory & Price enabled by its
+ * pickup location and shows, per location, each item's configured stock, the
+ * units booked in the selected date/range, and remaining availability. Reuses
+ * the same helpers the booking form uses so the numbers match what customers
+ * see: rbfw_get_location_inventory() (configured stock) and
+ * rbfw_location_sold_qty() (peak booked units in the window).
+ *
+ * @param WP_Query    $query All rbfw_item posts.
+ * @param string|null $date  Selected date (d-m-Y or Y-m-d); defaults to today.
+ * @param string|null $start Optional range start (used with $end).
+ * @param string|null $end   Optional range end.
+ * @return string HTML (safe for wp_kses( ..., rbfw_allowed_html() )).
+ */
+function rbfw_inventory_location_table( $query, $date = null, $start = null, $end = null ) {
+    $norm = static function ( $s ) {
+        $s = is_string( $s ) ? trim( $s ) : '';
+        if ( '' === $s ) {
+            return '';
+        }
+        $ts = strtotime( $s );
+        return $ts ? gmdate( 'Y-m-d', $ts ) : '';
+    };
+
+    $start_ymd = $norm( $start );
+    $end_ymd   = $norm( $end );
+    if ( '' === $start_ymd || '' === $end_ymd ) {
+        $single    = $norm( $date );
+        $single    = '' !== $single ? $single : current_time( 'Y-m-d' );
+        $start_ymd = $single;
+        $end_ymd   = $single;
+    }
+    if ( strtotime( $end_ymd ) < strtotime( $start_ymd ) ) {
+        $end_ymd = $start_ymd;
+    }
+
+    /* Location slug => display name. */
+    $loc_names = array();
+    $terms     = get_terms( array( 'taxonomy' => 'rbfw_item_location', 'hide_empty' => false ) );
+    if ( ! is_wp_error( $terms ) && $terms ) {
+        foreach ( $terms as $t ) {
+            /* Key by both the term slug and sanitize_title(name): location
+             * inventory rows are keyed by the sanitized name, which usually —
+             * but not always — equals the term slug. */
+            $loc_names[ $t->slug ]                    = $t->name;
+            $loc_names[ sanitize_title( $t->name ) ]  = $t->name;
+        }
+    }
+
+    /* Group items under each location they offer. Read $query->posts directly
+     * (not the have_posts() loop pointer, which the item table already consumed
+     * on initial page render). */
+    $by_location = array();
+    $items       = ( $query instanceof WP_Query ) ? (array) $query->posts : array();
+    if ( ! empty( $items ) ) {
+        foreach ( $items as $item ) {
+            $item_id = (int) $item->ID;
+            $conf    = function_exists( 'rbfw_get_location_inventory' ) ? rbfw_get_location_inventory( $item_id ) : array();
+            if ( empty( $conf ) ) {
+                continue;
+            }
+            foreach ( $conf as $slug => $row ) {
+                $stock  = (int) ( isset( $row['stock'] ) ? $row['stock'] : 0 );
+                $booked = function_exists( 'rbfw_location_sold_qty' ) ? (int) rbfw_location_sold_qty( $item_id, $slug, $start_ymd, $end_ymd ) : 0;
+                $by_location[ $slug ][] = array(
+                    'name'   => get_the_title( $item_id ),
+                    'stock'  => $stock,
+                    'booked' => $booked,
+                    'avail'  => max( 0, $stock - $booked ),
+                );
+            }
+        }
+    }
+
+    ob_start();
+
+    if ( empty( $by_location ) ) {
+        ?>
+        <div class="rbfw_inv_loc_empty">
+            <p><?php esc_html_e( 'No items have Location Inventory & Price enabled yet. Turn it on for an item (Location tab) and set per-location stock to see it here.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+
+    /* Stable, name-sorted location order. */
+    uksort( $by_location, static function ( $a, $b ) use ( $loc_names ) {
+        return strcasecmp( isset( $loc_names[ $a ] ) ? $loc_names[ $a ] : $a, isset( $loc_names[ $b ] ) ? $loc_names[ $b ] : $b );
+    } );
+
+    foreach ( $by_location as $slug => $rows ) {
+        $loc_name  = isset( $loc_names[ $slug ] ) ? $loc_names[ $slug ] : $slug;
+        $tot_stock = 0;
+        $tot_book  = 0;
+        $tot_avail = 0;
+        foreach ( $rows as $r ) {
+            $tot_stock += $r['stock'];
+            $tot_book  += $r['booked'];
+            $tot_avail += $r['avail'];
+        }
+        ?>
+        <div class="rbfw_inv_loc_group">
+            <div class="rbfw_inv_loc_head">
+                <div class="rbfw_inv_loc_head_main">
+                    <span class="rbfw_inv_loc_title"><?php echo esc_html( $loc_name ); ?></span>
+                    <span class="rbfw_inv_loc_count"><?php echo esc_html( sprintf( _n( '%s item', '%s items', count( $rows ), 'booking-and-rental-manager-for-woocommerce' ), number_format_i18n( count( $rows ) ) ) ); ?></span>
+                </div>
+                <div class="rbfw_inv_loc_head_stats">
+                    <span class="rbfw_inv_loc_stat"><?php esc_html_e( 'Stock', 'booking-and-rental-manager-for-woocommerce' ); ?> <span class="rbfw_inv_loc_num"><?php echo esc_html( number_format_i18n( $tot_stock ) ); ?></span></span>
+                    <span class="rbfw_inv_loc_stat"><?php esc_html_e( 'Booked', 'booking-and-rental-manager-for-woocommerce' ); ?> <span class="rbfw_inv_loc_num"><?php echo esc_html( number_format_i18n( $tot_book ) ); ?></span></span>
+                    <span class="rbfw_inv_loc_stat"><?php esc_html_e( 'Available', 'booking-and-rental-manager-for-woocommerce' ); ?> <span class="rbfw_inv_loc_num"><?php echo esc_html( number_format_i18n( $tot_avail ) ); ?></span></span>
+                </div>
+            </div>
+            <table class="rbfw_inv_table rbfw_inv_loc_table">
+                <thead class="rbfw_inv_thead">
+                <tr class="rbfw_inv_thead_row">
+                    <th class="rbfw_inv_th_left"><?php esc_html_e( 'Item Name', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                    <th class="rbfw_text_center"><?php esc_html_e( 'Stock', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                    <th class="rbfw_text_center"><?php esc_html_e( 'Booked', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                    <th class="rbfw_text_center"><?php esc_html_e( 'Available', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $rows as $r ) : ?>
+                    <tr>
+                        <td class="rbfw_inv_th_left"><?php echo esc_html( $r['name'] ); ?></td>
+                        <td class="rbfw_text_center"><?php echo esc_html( number_format_i18n( $r['stock'] ) ); ?></td>
+                        <td class="rbfw_text_center"><?php echo esc_html( number_format_i18n( $r['booked'] ) ); ?></td>
+                        <td class="rbfw_text_center"><span class="rbfw_inv_avail_badge <?php echo $r['avail'] > 0 ? 'is_in' : 'is_out'; ?>"><?php echo esc_html( number_format_i18n( $r['avail'] ) ); ?></span></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+
+    return ob_get_clean();
+}
+
+/* AJAX: re-render the "By Location" table for a chosen date / range. */
+add_action( 'wp_ajax_rbfw_get_location_stock_by_filter', 'rbfw_get_location_stock_by_filter' );
+function rbfw_get_location_stock_by_filter() {
+    check_ajax_referer( 'rbfw_get_location_stock_action', 'nonce' );
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        wp_send_json_error( 'Unauthorized access', 403 );
+    }
+    $selected_date = isset( $_POST['selected_date'] ) ? sanitize_text_field( wp_unslash( $_POST['selected_date'] ) ) : '';
+    $start_date    = isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : '';
+    $end_date      = isset( $_POST['end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) : '';
+    $query         = new WP_Query( array(
+        'post_type'              => 'rbfw_item',
+        'order'                  => 'DESC',
+        'posts_per_page'         => -1,
+        'update_post_meta_cache' => true,
+        'update_term_meta_cache' => true,
+    ) );
+    echo wp_kses( rbfw_inventory_location_table( $query, $selected_date, $start_date, $end_date ), rbfw_allowed_html() );
+    wp_die();
 }
 
 function rbfw_check_available_by_specific_date_md($post_id, $specific_date = null){


### PR DESCRIPTION
Add a location-wise view to the Inventory admin page (page=rbfw_inventory) alongside the existing per-item table, switched by a "By Item / By Location" tab. The location view groups every rental item that has Location Inventory & Price enabled by its pickup location and shows, per location, each item's configured stock, units booked for the selected date/range, and remaining availability.

Reuses the booking-form helpers so the numbers match what customers see: rbfw_get_location_inventory() (per-location stock) and rbfw_location_sold_qty() (peak booked units in the window).

- inc/rbfw_inventory_functions.php: rbfw_inventory_location_table() renderer, the tab markup/panels, and the rbfw_get_location_stock_by_filter AJAX handler (its own date filter; the item view's filter is untouched).
- inc/RBFW_Dependencies.php: localize ajaxurl + nonce for the location filter.
- admin/js/rbfw_inventory.js: tab switching + location filter AJAX.
- admin/css/rbfw_inventory.css: tab bar, location cards, availability badges.

The chosen tab persists across reloads: the JS mirrors the selection into the ?inv_tab= URL param and the page renders the matching tab active server-side (no flash of the wrong panel).