### PR TITLE
feat(single-day): enable Item Variations with enforced per-size stock

### DIFF
--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -748,7 +748,37 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $rbfw_pickup_point                               = isset( $sd_input_data_sabitized['rbfw_pickup_point'] ) ? $sd_input_data_sabitized['rbfw_pickup_point'] : '';
                 $rbfw_dropoff_point                              = isset( $sd_input_data_sabitized['rbfw_dropoff_point'] ) ? $sd_input_data_sabitized['rbfw_dropoff_point'] : '';
                 list( $rbfw_management_info, $rbfw_management_price ) = rbfw_apply_location_charge( $rbfw_id, $rbfw_pickup_point, $rbfw_management_info, $rbfw_management_price );
-                $rbfw_bikecarsd_ticket_info                      = $rbfw_bikecarsd->rbfw_bikecarsd_ticket_info( $rbfw_id, $rbfw_start_datetime, $end_date, $rbfw_type_info, $rbfw_service_info, $rbfw_bikecarsd_selected_time, $rbfw_regf_info, $rbfw_pickup_point, $rbfw_dropoff_point, $end_time, $rbfw_item_quantity , $bikecarsd_selected_date , $rbfw_management_info , $rbfw_management_price);
+
+                /* Item Variations (Single Day): capture the customer's size selection the
+                   same way the multi-day branch does, so per-size stock can be enforced by
+                   rbfw_check_rental_availability() and the choice is shown in cart/order.
+                   Mirrors the multi-day capture block below in this same function. */
+                $variation_data = get_post_meta( $rbfw_id, 'rbfw_variations_data', true );
+                $variation_info = [];
+                if ( ! empty( $variation_data ) && is_array( $variation_data ) ) {
+                    $i = 0;
+                    foreach ( $variation_data as $level_one_arr ) {
+                        // Skip incomplete/legacy variation rows (missing id or values).
+                        if ( ! is_array( $level_one_arr ) || empty( $level_one_arr['field_id'] ) || empty( $level_one_arr['value'] ) || ! is_array( $level_one_arr['value'] ) ) {
+                            $i ++;
+                            continue;
+                        }
+                        $field_id             = $level_one_arr['field_id'];
+                        $field_label          = isset( $level_one_arr['field_label'] ) ? $level_one_arr['field_label'] : '';
+                        $selected_field_value = ! empty( $sd_input_data_sabitized[ $field_id ] ) ? $sd_input_data_sabitized[ $field_id ] : [];
+                        foreach ( $level_one_arr['value'] as $level_two_arr_value ) {
+                            $level_two_name = isset( $level_two_arr_value['name'] ) ? $level_two_arr_value['name'] : '';
+                            if ( $selected_field_value == $level_two_name ) {
+                                $variation_info[ $i ]['field_id']    = $field_id;
+                                $variation_info[ $i ]['field_label'] = $field_label;
+                                $variation_info[ $i ]['field_value'] = $selected_field_value;
+                            }
+                        }
+                        $i ++;
+                    }
+                }
+
+                $rbfw_bikecarsd_ticket_info                      = $rbfw_bikecarsd->rbfw_bikecarsd_ticket_info( $rbfw_id, $rbfw_start_datetime, $end_date, $rbfw_type_info, $rbfw_service_info, $rbfw_bikecarsd_selected_time, $rbfw_regf_info, $rbfw_pickup_point, $rbfw_dropoff_point, $end_time, $rbfw_item_quantity , $bikecarsd_selected_date , $rbfw_management_info , $rbfw_management_price, $variation_info);
 
                 $sub_total_price                                 = apply_filters( 'rbfw_cart_base_price', $sub_total_price );
                 $security_deposit                                = rbfw_security_deposit( $rbfw_id, $sub_total_price );
@@ -764,6 +794,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $cart_item_data['rbfw_end_date']                 = $end_date;
                 $cart_item_data['rbfw_end_time']                 = $end_time;
                 $cart_item_data['rbfw_type_info']                = $rbfw_type_info;
+                $cart_item_data['rbfw_variation_info']           = $variation_info;
                 $cart_item_data['rbfw_service_info']             = $rbfw_service_info;
                 $cart_item_data['rbfw_bikecarsd_duration_price'] = $rbfw_bikecarsd_duration_price;
                 $cart_item_data['rbfw_bikecarsd_service_price']  = $rbfw_bikecarsd_service_price;
@@ -1412,6 +1443,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $rbfw_end_time       = $values['rbfw_end_time'] ? $values['rbfw_end_time'] : '';
                 $rbfw_ticket_info    = $values['rbfw_ticket_info'] ? $values['rbfw_ticket_info'] : [];
                 $rbfw_type_info      = $values['rbfw_type_info'] ? $values['rbfw_type_info'] : [];
+                $variation_info      = ! empty( $values['rbfw_variation_info'] ) ? $values['rbfw_variation_info'] : [];
 
                 $rbfw_management_info = $values['rbfw_management_info'] ? $values['rbfw_management_info'] : [];
                 $rbfw_management_price = $values['rbfw_management_price'] ? $values['rbfw_management_price'] : [];
@@ -1488,6 +1520,17 @@ if (!class_exists('RBFW_Woocommerce')) {
                 }
                 if ( ! empty( $dropoff_location ) ) {
                     $item->add_meta_data( rbfw_string_return( 'rbfw_text_dropoff_location', esc_html__( 'Drop-off Location', 'booking-and-rental-manager-for-woocommerce' ) ), $dropoff_location );
+                }
+                if ( ! empty( $variation_info ) ) {
+                    $variation_content  = '<table style="border:1px solid #f5f5f5;margin:0;width: 100%;">';
+                    foreach ( $variation_info as $key => $value ) {
+                        $variation_content .= '<tr>';
+                        $variation_content .= '<td style="border:1px solid #f5f5f5;"><strong>' . esc_html( $value['field_label'] ?? '' ) . '</strong></td>';
+                        $variation_content .= '<td style="border:1px solid #f5f5f5;">' . esc_html( $value['field_value'] ?? '' ) . '</td>';
+                        $variation_content .= '</tr>';
+                    }
+                    $variation_content .= '</table>';
+                    $item->add_meta_data( rbfw_string_return( 'rbfw_text_variation_information', esc_html__( 'Variation Information', 'booking-and-rental-manager-for-woocommerce' ) ), $variation_content );
                 }
 
 

