### PR TITLE
fix(security): stop client-controlled multi-day service price manipul…

### DIFF
--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -893,6 +893,17 @@ if (!class_exists('RBFW_Woocommerce')) {
                 $rbfw_service_infos_post = isset( $sd_input_data_sabitized['rbfw_service_price_data'] ) ? $sd_input_data_sabitized['rbfw_service_price_data'] : [];
                 $rbfw_service_infos = [];
 
+                /*
+                 * SECURITY: the per-service unit price and price type are taken from the
+                 * item's stored configuration (rbfw_service_category_price), NEVER from the
+                 * request. The form posts rbfw_service_price_data[..][price], but trusting it
+                 * would let any visitor set an arbitrary/negative price and force the order
+                 * total to pennies. We only honour the customer's selection (which service +
+                 * quantity); the price is re-derived server-side and unknown services are
+                 * not charged.
+                 */
+                $rbfw_trusted_service_prices = rbfw_get_trusted_category_service_prices( $rbfw_id );
+
                 if ( ! empty( $rbfw_service_infos_post ) && is_array( $rbfw_service_infos_post ) ) {
                     foreach ( $rbfw_service_infos_post as $key_cat => $value ) {
                         if ( ! is_array( $value ) ) {
@@ -910,8 +921,18 @@ if (!class_exists('RBFW_Woocommerce')) {
                             if ( $service_qty <= 0 ) {
                                 continue; // service not selected
                             }
-                            $service_unit_price = isset( $item['price'] ) ? (float) $item['price'] : 0;
-                            $service_type       = isset( $item['service_price_type'] ) ? $item['service_price_type'] : '';
+                            $service_name = (string) $item['name'];
+                            // Trusted price/type from stored config; a service not present in the
+                            // item's configuration is never charged (posted price is ignored).
+                            if ( ! isset( $rbfw_trusted_service_prices[ $cat_title ][ $service_name ] ) ) {
+                                continue;
+                            }
+                            $service_unit_price = $rbfw_trusted_service_prices[ $cat_title ][ $service_name ]['price'];
+                            $service_type       = $rbfw_trusted_service_prices[ $cat_title ][ $service_name ]['type'];
+                            // Overwrite any request-supplied price/type so the stored order/ticket
+                            // record reflects the real, server-derived values.
+                            $item['price']              = $service_unit_price;
+                            $item['service_price_type'] = $service_type;
                             $rbfw_service_infos[ $cat_title ][] = $item;
                             if ( 'day_wise' === $service_type ) {
                                 $rbfw_service_price += $service_unit_price * $service_qty * $total_days;

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -2,6 +2,52 @@
 	if ( ! defined( 'ABSPATH' ) ) {
 		exit;
 	}
+
+	/**
+	 * Trusted per-service prices for the multi-day "category services" feature.
+	 *
+	 * SECURITY: the booking form posts rbfw_service_price_data[cat][ser][price], but a
+	 * price sent in the request must NEVER be trusted — it lets a visitor set an
+	 * arbitrary (even negative) service price and drive the order total to pennies.
+	 * The only source of truth is the item's stored rbfw_service_category_price config.
+	 *
+	 * @param int $post_id rbfw_item id.
+	 * @return array Map [ cat_title ][ service_title ] => [ 'price' => float>=0, 'type' => string ].
+	 */
+	if ( ! function_exists( 'rbfw_get_trusted_category_service_prices' ) ) {
+		function rbfw_get_trusted_category_service_prices( $post_id ) {
+			$raw = get_post_meta( $post_id, 'rbfw_service_category_price', true );
+			if ( ! is_array( $raw ) ) {
+				$decoded = json_decode( is_string( $raw ) ? $raw : '', true );
+				if ( is_array( $decoded ) ) {
+					$raw = $decoded;
+				} elseif ( is_string( $raw ) && is_serialized( $raw ) ) {
+					$raw = maybe_unserialize( $raw );
+				}
+			}
+			$map = array();
+			if ( is_array( $raw ) ) {
+				foreach ( $raw as $cat ) {
+					if ( ! is_array( $cat ) ) {
+						continue;
+					}
+					$cat_title = isset( $cat['cat_title'] ) ? (string) $cat['cat_title'] : '';
+					$services  = ( isset( $cat['cat_services'] ) && is_array( $cat['cat_services'] ) ) ? $cat['cat_services'] : array();
+					foreach ( $services as $svc ) {
+						if ( ! is_array( $svc ) || empty( $svc['title'] ) ) {
+							continue;
+						}
+						$map[ $cat_title ][ (string) $svc['title'] ] = array(
+							'price' => max( 0, (float) ( isset( $svc['price'] ) ? $svc['price'] : 0 ) ),
+							'type'  => isset( $svc['service_price_type'] ) ? (string) $svc['service_price_type'] : '',
+						);
+					}
+				}
+			}
+
+			return $map;
+		}
+	}
 // Language Load
 	function rbfw_allowed_html() {
 		$allowed_html = array(

--- a/inc/woocommerce/rbfw_cart_price_function.php
+++ b/inc/woocommerce/rbfw_cart_price_function.php
@@ -5,6 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'rbfw_set_cart_item_price', 'rbfw_set_cart_item_price_func', 10, 2 );
 function rbfw_set_cart_item_price_func( $value, $rbfw_id ) {
     $total_price = isset($value['rbfw_tp'])?$value['rbfw_tp']:0;
+    // Defense-in-depth: a booking can never cost less than 0. This caps any residual
+    // price-manipulation attempt from ever producing a negative line price/total.
+    $total_price = max( 0, (float) $total_price );
     $value['data']->set_price( $total_price );
     $value['data']->set_regular_price( $total_price );
     $value['data']->set_sale_price( $total_price );


### PR DESCRIPTION
…ation

The multi-day cart builder trusted the per-service unit price sent in the request (rbfw_service_price_data[cat][ser][price]) instead of the item's stored configuration. Because add-to-cart is reachable by guests and the price was added with no clamp and no total floor, any visitor could inject a category service with an arbitrary (even negative) price and drive a real, fulfillable booking's total down to pennies — a High-severity arbitrary price-manipulation flaw (same class as CWE-20/CWE-472).

Fix:
- Re-derive each category-service unit price and price type from the item's stored rbfw_service_category_price config; the request only selects which service and quantity. Unknown/unconfigured services are never charged. New helper rbfw_get_trusted_category_service_prices() (inc/rbfw_functions.php) builds a trusted [cat_title][service_title] => {price>=0, type} map and clamps configured prices to >= 0.
- Overwrite any request-supplied price/type in the stored order/ticket record with the trusted values so the saved record is accurate.
- Defense-in-depth: floor the WooCommerce cart line price at max(0, ...) in rbfw_set_cart_item_price_func() so no rent type can ever yield a negative line total.

Legitimate bookings are unchanged (prices still come from the same config); verified against the live install: forged/negative prices are ignored, real prices and quantities compute the correct total.

Files:
- inc/rbfw_functions.php (trusted-price helper)
- Frontend/RBFW_Woocommerse.php (multi-day service loop uses trusted prices)
- inc/woocommerce/rbfw_cart_price_function.php (>= 0 price floor)