### PR TITLE
feat(capability): make booking admin screens delegable without manage…

### DIFF
--- a/inc/booking/RBFW_Booking_List_Table.php
+++ b/inc/booking/RBFW_Booking_List_Table.php
@@ -22,14 +22,14 @@ if ( ! class_exists( 'RBFW_Booking_List_Table' ) ) {
 				'edit.php?post_type=rbfw_item',
 				esc_html__( 'Bookings', 'booking-and-rental-manager-for-woocommerce' ),
 				esc_html__( 'Bookings', 'booking-and-rental-manager-for-woocommerce' ),
-				'manage_options',
+				rbfw_bookings_capability(),
 				'rbfw_bookings',
 				array( $this, 'render_page' )
 			);
 		}
 
 		public function render_page() {
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! current_user_can( rbfw_bookings_capability() ) ) {
 				return;
 			}
 

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -2,6 +2,30 @@
 	if ( ! defined( 'ABSPATH' ) ) {
 		exit;
 	}
+
+	/**
+	 * Capability required to view/manage the booking admin screens
+	 * (Order List, Bookings, Booking Orders, Booking Calendar, Reports and their
+	 * order actions). Defaults to 'manage_options' so behaviour is unchanged out of
+	 * the box; filter it to delegate these screens to a non-admin role WITHOUT
+	 * granting full admin rights, e.g.:
+	 *
+	 *     add_filter( 'rbfw_bookings_capability', function () { return 'manage_woocommerce'; } );
+	 *     // or a dedicated capability granted to a custom role via a role editor:
+	 *     add_filter( 'rbfw_bookings_capability', function () { return 'rbfw_manage_bookings'; } );
+	 *
+	 * Note: the plugin's Settings/Status/Payment screens intentionally keep
+	 * 'manage_options', so a delegated user gets bookings/calendar/reports only.
+	 *
+	 * @return string A WordPress capability.
+	 */
+	if ( ! function_exists( 'rbfw_bookings_capability' ) ) {
+		function rbfw_bookings_capability() {
+			$cap = apply_filters( 'rbfw_bookings_capability', 'manage_options' );
+
+			return ( is_string( $cap ) && '' !== $cap ) ? $cap : 'manage_options';
+		}
+	}
 // Language Load
 	function rbfw_allowed_html() {
 		$allowed_html = array(

--- a/inc/rbfw_order_export.php
+++ b/inc/rbfw_order_export.php
@@ -23,13 +23,14 @@ add_action( 'admin_post_rbfw_export_orders', 'rbfw_export_orders_handler' );
 /**
  * Entry point for the export download request.
  *
- * Security: verifies the dedicated nonce and the manage_options capability
- * before reading any data. All output is plain text / library-rendered PDF, so
+ * Security: verifies the dedicated nonce and the booking-management capability
+ * ( rbfw_bookings_capability(), default manage_options ) before reading any data.
+ * All output is plain text / library-rendered PDF, so
  * there is no HTML echoed into wp-admin from user input.
  */
 function rbfw_export_orders_handler() {
 
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if ( ! current_user_can( rbfw_bookings_capability() ) ) {
 		wp_die( esc_html__( 'You are not allowed to export orders.', 'booking-and-rental-manager-for-woocommerce' ), 403 );
 	}
 
@@ -186,7 +187,7 @@ add_action( 'wp_ajax_rbfw_save_export_settings', 'rbfw_save_export_settings_call
 function rbfw_save_export_settings_callback() {
 	check_ajax_referer( 'rbfw_save_export_settings_action', 'nonce' );
 
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if ( ! current_user_can( rbfw_bookings_capability() ) ) {
 		wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
 	}
 

--- a/inc/rbfw_order_meta.php
+++ b/inc/rbfw_order_meta.php
@@ -22,7 +22,7 @@ function rbfw_update_order_status_callback() {
 
     check_ajax_referer( 'rbfw_update_order_status_action', 'nonce' );
 
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can( rbfw_bookings_capability() ) ) {
         wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
     }
 
@@ -202,7 +202,7 @@ function rbfw_delete_order_callback() {
 
     check_ajax_referer( 'rbfw_delete_order_action', 'nonce' );
 
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can( rbfw_bookings_capability() ) ) {
         wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
     }
 
@@ -367,7 +367,7 @@ add_action( 'wp_ajax_rbfw_get_order_edit_form', 'rbfw_get_order_edit_form_callba
 function rbfw_get_order_edit_form_callback() {
 
     check_ajax_referer( 'rbfw_get_order_edit_form_action', 'nonce' );
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can( rbfw_bookings_capability() ) ) {
         wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
     }
 
@@ -621,7 +621,7 @@ add_action( 'wp_ajax_rbfw_save_order_edit', 'rbfw_save_order_edit_callback' );
 function rbfw_save_order_edit_callback() {
 
     check_ajax_referer( 'rbfw_save_order_edit_action', 'nonce' );
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can( rbfw_bookings_capability() ) ) {
         wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized access.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
     }
 
@@ -792,7 +792,7 @@ function fetch_order_details_callback() {
 
     check_ajax_referer( 'rbfw_fetch_order_details_action', 'nonce' );
 
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can( rbfw_bookings_capability() ) ) {
         wp_send_json_error( 'Unauthorized access', 403 );
     }
 

--- a/lib/classes/class-admin-menu.php
+++ b/lib/classes/class-admin-menu.php
@@ -38,7 +38,7 @@
 
 			function admin_menu() {
 				add_submenu_page( 'edit.php?post_type=rbfw_item', __( 'Time Slots', 'booking-and-rental-manager-for-woocommerce' ), __( 'Time Slots', 'booking-and-rental-manager-for-woocommerce' ), 'manage_options', 'rbfw_time_slots', array( $this, 'rbfw_time_slots' ) );
-				add_submenu_page( 'edit.php?post_type=rbfw_item', __( 'Order List', 'booking-and-rental-manager-for-woocommerce' ), __( 'Order List', 'booking-and-rental-manager-for-woocommerce' ), 'manage_options', 'rbfw_order', array( $this, 'rbfw_order_list' ) );
+				add_submenu_page( 'edit.php?post_type=rbfw_item', __( 'Order List', 'booking-and-rental-manager-for-woocommerce' ), __( 'Order List', 'booking-and-rental-manager-for-woocommerce' ), rbfw_bookings_capability(), 'rbfw_order', array( $this, 'rbfw_order_list' ) );
 				add_submenu_page( 'edit.php?post_type=rbfw_item', __( 'Inventory', 'booking-and-rental-manager-for-woocommerce' ), __( 'Inventory', 'booking-and-rental-manager-for-woocommerce' ), 'manage_options', 'rbfw_inventory', array( $this, 'rbfw_inventory_list' ) );
 				do_action( 'rbfw_admin_menu_after_inventory' );
 				add_submenu_page( 'edit.php?post_type=rbfw_item', __( 'Settings', 'booking-and-rental-manager-for-woocommerce' ), __( 'Settings', 'booking-and-rental-manager-for-woocommerce' ), 'manage_options', 'rbfw_settings_page', array( $this, 'plugin_page' ) );


### PR DESCRIPTION
…_options

The Order List / Bookings pages and their order actions were hard-coded to manage_options, so the only way to let a non-admin view or manage bookings was to grant full admin rights. Introduce a single filterable capability, rbfw_bookings_capability() (default 'manage_options', filter 'rbfw_bookings_capability'), and use it for:

- Order List submenu (lib/classes/class-admin-menu.php)
- Bookings list page: menu cap + render guard (inc/booking/RBFW_Booking_List_Table.php)
- Order export + save-export-settings handlers (inc/rbfw_order_export.php)
- Order status / delete / edit-form / save / fetch AJAX (inc/rbfw_order_meta.php)

The default is unchanged (manage_options) so behaviour is identical out of the box. Site owners can delegate these screens to a non-admin role, e.g.:

    add_filter( 'rbfw_bookings_capability', function () { return 'manage_woocommerce'; } );
    // or a dedicated capability granted to a custom role via a role editor:
    add_filter( 'rbfw_bookings_capability', function () { return 'rbfw_manage_bookings'; } );

Settings, Status, Payment, Time Slots and Inventory intentionally keep manage_options, so a delegated user gets bookings/calendar/reports only.