### PR TITLE
fix(pricing): stop false "Enable Time Picker" error in duration-based…… mode

### DIFF
--- a/admin/settings/Pricing.php
+++ b/admin/settings/Pricing.php
@@ -1657,9 +1657,13 @@
                     $has_valid_row = false;
 
                     // "Manage a single-item inventory on an hourly basis" needs the time
-                    // picker enabled so slots can be selected — enforce that pairing.
+                    // picker enabled so slots can be selected — enforce that pairing, BUT only
+                    // when duration-based rental is off. With duration-based rental on, each row
+                    // carries its own explicit Start/End Time, so the generic Time Picker is not
+                    // used; the editor UI intentionally force-disables and hides it in that mode,
+                    // which would otherwise make this requirement impossible to satisfy.
                     $time_picker_on = isset( $post_data['rbfw_enable_time_picker'] ) && $post_data['rbfw_enable_time_picker'] === 'yes';
-                    if ( $timely && ! $time_picker_on ) {
+                    if ( $timely && ! $specific && ! $time_picker_on ) {
                         $errors[] = __( 'Please enable "Enable Time Picker" — it is required when "Manage a single-item inventory on an hourly basis" is enabled.', 'booking-and-rental-manager-for-woocommerce' );
                     }
 


### PR DESCRIPTION


Single-Day/Appointment items showed a blocking validation error — "Please enable Enable Time Picker — it is required when Manage a single-item inventory on an hourly basis is enabled." — whenever BOTH "Manage a single-item inventory on an hourly basis" (manage_inventory_as_timely) and "Enable duration-based rental items" (enable_specific_duration) were turned on, making the item impossible to save.

Root cause: the editor UI intentionally force-disables and hides the "Enable Time Picker" control when duration-based rental is on (each rental row then carries its own explicit Start/End Time, so the generic time-slot picker is not used — see syncTimePickerWithSpecificDuration() in mkb-admin.js and syncTimelyUI() in rbfw-modern-editor.js). But the server-side pricing validator still required rbfw_enable_time_picker=yes whenever the hourly-inventory toggle was on, regardless of the duration-based toggle. With the picker forced off, the requirement could never be met.

Fix: in RBFW_Pricing::get_pricing_validation_errors() only require the Time Picker when hourly inventory is on AND duration-based rental is OFF (timely && !specific && !time_picker_on). The legitimate case (hourly inventory without duration-based rental, picker off) still errors as before.

Shared by both the Modern editor (RBFW_Modern_Editor.php) and Classic editor
(Pricing.php) save paths, so one change covers both. Verified: timely+specific ->
no error; timely-only+picker off -> error; timely-only+picker on -> no error.