--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -18,9 +18,28 @@ if (!class_exists('RBFW_Woocommerce')) {
             add_action( 'woocommerce_after_checkout_validation', array($this ,  'rbfw_validation_before_checkout') );
             add_action( 'woocommerce_after_checkout_validation', array($this ,  'rbfw_validate_availability_before_checkout'), 20 );
             add_action( 'woocommerce_checkout_create_order_line_item', array($this ,  'rbfw_add_order_item_data'), 90, 4 );
-            add_action( 'woocommerce_before_thankyou', array($this ,  'rbfw_booking_management') );
-           // add_action( 'woocommerce_checkout_order_processed', 'rbfw_booking_management' );
+            /*
+             * Build the rbfw_order mirror + inventory + attendee records.
+             *
+             * These records must be created from server-side order lifecycle events, NOT only
+             * from the thank-you page view. Redirect/IPN gateways (Opay, PayPal, Stripe redirect,
+             * etc.) complete the order server-side and the customer frequently never lands on the
+             * WooCommerce thank-you page, so `woocommerce_before_thankyou` alone silently drops the
+             * booking from the Order List / Booking Calendar / Inventory / Attendee list even though
+             * the order is paid. rbfw_booking_management() is idempotent (it early-returns when a
+             * mirror with the same rbfw_link_order_id already exists), so firing it from several
+             * hooks is safe — whichever runs first records the booking and the rest no-op.
+             */
+            add_action( 'woocommerce_checkout_order_processed', array($this ,  'rbfw_booking_management') );           // classic checkout (all gateways, at placement)
+            add_action( 'woocommerce_store_api_checkout_order_processed', array($this ,  'rbfw_booking_management_from_order') ); // block / Store API checkout
+            add_action( 'woocommerce_payment_complete', array($this ,  'rbfw_booking_management') );                   // async payment confirmation (redirect/IPN gateways)
+            add_action( 'woocommerce_order_status_processing', array($this ,  'rbfw_booking_management') );            // safety net: any path that marks the order paid
+            add_action( 'woocommerce_order_status_completed', array($this ,  'rbfw_booking_management') );             // safety net: manual/offline/admin completion
+            add_action( 'woocommerce_before_thankyou', array($this ,  'rbfw_booking_management') );                    // legacy path (kept; harmless when already recorded)
             add_action( 'rbfw_wc_order_status_change', array($this ,  'rbfw_change_user_order_status_on_order_status_change'), 10, 3 );
+            /* Self-healing: rebuild booking records for paid orders placed before this fix
+               (e.g. redirect-gateway orders that never triggered the thank-you page). */
+            add_action( 'admin_init', array($this ,  'rbfw_backfill_missing_order_mirrors') );
         }
 
         public function rbfw_prevent_duplicate_cart_item( $passed, $product_id  ) {
@@ -2209,6 +2228,84 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $rbfw_post_id = $rbfw_post->ID;
                 update_post_meta( $rbfw_post_id, 'rbfw_order_status', $order_status );
                 rbfw_update_inventory( $rbfw_post_id, $order_status );
+            }
+        }
+        /**
+         * One-time reconcile that rebuilds the rbfw_order mirror / inventory / attendee
+         * records for paid orders that were placed before the server-side hooks above were
+         * wired in — most importantly redirect/IPN-gateway orders (Opay, PayPal, Stripe redirect)
+         * whose customers never landed on the thank-you page, so the booking was never recorded.
+         *
+         * rbfw_booking_management() is idempotent, so re-running it over existing orders only
+         * creates what is missing. The scan walks paid orders newest-first, a bounded batch per
+         * admin request (to avoid timeouts on large stores), advancing a date cursor until it
+         * reaches the beginning, then marks itself done. Uses wc_get_orders() so it is safe under
+         * both legacy and High-Performance Order Storage.
+         */
+        public function rbfw_backfill_missing_order_mirrors() {
+            if ( get_option( 'rbfw_order_mirror_backfill_done' ) === 'yes' ) {
+                return;
+            }
+            $cap = function_exists( 'rbfw_bookings_capability' ) ? rbfw_bookings_capability() : 'manage_options';
+            if ( ! current_user_can( $cap ) ) {
+                return;
+            }
+            if ( ! function_exists( 'wc_get_orders' ) ) {
+                return;
+            }
+
+            $batch  = 30;
+            $cursor = (int) get_option( 'rbfw_order_mirror_backfill_cursor', 0 ); // unix ts; 0 = start from newest
+            $query  = array(
+                'limit'   => $batch,
+                'status'  => array( 'processing', 'completed', 'on-hold', 'refunded' ),
+                'orderby' => 'date',
+                'order'   => 'DESC',
+                'return'  => 'ids',
+            );
+            if ( $cursor > 0 ) {
+                $query['date_created'] = '<' . $cursor;
+            }
+            $order_ids = wc_get_orders( $query );
+
+            if ( empty( $order_ids ) ) {
+                update_option( 'rbfw_order_mirror_backfill_done', 'yes' );
+                delete_option( 'rbfw_order_mirror_backfill_cursor' );
+                return;
+            }
+
+            $oldest_ts = $cursor;
+            foreach ( $order_ids as $oid ) {
+                $order = wc_get_order( $oid );
+                if ( ! $order ) {
+                    continue;
+                }
+                $created = $order->get_date_created();
+                if ( $created ) {
+                    $ts        = $created->getTimestamp();
+                    $oldest_ts = ( $oldest_ts === 0 ) ? $ts : min( $oldest_ts, $ts );
+                }
+                // Idempotent: no-ops when this order already has its mirror, and when it has no rental items.
+                $this->rbfw_booking_management( $order->get_id() );
+            }
+
+            if ( $oldest_ts > 0 ) {
+                update_option( 'rbfw_order_mirror_backfill_cursor', $oldest_ts );
+            }
+            if ( count( $order_ids ) < $batch ) {
+                update_option( 'rbfw_order_mirror_backfill_done', 'yes' );
+                delete_option( 'rbfw_order_mirror_backfill_cursor' );
+            }
+        }
+        /**
+         * Adapter for hooks that pass a WC_Order object instead of an order id
+         * (e.g. woocommerce_store_api_checkout_order_processed).
+         */
+        public function rbfw_booking_management_from_order( $order ) {
+            if ( is_a( $order, 'WC_Order' ) ) {
+                $this->rbfw_booking_management( $order->get_id() );
+            } elseif ( is_numeric( $order ) ) {
+                $this->rbfw_booking_management( (int) $order );
             }
         }
         public  function rbfw_booking_management( $wc_order_id = 0 ) {

--- a/admin/js/mkb-admin.js
+++ b/admin/js/mkb-admin.js
@@ -348,7 +348,8 @@
                 }
                 jQuery('.rbfw_general_price_config_wrapper').hide();
                 jQuery('.rbfw_switch_extra_service_qty').hide();
-                jQuery('li[data-target-tabs="#rbfw_variations"]').hide();
+                // Single Day now supports item variations: keep the Inventory/Variations tab visible.
+                jQuery('li[data-target-tabs="#rbfw_variations"]').show();
                 jQuery('.rbfw_switch_md_type_item_qty').hide();
                 jQuery('li[data-target-tabs="#rbfw_date_settings_meta_boxes"]').show();
                 jQuery('.rbfw_resort_price_config_wrapper').hide();

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -2081,8 +2081,9 @@
             }
 
             // Inventory card (stock + variations): mirror the classic editor, which
