### PR TITLE
Fix æ/ø/å corruption in Modern Editor saves (JSON escape + slash stripping)

### DIFF
--- a/admin/RBFW_Modern_Editor.php
+++ b/admin/RBFW_Modern_Editor.php
@@ -541,7 +541,7 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 			}
 
 		/* ── Extra service table (service_name[], service_price[], etc.) ── */
-			$input = RBFW_Function::data_sanitize( $_POST );
+			$input = RBFW_Function::data_sanitize( wp_unslash( $_POST ) );
 			$names       = $input['service_name']  ?? [];
 			$prices      = $input['service_price'] ?? [];
 			$descs       = $input['service_desc']  ?? [];
@@ -560,16 +560,22 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 				}
 			}
 			if ( ! empty( $new_extra ) ) {
-				update_post_meta( $post_id, 'rbfw_extra_service_data', $new_extra );
+				update_post_meta( $post_id, 'rbfw_extra_service_data', wp_slash( $new_extra ) );
 			} elseif ( isset( $_POST['service_name'] ) ) {
 				delete_post_meta( $post_id, 'rbfw_extra_service_data' );
 			}
 
-			/* Extra service category price */
+			/* Extra service category price.
+			 * Stored as a native array (WP serializes it) — matching the classic
+			 * editor and both readers (Extra_Service.php / RBFW_Woocommerse.php),
+			 * which check is_array() first. Previously this was wp_json_encode()d
+			 * without JSON_UNESCAPED_UNICODE and without wp_slash(), so multibyte
+			 * chars (æ/ø/å) became "æ"-style escapes whose backslashes were then
+			 * stripped by update_post_meta(), corrupting the stored JSON. */
 			if ( isset( $_POST['rbfw_service_category_price'] ) && is_array( $_POST['rbfw_service_category_price'] ) ) {
 				$scp_raw = wp_unslash( $_POST['rbfw_service_category_price'] );
 				array_walk_recursive( $scp_raw, function ( &$v ) { $v = is_string( $v ) ? sanitize_text_field( $v ) : ''; } );
-				update_post_meta( $post_id, 'rbfw_service_category_price', wp_json_encode( $scp_raw ) );
+				update_post_meta( $post_id, 'rbfw_service_category_price', wp_slash( $scp_raw ) );
 			}
 			if ( isset( $_POST['rbfw_enable_category_service_price'] ) ) {
 				update_post_meta( $post_id, 'rbfw_enable_category_service_price', sanitize_text_field( wp_unslash( $_POST['rbfw_enable_category_service_price'] ) ) );

--- a/admin/RBFW_Modern_Editor.php
+++ b/admin/RBFW_Modern_Editor.php
@@ -23,6 +23,7 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 			add_action( 'admin_menu',             [ $this, 'fix_add_new_submenu_link' ], 999 );
 			add_action( 'load-post.php',          [ $this, 'maybe_redirect_edit_screen' ] );
 			add_action( 'load-post-new.php',      [ $this, 'maybe_redirect_new_screen' ] );
+			add_action( 'current_screen',         [ $this, 'maybe_create_draft_before_output' ] );
 			add_action( 'admin_enqueue_scripts',  [ $this, 'enqueue_assets' ] );
 			add_action( 'admin_head',             [ $this, 'hide_menu_styles' ] );
 			add_filter( 'admin_body_class',       [ $this, 'admin_body_class' ] );
@@ -277,6 +278,37 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 
 			wp_safe_redirect( $this->edit_url( $post_id, 'general' ) );
 			exit;
+		}
+
+		/**
+		 * When the modern editor page is opened without an item_id (e.g. the
+		 * "Add New" submenu link), create the draft and redirect EARLY —
+		 * on `current_screen`, before admin-header.php has produced any output.
+		 * Doing this inside render_page() triggers "Cannot modify header
+		 * information — headers already sent" warnings.
+		 */
+		public function maybe_create_draft_before_output(): void {
+			if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+				return;
+			}
+
+			if ( ! $this->is_edit_screen() ) {
+				return;
+			}
+
+			if ( isset( $_GET['item_id'] ) && absint( $_GET['item_id'] ) > 0 ) {
+				return;
+			}
+
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return;
+			}
+
+			$new_id = $this->create_draft_item();
+			if ( $new_id > 0 ) {
+				wp_safe_redirect( $this->edit_url( $new_id, 'general' ) );
+				exit;
+			}
 		}
 
 		/* ── Body class / menu highlight ────────────────────────────────────── */