-            // hides inventory for resort / bike_car_sd / appointment.
-            var _invShow = (type !== 'resort' && type !== 'bike_car_sd' && type !== 'appointment');
+            // hides inventory for resort / appointment. Single Day (bike_car_sd) now
+            // supports item variations, so its inventory card stays visible.
+            var _invShow = (type !== 'resort' && type !== 'appointment');
             $pricing.find('.rbfw-me-inventory-card').toggleClass('rbfw-me-hidden', !_invShow);
 
             // Location card (Advanced step): available for every rent type

--- a/admin/settings/Inventory.php
+++ b/admin/settings/Inventory.php
@@ -17,7 +17,7 @@
 				$rbfw_item_type         = get_post_meta( $rbfw_id, 'rbfw_item_type', true ) ? get_post_meta( $rbfw_id, 'rbfw_item_type', true ) : 'bike_car_sd';
 				$rbfw_enable_variations = get_post_meta( $rbfw_id, 'rbfw_enable_variations', true ) ? get_post_meta( $rbfw_id, 'rbfw_enable_variations', true ) : 'no';
 				?>
-                <li data-target-tabs="#rbfw_variations" <?php echo ( $rbfw_item_type == 'resort' || $rbfw_item_type == 'bike_car_sd' || $rbfw_item_type == 'appointment' )?'style="display:none"':'' ?>>
+                <li data-target-tabs="#rbfw_variations" <?php echo ( $rbfw_item_type == 'resort' || $rbfw_item_type == 'appointment' )?'style="display:none"':'' ?>>
                     <i class="fas fa-table-cells-large"></i><?php esc_html_e( 'Inventory', 'booking-and-rental-manager-for-woocommerce' ); ?>
                 </li>
 				<?php