@@ -841,11 +873,23 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 
 			$post    = $post_id ? get_post( $post_id ) : null;
 
-			/* Create draft if no ID yet */
+			/* Create draft if no ID yet.
+			 * Normally handled earlier by maybe_create_draft_before_output();
+			 * this fallback must never call wp_safe_redirect() once admin-header
+			 * output has started, so fall back to a JS/meta redirect. */
 			if ( ! $post_id ) {
 				$new_id = $this->create_draft_item();
 				if ( $new_id > 0 ) {
-					wp_safe_redirect( $this->edit_url( $new_id, 'general' ) );
+					$redirect_url = $this->edit_url( $new_id, 'general' );
+					if ( ! headers_sent() ) {
+						wp_safe_redirect( $redirect_url );
+					} else {
+						printf(
+							'<script>window.location.replace(%s);</script><noscript><meta http-equiv="refresh" content="0;url=%s"></noscript>',
+							wp_json_encode( esc_url_raw( $redirect_url ) ),
+							esc_url( $redirect_url )
+						);
+					}
 					exit;
 				}
 			}

--- a/admin/RBFW_Quick_Setup.php
+++ b/admin/RBFW_Quick_Setup.php
@@ -13,6 +13,40 @@ function rbfw_quick_setup_exit()
             wp_redirect($redirect_url);
             exit;
         }
+
+        /*
+         * Handle the "Finish" step here on admin_init — BEFORE any admin page
+         * output — instead of inside the page render callback, where the
+         * wp_redirect() would fire after headers are sent and trigger
+         * "Cannot modify header information" warnings.
+         */
+        if (isset($_POST['finish_quick_setup'])) {
+
+            if (isset($_POST['rbfw_rent_label']) && !empty($_POST['rbfw_rent_label'])) {
+                $rbfw_basic_gen_settings = get_option('rbfw_basic_gen_settings', true);
+                $rbfw_basic_gen_settings = is_array($rbfw_basic_gen_settings) ? $rbfw_basic_gen_settings : [];
+                $rbfw_basic_gen_settings['rbfw_rent_label'] =  sanitize_text_field(wp_unslash($_POST['rbfw_rent_label']));
+                $rbfw_basic_gen_settings['rbfw_gutenburg_switch'] =  'Off';
+                update_option('rbfw_basic_gen_settings', $rbfw_basic_gen_settings);
+            }
+
+            if (isset($_POST['rbfw_rent_slug']) && !empty($_POST['rbfw_rent_slug'])) {
+                $rbfw_basic_gen_settings = get_option('rbfw_basic_gen_settings', true);
+                $rbfw_basic_gen_settings = is_array($rbfw_basic_gen_settings) ? $rbfw_basic_gen_settings : [];
+                $rbfw_basic_gen_settings['rbfw_rent_slug'] = sanitize_text_field(wp_unslash($_POST['rbfw_rent_slug']));
+                update_option('rbfw_basic_gen_settings', $rbfw_basic_gen_settings);
+            }
+
+            $sample_rent_items = get_option('rbfw_sample_rent_items');
+            if ($sample_rent_items !== 'yes' && class_exists('RbfwImportDemo')) {
+                $dummy_import = new RbfwImportDemo();
+                $dummy_import->rbfw_import_demo_function();
+            }
+
+            update_option('rbfw_quick_setup_done', 'yes');
+            wp_safe_redirect(admin_url('edit.php?post_type=rbfw_item'));
+            exit;
+        }
     }
 }
 
@@ -109,32 +143,11 @@ if (!class_exists('RBFW_Quick_Setup')) {
                     </script>
             <?php
                 }
-                if (isset($_POST['finish_quick_setup'])) {
-
-                    if (isset($_POST['rbfw_rent_label']) && !empty($_POST['rbfw_rent_label'])) {
-                        $rbfw_basic_gen_settings = get_option('rbfw_basic_gen_settings', true);
-                        $rbfw_basic_gen_settings = is_array($rbfw_basic_gen_settings) ? $rbfw_basic_gen_settings : [];
-                        $rbfw_basic_gen_settings['rbfw_rent_label'] =  sanitize_text_field(wp_unslash($_POST['rbfw_rent_label']));
-                        $rbfw_basic_gen_settings['rbfw_gutenburg_switch'] =  'Off';
-                        update_option('rbfw_basic_gen_settings', $rbfw_basic_gen_settings);
-                    }
-
-                    if (isset($_POST['rbfw_rent_slug']) && !empty($_POST['rbfw_rent_slug'])) {
-                        $rbfw_basic_gen_settings = get_option('rbfw_basic_gen_settings', true);
-                        $rbfw_basic_gen_settings['rbfw_rent_slug'] = sanitize_text_field(wp_unslash($_POST['rbfw_rent_slug']));
-                        update_option('rbfw_basic_gen_settings', $rbfw_basic_gen_settings);
-                    }
-
-
-                    $sample_rent_items = get_option( 'rbfw_sample_rent_items' );
-                    if ( $sample_rent_items !== 'yes' ) {
-                        $dummy_import = new RbfwImportDemo();
-                        $dummy_import->rbfw_import_demo_function();
-                    }
-
-                    update_option('rbfw_quick_setup_done', 'yes');
-                    wp_redirect(admin_url('edit.php?post_type=rbfw_item'));
-                }
+                /*
+                 * NOTE: the "finish_quick_setup" submission is handled early in
+                 * rbfw_quick_setup_exit() (admin_init, priority 99) so the redirect
+                 * happens before headers are sent. No render-time handling here.
+                 */
             }
 
             ?>


### PR DESCRIPTION


Problem
-------
Since the Modern Editor was introduced, items containing Danish/multibyte characters (æ, ø, å) intermittently displayed literal escape sequences on the frontend (e.g. "ø" instead of "ø", or "u00e6" with the backslash stripped). Re-saving the item temporarily fixed the value until the next Modern Editor save corrupted it again.

Root cause
----------
In RBFW_Modern_Editor::save (extra service category price block), the submitted array was persisted as:

    update_post_meta( $post_id, 'rbfw_service_category_price',
                      wp_json_encode( $scp_raw ) );

Two bugs compounded:

1. wp_json_encode() was called WITHOUT JSON_UNESCAPED_UNICODE, so multibyte characters were stored as \uXXXX escape sequences (æ -> æ, ø -> ø, å -> å).

2. The JSON string was passed to update_post_meta() WITHOUT wp_slash(). update_post_meta() expects slashed input and strips one level of backslashes, turning "æ" into "u00e6" and breaking the stored JSON. On read, json_decode() then either failed (wiping the category list until the next edit) or leaked the literal escape text into the frontend output.

This only triggered for values containing non-ASCII characters saved via the Modern Editor, which is why the issue appeared intermittent and "self-healing" after a re-edit.

Fix
---
* Store rbfw_service_category_price as a native PHP array (wp_slash()ed), letting WordPress serialize it. This matches the classic editor and both readers — admin/settings/Extra_Service.php and Frontend/RBFW_Woocommerse.php — which check is_array() first and keep json_decode() only as a legacy fallback. Old valid JSON rows still load and are migrated to the safe array format on next save. No JSON escaping is involved anymore; æøå are stored as plain UTF-8.

* Extra service table block: properly wp_unslash( $_POST ) before sanitizing, and wp_slash() the array when writing rbfw_extra_service_data, so quotes/backslashes in service names also survive the save round-trip.

Notes
-----
Rows already corrupted on live sites (containing literal "u00e6"-style text) cannot be auto-recovered from the mangled JSON; affected items need one re-save in the editor after deploying this fix. They can be located with:

    SELECT post_id FROM wp_postmeta
    WHERE meta_key='rbfw_service_category_price'
      AND meta_value LIKE '%u00%';

php -l passes on the modified file.