@@ -260,7 +260,7 @@
                 <section>
                     <div>
                         <label><?php esc_html_e( 'Item variation', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
-                        <p><?php esc_html_e( 'Enable/Disable Variations. It will work when the type is Bike/Car for multiple day, Dress, Equipment & Others.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+                        <p><?php esc_html_e( 'Enable/Disable Variations. It will work when the type is Single Day, Bike/Car for multiple day, Dress, Equipment & Others.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
                     </div>
                     <label class="switch">
                         <input type="checkbox" name="rbfw_enable_variations" value="<?php echo esc_attr( $rbfw_enable_variations ); ?>" <?php echo esc_attr( ( $rbfw_enable_variations == 'yes' ) ? 'checked' : '' ); ?>>
@@ -297,7 +297,7 @@
 			public function add_tabs_content( $post_id ) {
 				$rbfw_item_type = get_post_meta( $post_id, 'rbfw_item_type', true ) ? get_post_meta( $post_id, 'rbfw_item_type', true ) : '';
 				?>
-                <div class="mpStyle mp_tab_item" data-tab-item="#rbfw_variations" data-tab-item="#rbfw_variations" <?php if ( $rbfw_item_type == 'resort' || $rbfw_item_type == 'bike_car_sd' || $rbfw_item_type == 'appointment' ) {
+                <div class="mpStyle mp_tab_item" data-tab-item="#rbfw_variations" data-tab-item="#rbfw_variations" <?php if ( $rbfw_item_type == 'resort' || $rbfw_item_type == 'appointment' ) {
 					echo 'style="display:none"';
 				} ?>>
 					<?php $this->section_header(); ?>

--- a/admin/views/rbfw-modern-editor.php
+++ b/admin/views/rbfw-modern-editor.php
@@ -341,11 +341,13 @@
 
 				<?php
 				// Inventory (stock quantity + variations). The classic editor hides this
-				// for resort / bike_car_sd / appointment; mirror that here, with applyType()
+				// for resort / appointment; mirror that here, with applyType()
 				// in the JS keeping it in sync when the rental type is changed live.
+				// Single Day (bike_car_sd) now supports item variations, so it is no
+				// longer hidden.
 				if ( class_exists( 'RBFW_Inventory' ) ) :
 					$rbfw_me_inv_type   = get_post_meta( $post_id, 'rbfw_item_type', true ) ?: 'bike_car_sd';
-					$rbfw_me_inv_hidden = in_array( $rbfw_me_inv_type, [ 'resort', 'bike_car_sd', 'appointment' ], true );
+					$rbfw_me_inv_hidden = in_array( $rbfw_me_inv_type, [ 'resort', 'appointment' ], true );
 				?>
 				<div class="rbfw-me-card rbfw-me-inventory-card<?php echo $rbfw_me_inv_hidden ? ' rbfw-me-hidden' : ''; ?>">
 					<div class="rbfw-me-card__head">

--- a/assets/mp_script/rbfw_script.js
+++ b/assets/mp_script/rbfw_script.js
@@ -12,6 +12,15 @@ jQuery(document).on('click','.rbfw_back_step_btn',function (e) {
     jQuery('.rbfw-bikecarsd-step[data-step="'+back_step+'"]').show();
 });
 
+// Item variations (Single Day): when the customer changes a size after a time slot is
+// already chosen, reload the rate list so its per-rate quantities reflect the new size.
+jQuery(document).on('change', '.rbfw_variation_field', function () {
+    let $selectedTime = jQuery('.rbfw_bikecarsd_time.selected').not('.disabled');
+    if ($selectedTime.length) {
+        $selectedTime.trigger('click');
+    }
+});
+
 
 jQuery(document).on('click','.rbfw_bikecarsd_time:not(.rbfw_bikecarsd_time.disabled)',function (e) {
 
@@ -32,6 +41,14 @@ jQuery(document).on('click','.rbfw_bikecarsd_time:not(.rbfw_bikecarsd_time.disab
         is_muffin_template = '0';
     }
 
+    // Item variations (Single Day): send the chosen size(s) so the rate list can cap
+    // each rate's available quantity by the selected size's remaining stock.
+    let rbfw_selected_variations = [];
+    jQuery('.rbfw_variation_field').each(function () {
+        let v = jQuery(this).val();
+        if (v) { rbfw_selected_variations.push(v); }
+    });
+
     jQuery.ajax({
         type: 'POST',
         url: rbfw_ajax_front.rbfw_ajaxurl,
@@ -41,6 +58,7 @@ jQuery(document).on('click','.rbfw_bikecarsd_time:not(.rbfw_bikecarsd_time.disab
             'selected_time': gTime,
             'selected_date': selected_date,
             'is_muffin_template': is_muffin_template,
+            'rbfw_selected_variations': rbfw_selected_variations,
             'nonce' : rbfw_ajax_front.nonce_bikecarsd_type_list
         },
         beforeSend: function() {

--- a/inc/class-bike-car-sd-function.php
+++ b/inc/class-bike-car-sd-function.php
@@ -81,7 +81,7 @@
 				return $main_array;
 			}
 
-			public function rbfw_bikecarsd_ticket_info( $product_id, $rbfw_start_datetime = null, $rbfw_end_date = null, $rbfw_type_info = array(), $rbfw_service_info = array(), $selected_time = null, $rbfw_regf_info = array(), $rbfw_pickup_point = null, $rbfw_dropoff_point = null, $end_time = null, $rbfw_item_quantity = null , $booking_date = null, $rbfw_management_info=[] , $rbfw_management_price=0) {
+			public function rbfw_bikecarsd_ticket_info( $product_id, $rbfw_start_datetime = null, $rbfw_end_date = null, $rbfw_type_info = array(), $rbfw_service_info = array(), $selected_time = null, $rbfw_regf_info = array(), $rbfw_pickup_point = null, $rbfw_dropoff_point = null, $end_time = null, $rbfw_item_quantity = null , $booking_date = null, $rbfw_management_info=[] , $rbfw_management_price=0, $rbfw_variation_info = array()) {
 				global $rbfw;
 				if ( ! empty( $product_id ) && ! empty( $rbfw_type_info ) ):
 					$rent_price          = 0;
@@ -169,6 +169,7 @@
 					$main_array[0]['rbfw_start_datetime']     = $rbfw_start_datetime . ' ' . $selected_time;
 					$main_array[0]['rbfw_end_datetime']       = $rbfw_end_date . ' ' . $end_time;
 					$main_array[0]['rbfw_type_info']          = $rbfw_type_info;
+					$main_array[0]['rbfw_variation_info']     = $rbfw_variation_info;
 					$main_array[0]['rbfw_service_info']       = $rbfw_service_info;
 					$main_array[0]['rbfw_management_info']    = $rbfw_management_info;
 					$main_array[0]['rbfw_rent_type']          = $rbfw_rent_type;

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -1352,7 +1352,7 @@ function rbfw_url_exclude_search_engine() {
 	/******************************************
 	 * Single Day Type: Get Available Quantity
 	 *****************************************/
-	function rbfw_get_bike_car_sd_available_qty( $post_id, $selected_date, $type, $selected_time = null ) {
+	function rbfw_get_bike_car_sd_available_qty( $post_id, $selected_date, $type, $selected_time = null, $variation_values = array() ) {
 		if ( empty( $post_id ) || empty( $selected_date ) || empty( $type ) ) {
 			return;
 		}
@@ -1404,6 +1404,28 @@ function rbfw_url_exclude_search_engine() {
 		}
 		$remaining_stock = $type_stock - $total_qty;
 		$remaining_stock = max( 0, $remaining_stock );
+
+		// Item variations (Single Day): additionally cap the per-rate remaining by the
+		// selected size's remaining stock, so the time-table reflects sold-out sizes.
+		// The authoritative gate is still rbfw_check_rental_availability() at add-to-cart.
+		if ( ! empty( $variation_values ) && function_exists( 'rbfw_sd_variation_remaining_stock' )
+			&& get_post_meta( $post_id, 'rbfw_enable_variations', true ) === 'yes' ) {
+			$size_remaining = null;
+			foreach ( (array) $variation_values as $vv ) {
+				$vv = (string) $vv;
+				if ( '' === $vv ) {
+					continue;
+				}
+				$r = rbfw_sd_variation_remaining_stock( $post_id, array( $selected_date ), $vv );
+				if ( null === $r ) {
+					continue;
+				}
+				$size_remaining = ( null === $size_remaining ) ? $r : min( $size_remaining, $r );
+			}
+			if ( null !== $size_remaining ) {
+				$remaining_stock = min( $remaining_stock, max( 0, $size_remaining ) );
+			}
+		}
 
 		return $remaining_stock;
 	}

--- a/inc/rbfw_inventory_functions.php
+++ b/inc/rbfw_inventory_functions.php
@@ -749,6 +749,26 @@ function rbfw_sd_sold_out_dates( $post_id ) {
         }
     }
 
+    // With item variations enabled, a date is also fully sold out when every size is
+    // exhausted (no size can be booked, regardless of rate availability).
+    $variations_enabled = ( get_post_meta( $post_id, 'rbfw_enable_variations', true ) === 'yes' );
+    $variation_values   = array();
+    if ( $variations_enabled ) {
+        $vdata = get_post_meta( $post_id, 'rbfw_variations_data', true );
+        if ( is_array( $vdata ) ) {
+            foreach ( $vdata as $grp ) {
+                if ( ! empty( $grp['value'] ) && is_array( $grp['value'] ) ) {
+                    foreach ( $grp['value'] as $val ) {
+                        if ( ! empty( $val['name'] ) ) {
+                            $variation_values[] = (string) $val['name'];
+                        }
+                    }
+                }
+            }
+        }
+        $variation_values = array_values( array_unique( $variation_values ) );
+    }
+
     $sold_out = [];
     foreach ( array_keys( $candidates ) as $date_dmy ) {
         $dt = DateTime::createFromFormat( 'd-m-Y', $date_dmy );
@@ -761,6 +781,19 @@ function rbfw_sd_sold_out_dates( $post_id ) {
             if ( (int) rbfw_get_bike_car_sd_available_qty( $post_id, $date_ymd, $type, '' ) > 0 ) {
                 $all_sold_out = false;
                 break;
+            }
+        }
+        if ( ! $all_sold_out && $variations_enabled && ! empty( $variation_values ) && function_exists( 'rbfw_sd_variation_remaining_stock' ) ) {
+            $any_size_available = false;
+            foreach ( $variation_values as $vv ) {
+                $rem = rbfw_sd_variation_remaining_stock( $post_id, array( $date_dmy ), $vv );
+                if ( null === $rem || $rem > 0 ) {
+                    $any_size_available = true;
+                    break;
+                }
+            }
+            if ( ! $any_size_available ) {
+                $all_sold_out = true;
             }
         }
         if ( $all_sold_out ) {
@@ -1779,6 +1812,34 @@ function rbfw_get_stock_details(){
                                     }
                                     $c++;
                                 }
+
+                                // Single Day item variations: also decrement per-size stock so the
+                                // closing-stock report reflects variation availability. Units = sum of
+                                // per-rate qty (single-day's real unit count), matching the booking gate.
+                                if ( $rent_type == 'bike_car_sd' && $rbfw_enable_variations == 'yes' && ! empty( $rbfw_variation_info ) ) {
+                                    $sd_units = array_sum( array_map( 'intval', $rbfw_type_info ) );
+                                    $f = 0;
+                                    foreach ( $rbfw_variations_data_closing as $key => $v_data ) {
+                                        $field_id    = isset( $rbfw_variations_data_closing[ $f ]['field_id'] ) ? $rbfw_variations_data_closing[ $f ]['field_id'] : '';
+                                        $field_value = ( isset( $rbfw_variations_data_closing[ $f ]['value'] ) && is_array( $rbfw_variations_data_closing[ $f ]['value'] ) ) ? $rbfw_variations_data_closing[ $f ]['value'] : array();
+                                        foreach ( $rbfw_variation_info as $key => $v_info ) {
+                                            $s_field_id    = $v_info['field_id'] ?? '';
+                                            $s_field_value = $v_info['field_value'] ?? '';
+                                            if ( $s_field_id == $field_id ) {
+                                                $g = 0;
+                                                foreach ( $field_value as $key => $f_value ) {
+                                                    $fv_name = $f_value['name'] ?? '';
+                                                    $fv_qty  = $f_value['quantity'] ?? '';
+                                                    if ( $s_field_value == $fv_name ) {
+                                                        $rbfw_variations_data_closing[ $f ]['value'][ $g ]['quantity'] = $fv_qty - $sd_units;
+                                                    }
+                                                    $g++;
+                                                }
+                                            }
+                                        }
+                                        $f++;
+                                    }
+                                }
                             } else {
 
                                 $sold_item_qty += $rbfw_item_quantity;
@@ -2599,6 +2660,93 @@ function rbfw_count_overlapping_cart_qty( $sibling_lines, $req_start_datetime, $
 }
 
 /**
+ * Remaining stock for a single-day item's variation value across a set of dates.
+ *
+ * Single-day availability is date-membership based (mirrors
+ * rbfw_get_bike_car_sd_available_qty() / total_variant_quantity()), NOT the datetime
+ * interval-overlap model used by rbfw_count_overlapping_booked_qty() — the latter
+ * applies a return-date "-1 day" adjustment that would mis-handle same-day bookings.
+ * Units are counted by summing rbfw_type_info (single-day's real unit count, since
+ * rbfw_item_quantity is not a reliable count for single-day), and both committed
+ * orders and competing cart lines are included.
+ *
+ * @param int      $post_id         rbfw_item id.
+ * @param string[] $date_range_dmy  Requested booking dates in 'd-m-Y'.
+ * @param string   $variation_value Variation value name (e.g. "M").
+ * @param array[]  $sibling_lines   Other cart lines for the same item.
+ * @return int|null Minimum remaining across the dates, or null if size stock unknown.
+ */
+function rbfw_sd_variation_remaining_stock( $post_id, $date_range_dmy, $variation_value, $sibling_lines = array() ) {
+	$stock = rbfw_get_variation_stock_for_value( $post_id, $variation_value );
+	if ( null === $stock ) {
+		return null;
+	}
+	if ( empty( $date_range_dmy ) || ! is_array( $date_range_dmy ) ) {
+		return $stock;
+	}
+	$inventory         = get_post_meta( $post_id, 'rbfw_inventory', true );
+	$inventory         = is_array( $inventory ) ? $inventory : array();
+	$blocking          = rbfw_get_blocking_order_statuses();
+	$mepp_reduce_stock = get_option( 'mepp_reduce_stock', 'full' );
+
+	// Pre-compute each competing cart line's per-date size units once.
+	$sibling_dates = array();
+	if ( ! empty( $sibling_lines ) && is_array( $sibling_lines ) ) {
+		foreach ( $sibling_lines as $line ) {
+			if ( ! is_array( $line ) || ! rbfw_inventory_entry_matches_variation( $line, $variation_value ) ) {
+				continue;
+			}
+			$s = ! empty( $line['rbfw_start_date'] ) ? $line['rbfw_start_date'] : '';
+			$e = ! empty( $line['rbfw_end_date'] ) ? $line['rbfw_end_date'] : $s;
+			if ( '' === $s ) {
+				continue;
+			}
+			$ti     = isset( $line['rbfw_type_info'] ) && is_array( $line['rbfw_type_info'] ) ? $line['rbfw_type_info'] : array();
+			$units  = max( 0, array_sum( array_map( 'intval', $ti ) ) );
+			$ts_end = strtotime( $e );
+			for ( $ts = strtotime( $s ); $ts && $ts_end && $ts <= $ts_end; $ts += DAY_IN_SECONDS ) {
+				$d                   = gmdate( 'd-m-Y', $ts );
+				$sibling_dates[ $d ] = ( isset( $sibling_dates[ $d ] ) ? $sibling_dates[ $d ] : 0 ) + $units;
+			}
+		}
+	}
+
+	$min_remaining = $stock;
+	foreach ( $date_range_dmy as $date ) {
+		$booked = 0;
+		foreach ( $inventory as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$status = isset( $entry['rbfw_order_status'] ) ? $entry['rbfw_order_status'] : '';
+			if ( ! in_array( $status, $blocking, true ) ) {
+				continue;
+			}
+			if ( 'partially-paid' === $status && 'deposit' === $mepp_reduce_stock ) {
+				continue;
+			}
+			$bdates = isset( $entry['booked_dates'] ) && is_array( $entry['booked_dates'] ) ? $entry['booked_dates'] : array();
+			if ( ! in_array( $date, $bdates, true ) ) {
+				continue;
+			}
+			if ( ! rbfw_inventory_entry_matches_variation( $entry, $variation_value ) ) {
+				continue;
+			}
+			$ti      = isset( $entry['rbfw_type_info'] ) && is_array( $entry['rbfw_type_info'] ) ? $entry['rbfw_type_info'] : array();
+			$booked += max( 0, array_sum( array_map( 'intval', $ti ) ) );
+		}
+		if ( isset( $sibling_dates[ $date ] ) ) {
+			$booked += $sibling_dates[ $date ];
+		}
+		$remaining = $stock - $booked;
+		if ( $remaining < $min_remaining ) {
+			$min_remaining = $remaining;
+		}
+	}
+	return $min_remaining;
+}
+
+/**
  * Evaluate availability for one rental request (cart line or add-to-cart POST).
  *
  * Returns a list of per-resource checks. Each check is:
@@ -2677,6 +2825,61 @@ function rbfw_check_rental_availability( $rbfw_id, $values, $sibling_lines = arr
 				'requested' => $req_qty,
 				'available' => max( 0, $available ),
 				'label'     => $item_name . ' (' . $li['item_name'] . ')',
+			);
+		}
+		return $checks;
+	}
+
+	/*
+	 * Single-day with item variations: enforce per-size stock as an ADDITIONAL
+	 * constraint on top of the existing per-rate availability (which is handled by
+	 * rbfw_get_bike_car_sd_available_qty in the booking step). Reuses the same
+	 * per-value counters as the multi-day variation path below, but counts units by
+	 * summing rbfw_type_info (single-day's real unit count) instead of
+	 * rbfw_item_quantity. When variations are off we fall through to the type-filter
+	 * gate, which leaves single-day to its existing handling.
+	 */
+	if ( 'bike_car_sd' === $rent_type && get_post_meta( $rbfw_id, 'rbfw_enable_variations', true ) === 'yes' ) {
+		$sd_type_info = isset( $values['rbfw_type_info'] ) && is_array( $values['rbfw_type_info'] ) ? $values['rbfw_type_info'] : array();
+		$sd_requested = array_sum( array_map( 'intval', $sd_type_info ) );
+		if ( $sd_requested < 1 ) {
+			$sd_requested = 1;
+		}
+		$sd_variation_values = array();
+		$sd_vinfo            = isset( $values['rbfw_variation_info'] ) && is_array( $values['rbfw_variation_info'] ) ? $values['rbfw_variation_info'] : array();
+		foreach ( $sd_vinfo as $r ) {
+			if ( is_array( $r ) && ! empty( $r['field_value'] ) ) {
+				$sd_variation_values[] = (string) $r['field_value'];
+			}
+		}
+		// Variations enabled but no resolvable selection -> fail open (the per-rate
+		// stock still governs via the single-day time-table); never block a valid booking.
+		if ( empty( $sd_variation_values ) ) {
+			return $checks;
+		}
+		// Build the requested booking dates (d-m-Y) the same way single-day inventory is keyed.
+		$sd_start_ymd = ! empty( $values['rbfw_start_date'] ) ? $values['rbfw_start_date'] : gmdate( 'Y-m-d', strtotime( $start_dt ) );
+		$sd_end_ymd   = ! empty( $values['rbfw_end_date'] ) ? $values['rbfw_end_date'] : gmdate( 'Y-m-d', strtotime( $end_dt ) );
+		$sd_dates     = array();
+		$sd_ts_start  = strtotime( $sd_start_ymd );
+		$sd_ts_end    = strtotime( $sd_end_ymd );
+		if ( $sd_ts_start && $sd_ts_end && $sd_ts_end >= $sd_ts_start ) {
+			for ( $ts = $sd_ts_start; $ts <= $sd_ts_end; $ts += DAY_IN_SECONDS ) {
+				$sd_dates[] = gmdate( 'd-m-Y', $ts );
+			}
+		} elseif ( $sd_ts_start ) {
+			$sd_dates[] = gmdate( 'd-m-Y', $sd_ts_start );
+		}
+		foreach ( $sd_variation_values as $vv ) {
+			$available = rbfw_sd_variation_remaining_stock( $rbfw_id, $sd_dates, $vv, $sibling_lines );
+			if ( null === $available ) {
+				continue; // unknown variation stock -> fail open for this value
+			}
+			$checks[] = array(
+				'ok'        => ( $sd_requested <= $available ),
+				'requested' => $sd_requested,
+				'available' => max( 0, $available ),
+				'label'     => $item_name . ' (' . $vv . ')',
 			);
 		}
 		return $checks;

--- a/templates/cart_page.php
+++ b/templates/cart_page.php
@@ -295,6 +295,9 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
     $rbfw_pickup_point  = isset($cart_item['rbfw_pickup_point']) ? $cart_item['rbfw_pickup_point'] : '';
     $rbfw_dropoff_point = isset($cart_item['rbfw_dropoff_point']) ? $cart_item['rbfw_dropoff_point'] : '';
 
+    // Item Variations (Single Day): the customer's size selection, if any.
+    $variation_info = isset($cart_item['rbfw_variation_info']) ? $cart_item['rbfw_variation_info'] : [];
+
     $rbfw_item_quantity = 1;
 
     if(!empty($rbfw_bikecarsd_data)):
@@ -420,6 +423,15 @@ $rbfw_management_info 	= $cart_item['rbfw_management_info'] ? $cart_item['rbfw_m
                 </td>
             </tr>
         <?php endif; ?>
+
+        <?php if ( ! empty( $variation_info ) ){ ?>
+            <?php foreach ( $variation_info as $key => $value ) { ?>
+                <tr>
+                    <th><?php echo esc_html( $value['field_label'] ?? '' ); ?></th>
+                    <td><?php echo esc_html( $value['field_value'] ?? '' ); ?></td>
+                </tr>
+            <?php } ?>
+        <?php } ?>
 
         <?php
 

--- a/templates/forms/single-day-registration.php
+++ b/templates/forms/single-day-registration.php
@@ -34,6 +34,10 @@
     $rdfw_available_time = get_post_meta( $rbfw_id, 'rdfw_available_time', true ) ? maybe_unserialize( get_post_meta( $rbfw_id, 'rdfw_available_time', true ) ) : [];
     $rbfw_buffer_time = get_post_meta( $rbfw_id, 'rbfw_buffer_time', true ) ? maybe_unserialize( get_post_meta( $rbfw_id, 'rbfw_buffer_time', true ) ) : 0;
 
+    /* Item Variations (e.g. Size S/M/L/XL) — supported on Single Day items. */
+    $rbfw_enable_variations = get_post_meta( $rbfw_id, 'rbfw_enable_variations', true ) ? get_post_meta( $rbfw_id, 'rbfw_enable_variations', true ) : 'no';
+    $rbfw_variations_data   = get_post_meta( $rbfw_id, 'rbfw_variations_data', true ) ? get_post_meta( $rbfw_id, 'rbfw_variations_data', true ) : [];
+
 
 
 
@@ -122,6 +126,44 @@
                         </div>
                     </div>
                 </div>
+
+                <?php
+                /* Item Variations (e.g. Size S/M/L/XL) — Single Day only.
+                   For the standard (non-timely) flow the size selector is rendered under
+                   the rate price table inside single_day_info.php (the AJAX step-3 content).
+                   Timely-inventory mode does not use that AJAX table, so render the selector
+                   here for timely items. Either way the choice is posted with "Book Now" and
+                   per-size stock is enforced at add-to-cart by rbfw_check_rental_availability(). */
+                if ( $rbfw_rent_type == 'bike_car_sd' && $manage_inventory_as_timely == 'on' && $rbfw_enable_variations == 'yes' && ! empty( $rbfw_variations_data ) ) { ?>
+                    <div class="rbfw-variations-content-wrapper">
+                        <?php foreach ( $rbfw_variations_data as $data_arr_one ) {
+                            // Some saved/legacy variation rows may omit one or more keys; default
+                            // them so the template never raises "Undefined array key" notices.
+                            $field_label    = isset( $data_arr_one['field_label'] ) ? $data_arr_one['field_label'] : '';
+                            $field_id       = isset( $data_arr_one['field_id'] ) ? $data_arr_one['field_id'] : '';
+                            $field_values   = ! empty( $data_arr_one['value'] ) && is_array( $data_arr_one['value'] ) ? $data_arr_one['value'] : array();
+                            $selected_value = ! empty( $data_arr_one['selected_value'] ) ? $data_arr_one['selected_value'] : '';
+                            ?>
+                            <div class="item">
+                                <div class="rbfw-single-right-heading"><?php echo esc_html( $field_label ); ?></div>
+                                <div class="item-content rbfw-p-relative">
+                                    <?php if ( ! empty( $field_values ) ) { ?>
+                                        <select class="rbfw-select rbfw_variation_field" required name="<?php echo esc_attr( $field_id ); ?>" id="<?php echo esc_attr( $field_id ); ?>" data-field="<?php echo esc_attr( $field_label ); ?>">
+                                            <?php if ( empty( $selected_value ) ) { ?>
+                                                <option value=""><?php echo esc_html( __( 'Choose', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $field_label ); ?></option>
+                                            <?php } ?>
+                                            <?php foreach ( $field_values as $data_arr_two ) {
+                                                $variant_name = isset( $data_arr_two['name'] ) ? $data_arr_two['name'] : '';
+                                                ?>
+                                                <option class="rbfw_variant" value="<?php echo esc_attr( $variant_name ); ?>" <?php if ( $variant_name !== '' && $variant_name == $selected_value ) { echo 'selected'; } ?>><?php echo esc_html( $variant_name ); ?></option>
+                                            <?php } ?>
+                                        </select>
+                                    <?php } ?>
+                                </div>
+                            </div>
+                        <?php } ?>
+                    </div>
+                <?php } ?>
 
                 <?php  if($manage_inventory_as_timely !='on' || $rbfw_rent_type =='appointment'){ ?>
                     <div class="item rbfw-bikecarsd-step" data-step="1">

--- a/templates/template_segment/single_day_info.php
+++ b/templates/template_segment/single_day_info.php
@@ -23,6 +23,65 @@ if(isset($_POST['post_id'])){
 
     $selected_date = isset($_POST['selected_date']) ? sanitize_text_field(wp_unslash($_POST['selected_date'])) : '';
 
+    // Selected item variation values (Single Day) posted from the booking form; used to
+    // cap each rate's available quantity by the chosen size. Nonce is verified above.
+    $rbfw_selected_variations = array();
+    if ( isset( $_POST['rbfw_selected_variations'] ) && is_array( $_POST['rbfw_selected_variations'] ) ) {
+        $rbfw_selected_variations = array_map( 'sanitize_text_field', wp_unslash( $_POST['rbfw_selected_variations'] ) );
+        $rbfw_selected_variations = array_values( array_filter( $rbfw_selected_variations, static function ( $v ) { return '' !== $v; } ) );
+    }
+    // Resolve, per variation group, which size is effective for the selected date and
+    // which values are sold out, so (a) rate quantities are capped by an AVAILABLE size,
+    // and (b) the selector rendered under the price table disables sold-out values.
+    // Resolution order: customer's posted choice (if available) > default (if available)
+    // > first available value.
+    $rbfw_selected_date_dmy    = $selected_date ? gmdate( 'd-m-Y', strtotime( $selected_date ) ) : '';
+    $rbfw_variation_soldout    = array(); // "field_id::name" => bool
+    $rbfw_resolved_variation   = array(); // field_id => resolved value name
+    $rbfw_effective_variations = array();
+    $rbfw_vdata_sd             = get_post_meta( $id, 'rbfw_variations_data', true );
+    if ( is_array( $rbfw_vdata_sd ) ) {
+        foreach ( $rbfw_vdata_sd as $grp ) {
+            $fid             = isset( $grp['field_id'] ) ? (string) $grp['field_id'] : '';
+            $vals            = ( ! empty( $grp['value'] ) && is_array( $grp['value'] ) ) ? $grp['value'] : array();
+            $def             = ! empty( $grp['selected_value'] ) ? (string) $grp['selected_value'] : '';
+            $posted          = '';
+            $first_available = '';
+            foreach ( $vals as $v ) {
+                $nm = isset( $v['name'] ) ? (string) $v['name'] : '';
+                if ( '' === $nm ) {
+                    continue;
+                }
+                $rem  = ( $rbfw_selected_date_dmy && function_exists( 'rbfw_sd_variation_remaining_stock' ) )
+                    ? rbfw_sd_variation_remaining_stock( $id, array( $rbfw_selected_date_dmy ), $nm )
+                    : null;
+                $sold = ( null !== $rem && $rem <= 0 );
+                $rbfw_variation_soldout[ $fid . '::' . $nm ] = $sold;
+                if ( ! $sold ) {
+                    if ( '' === $first_available ) {
+                        $first_available = $nm;
+                    }
+                    if ( in_array( $nm, $rbfw_selected_variations, true ) ) {
+                        $posted = $nm;
+                    }
+                }
+            }
+            if ( '' !== $posted ) {
+                $resolved = $posted;
+            } elseif ( '' !== $def && empty( $rbfw_variation_soldout[ $fid . '::' . $def ] ) ) {
+                $resolved = $def;
+            } else {
+                $resolved = $first_available;
+            }
+            $rbfw_resolved_variation[ $fid ] = $resolved;
+            if ( '' !== $resolved ) {
+                $rbfw_effective_variations[] = $resolved;
+            }
+        }
+    }
+    // Variations enabled but no value is available for this date -> nothing is bookable;
+    // the rate quantities below are forced to sold-out.
+    $rbfw_variations_all_soldout = ( get_post_meta( $id, 'rbfw_enable_variations', true ) === 'yes' && ! empty( $rbfw_vdata_sd ) && empty( $rbfw_effective_variations ) );
 
     $default_timezone = wp_timezone_string();
     $date = new DateTime("now", new DateTimeZone($default_timezone));
@@ -111,7 +170,8 @@ if(isset($_POST['post_id'])){
 
                             $i = 1;
                             foreach ($rbfw_bike_car_sd_data as $value) {
-                                $max_available_qty = rbfw_get_bike_car_sd_available_qty($id, $selected_date, $value['rent_type'], $selected_time);
+                                $max_available_qty = rbfw_get_bike_car_sd_available_qty($id, $selected_date, $value['rent_type'], $selected_time, $rbfw_effective_variations);
+                                if ( ! empty( $rbfw_variations_all_soldout ) ) { $max_available_qty = 0; }
                                 if( isset($value['qty']) && $value['qty'] > 0 ){
 
                                     if ( is_plugin_active( 'booking-and-rental-manager-seasonal-pricing/rent-seasonal-pricing.php' ) ) {
@@ -169,9 +229,48 @@ if(isset($_POST['post_id'])){
                             </tbody>
                         </table>
 
-
-
-
+            <?php
+            /* Item Variations (Single Day): the chosen size caps each rate's available
+               quantity above and is enforced at add-to-cart. Rendered directly under the
+               rate price table; the selection is preserved across AJAX reloads via the
+               posted rbfw_selected_variations (see rbfw_script.js), and changing it reloads
+               this table so the per-rate quantities reflect the new size. */
+            $rbfw_sd_variations_data   = get_post_meta( $id, 'rbfw_variations_data', true );
+            $rbfw_sd_enable_variations = get_post_meta( $id, 'rbfw_enable_variations', true ) ? get_post_meta( $id, 'rbfw_enable_variations', true ) : 'no';
+            $rbfw_sd_rent_type         = get_post_meta( $id, 'rbfw_item_type', true );
+            if ( $rbfw_sd_rent_type == 'bike_car_sd' && $rbfw_sd_enable_variations == 'yes' && ! empty( $rbfw_sd_variations_data ) ) { ?>
+                <div class="rbfw-variations-content-wrapper rbfw-bikecarsd-variations">
+                    <?php foreach ( $rbfw_sd_variations_data as $data_arr_one ) {
+                        // Default any missing keys so legacy rows never raise notices.
+                        $field_label   = isset( $data_arr_one['field_label'] ) ? $data_arr_one['field_label'] : '';
+                        $field_id      = isset( $data_arr_one['field_id'] ) ? $data_arr_one['field_id'] : '';
+                        $field_values  = ! empty( $data_arr_one['value'] ) && is_array( $data_arr_one['value'] ) ? $data_arr_one['value'] : array();
+                        // Preselect the resolved (available) value for the selected date so a
+                        // sold-out size is never auto-selected.
+                        $current_value = isset( $rbfw_resolved_variation[ $field_id ] ) ? $rbfw_resolved_variation[ $field_id ] : '';
+                        ?>
+                        <div class="item">
+                            <div class="rbfw-single-right-heading"><?php echo esc_html( $field_label ); ?></div>
+                            <div class="item-content rbfw-p-relative">
+                                <?php if ( ! empty( $field_values ) ) { ?>
+                                    <select class="rbfw-select rbfw_variation_field" required name="<?php echo esc_attr( $field_id ); ?>" id="<?php echo esc_attr( $field_id ); ?>" data-field="<?php echo esc_attr( $field_label ); ?>">
+                                        <?php if ( '' === $current_value ) { ?>
+                                            <option value=""><?php echo esc_html( __( 'Choose', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $field_label ); ?></option>
+                                        <?php } ?>
+                                        <?php foreach ( $field_values as $data_arr_two ) {
+                                            $variant_name = isset( $data_arr_two['name'] ) ? $data_arr_two['name'] : '';
+                                            $is_sold_out  = ( '' !== $variant_name ) && ! empty( $rbfw_variation_soldout[ $field_id . '::' . $variant_name ] );
+                                            $option_label = $variant_name . ( $is_sold_out ? ' (' . __( 'Sold Out', 'booking-and-rental-manager-for-woocommerce' ) . ')' : '' );
+                                            ?>
+                                            <option class="rbfw_variant" value="<?php echo esc_attr( $variant_name ); ?>" <?php disabled( $is_sold_out ); ?> <?php selected( $variant_name !== '' && $variant_name === $current_value ); ?>><?php echo esc_html( $option_label ); ?></option>
+                                        <?php } ?>
+                                    </select>
+                                <?php } ?>
+                            </div>
+                        </div>
+                    <?php } ?>
+                </div>
+            <?php } ?>
 
             <?php if(!empty($rbfw_extra_service_data)){  ?>
 


### PR DESCRIPTION
Item Variations (e.g. Size S/M/L/XL, each value carrying its own stock) were previously available only for the multi-day family (bike_car_md, dress, equipment, others) and hidden for Single Day (bike_car_sd). This adds full variation support to Single Day, with per-size stock ENFORCED at booking time (a sold-out size cannot be booked). Scope is Single Day only; resort/appointment are unchanged.

Enforcement reuses the existing rent-type-agnostic inventory substrate (rbfw_inventory records already store booked_dates + rbfw_variation_info for bike_car_sd). Single Day keeps its per-rate/timely stock; per-size variation stock is layered on top as an additional constraint.

Admin
- Un-gate the Inventory/Variations tab for bike_car_sd in both editors: classic (admin/settings/Inventory.php tab + content, admin/js/mkb-admin.js) and modern (admin/views/rbfw-modern-editor.php, admin/js/rbfw-modern-editor.js). resort/appointment stay gated. Updated the toggle help text.

Frontend
- Render a size <select> under the rate price table in the AJAX step-3 template (templates/template_segment/single_day_info.php); timely-mode items render it on the main form (templates/forms/single-day-registration.php).
- Sold-out sizes for the selected date are shown disabled and labelled "(Sold Out)" and are never auto-selected; the default/selection resolves posted -> default -> first available. When every size is sold out the rate rows fall back to "Sold Out".
- Each rate's available quantity is capped by the resolved size's remaining stock (rbfw_get_bike_car_sd_available_qty gains an optional size arg). The selection is posted through the time-table AJAX and the table reloads when the size changes (assets/mp_script/rbfw_script.js).

Capture & recording
- The Single Day add-to-cart branch (Frontend/RBFW_Woocommerse.php) now builds rbfw_variation_info and stores it on the cart line, and threads it through rbfw_bikecarsd_ticket_info() (inc/class-bike-car-sd-function.php) so the inventory recorder persists the chosen size with the booking.

Enforcement (authoritative)
- rbfw_check_rental_availability() (inc/rbfw_inventory_functions.php) now handles bike_car_sd: it blocks a booking whose requested units exceed the selected size's remaining stock for the booked date(s). Wired into both the add-to-cart and checkout validators. Units are counted by summing rbfw_type_info (Single Day's real unit count) via a new date-membership helper rbfw_sd_variation_remaining_stock(), which mirrors rbfw_get_bike_car_sd_available_qty() rather than the datetime-overlap counter (whose return-date "-1 day" adjustment would mishandle same-day bookings).

Display
- Chosen size shown in the cart (templates/cart_page.php), the order line item / WooCommerce emails & PDFs (Frontend/RBFW_Woocommerse.php), and decremented in the admin closing-stock report (rbfw_get_stock_details).
- Calendar: rbfw_sd_sold_out_dates() also marks a date sold out when every size is exhausted.

Backward compatible: items with variations disabled hit no new paths; multi-day / resort / appointment behaviour is unchanged. Verified end-to-end against the live site (WP-CLI): per-size + date scoping, quantity limits, cancellation release, sold-out disabling, and fail-open when disabled.