### PR TITLE
Add unified coupon & discount engine (core) + i18n fixes

### DIFF
--- a/admin/css/rbfw-modern-editor.css
+++ b/admin/css/rbfw-modern-editor.css
@@ -3992,6 +3992,20 @@ body.rtl.rbfw-modern-editor-screen .rbfw-me-step-nav {
     justify-content: space-between !important;
     gap: 20px !important;
 }
+/* Hide inventory toggle rows that don't apply to the current rent type.
+   These override the generic `display:flex !important` rule above (higher
+   specificity + driven by the pricing panel's data-item-type, which
+   applyType() keeps in sync on live type changes).
+   - Return-date release: not for Single Day / Appointment.
+   - Multiple-item selection: only multi-day Bike/Car, Dress, Equipment, Others. */
+.rbfw-me-panel[data-item-type="bike_car_sd"]    .rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_stock_return_date_section,
+.rbfw-me-panel[data-item-type="appointment"]    .rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_stock_return_date_section,
+.rbfw-me-panel[data-item-type="bike_car_sd"]    .rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_switch_md_type_item_qty,
+.rbfw-me-panel[data-item-type="appointment"]    .rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_switch_md_type_item_qty,
+.rbfw-me-panel[data-item-type="resort"]         .rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_switch_md_type_item_qty,
+.rbfw-me-panel[data-item-type="multiple_items"] .rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section.rbfw_switch_md_type_item_qty {
+    display: none !important;
+}
 .rbfw-me-inventory-card .rbfw-me-pricing-classic-wrap > section > div:first-child {
     flex: 1 1 auto !important;
     min-width: 0 !important;

--- a/admin/css/rbfw_coupon_admin.css
+++ b/admin/css/rbfw_coupon_admin.css
@@ -1,0 +1,454 @@
+/* ===================================================================
+   Coupons manager — matched to the Global Settings design language
+   (admin/css/rbfw_global_settings.css): same gradient panel header,
+   panel shell, accent blue, brand pink, and section headings.
+   Everything is scoped under .rbfw-cpn.
+   =================================================================== */
+
+.rbfw-cpn {
+	--cpn-accent: #2271B1;   /* blue — active step, links */
+	--cpn-primary: #F12971;  /* brand pink — save / primary */
+	--cpn-heading: #1D2327;
+	--cpn-muted: #6B7280;
+	--cpn-line: #F0F2F5;
+	--cpn-border: #E8E8E8;
+	margin: 20px 20px 20px 0;
+	box-sizing: border-box;
+}
+
+.rbfw-cpn *,
+.rbfw-cpn *::before,
+.rbfw-cpn *::after { box-sizing: border-box; }
+
+/* ── Panel shell ───────────────────────────────────────────────── */
+.rbfw-cpn-panel {
+	background: #fff;
+	border: 1px solid var(--cpn-border);
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+	overflow: hidden;
+}
+
+.rbfw-cpn-panel-head,
+.rbfw-cpn-modal-head {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 18px 24px;
+	background: linear-gradient(135deg, #3F13A4 0%, #2271B1 100%);
+}
+
+.rbfw-cpn-head-icon {
+	width: 48px; height: 48px;
+	background: rgba(255, 255, 255, 0.15);
+	border-radius: 10px;
+	display: flex; align-items: center; justify-content: center;
+	flex-shrink: 0;
+}
+.rbfw-cpn-head-icon i { font-size: 22px; color: #fff; }
+
+.rbfw-cpn-head-text { min-width: 0; }
+.rbfw-cpn-head-text h2 {
+	color: #fff; font-size: 18px; font-weight: 700;
+	margin: 0 0 3px; padding: 0; line-height: 1.2; border: none;
+}
+.rbfw-cpn-head-text p {
+	color: rgba(255, 255, 255, 0.80);
+	font-size: 12.5px; margin: 0; line-height: 1.4;
+}
+
+.rbfw-cpn-btn-add {
+	margin-left: auto;
+	display: inline-flex; align-items: center; gap: 8px;
+	background: #fff; color: #1D2327;
+	border: none; border-radius: 8px;
+	padding: 10px 18px;
+	font-size: 13px; font-weight: 700; cursor: pointer;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+	transition: transform .15s ease, box-shadow .15s ease;
+	white-space: nowrap;
+}
+.rbfw-cpn-btn-add:hover { transform: translateY(-1px); box-shadow: 0 6px 16px rgba(0,0,0,.24); }
+.rbfw-cpn-btn-add i { color: var(--cpn-primary); }
+
+.rbfw-cpn-panel-body { padding: 20px 24px 24px; }
+
+/* ── Notice ────────────────────────────────────────────────────── */
+.rbfw-cpn-notice {
+	display: flex; align-items: center; gap: 10px;
+	background: #FFF8E5; border: 1px solid #FFE9A8;
+	color: #7A5B00; border-radius: 8px;
+	padding: 12px 16px; margin-bottom: 18px; font-size: 13px;
+}
+.rbfw-cpn-notice a { color: #7A5B00; font-weight: 600; }
+
+/* ── Stat cards ────────────────────────────────────────────────── */
+.rbfw-cpn-stats { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 20px; }
+.rbfw-cpn-stat {
+	flex: 1 1 170px;
+	display: flex; align-items: center; gap: 12px;
+	background: #fff; border: 1px solid #EAEAEA; border-radius: 8px;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+	padding: 14px 16px;
+}
+.rbfw-cpn-stat-ico {
+	width: 40px; height: 40px; border-radius: 10px; flex-shrink: 0;
+	display: flex; align-items: center; justify-content: center; font-size: 16px;
+}
+.rbfw-cpn-stat-ico.blue   { background: #E7F1FA; color: #2271B1; }
+.rbfw-cpn-stat-ico.green  { background: #E6F6EC; color: #17803D; }
+.rbfw-cpn-stat-ico.pink   { background: #FDE7F0; color: #F12971; }
+.rbfw-cpn-stat-ico.purple { background: #EEE8FB; color: #5B21B6; }
+.rbfw-cpn-stat-ico.slate  { background: #EEF1F5; color: #475569; }
+.rbfw-cpn-stat span {
+	display: block; font-size: 20px; font-weight: 700;
+	color: var(--cpn-heading); line-height: 1.2;
+}
+.rbfw-cpn-stat span.sm { font-size: 14px; }
+.rbfw-cpn-stat span .woocommerce-Price-amount { font-size: 20px; }
+.rbfw-cpn-stat label {
+	font-size: 11px; color: var(--cpn-muted);
+	text-transform: uppercase; letter-spacing: .05em; font-weight: 600;
+}
+
+/* ── Table ─────────────────────────────────────────────────────── */
+.rbfw-cpn-tablecard {
+	background: #fff; border: 1px solid #EAEAEA; border-radius: 8px;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06); overflow: hidden;
+}
+.rbfw-cpn-table { width: 100%; border-collapse: separate; border-spacing: 0; }
+.rbfw-cpn-table thead th {
+	background: #F8FAFC; text-align: left;
+	font-size: 11.5px; font-weight: 700; letter-spacing: .04em;
+	text-transform: uppercase; color: #64748B;
+	padding: 13px 16px; border-bottom: 1px solid var(--cpn-line);
+}
+.rbfw-cpn-table td {
+	padding: 14px 16px; border-bottom: 1px solid var(--cpn-line);
+	font-size: 13px; color: #3D4A5C; vertical-align: middle;
+}
+.rbfw-cpn-table tbody tr:last-child td { border-bottom: none; }
+.rbfw-cpn-table tbody tr { transition: background-color .18s ease; }
+.rbfw-cpn-table tbody tr:hover { background: #FAFBFC; }
+.rbfw-cpn-table .ta-r { text-align: right; }
+
+.rbfw-cpn-code {
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	font-size: 13.5px; font-weight: 700; color: var(--cpn-heading);
+	letter-spacing: .02em;
+}
+.rbfw-cpn-tags { display: flex; gap: 5px; margin-top: 5px; flex-wrap: wrap; }
+.rbfw-cpn-badge {
+	display: inline-flex; align-items: center; gap: 4px;
+	font-size: 9.5px; font-weight: 800; letter-spacing: .05em;
+	padding: 3px 7px; border-radius: 20px;
+}
+.rbfw-cpn-badge i { font-size: 8px; }
+.rbfw-cpn-badge.auto  { background: #E7F1FA; color: #1E5C8F; }
+.rbfw-cpn-badge.stack { background: #E6F6EC; color: #166534; }
+
+.rbfw-cpn-amount { font-weight: 700; color: var(--cpn-heading); }
+.rbfw-cpn-muted { color: var(--cpn-muted); font-size: 12.5px; }
+.rbfw-cpn-usage { font-weight: 600; font-size: 12.5px; }
+.rbfw-cpn-bar { margin-top: 5px; height: 4px; width: 76px; background: #EEF1F5; border-radius: 20px; overflow: hidden; }
+.rbfw-cpn-bar i { display: block; height: 100%; background: var(--cpn-accent); border-radius: 20px; }
+
+.rbfw-cpn-status {
+	display: inline-block; font-size: 10.5px; font-weight: 800;
+	padding: 4px 10px; border-radius: 20px; text-transform: uppercase; letter-spacing: .04em;
+}
+.rbfw-cpn-status.on  { background: #E6F6EC; color: #166534; }
+.rbfw-cpn-status.off { background: #F1F3F5; color: #6B7280; }
+
+.rbfw-cpn-actions { white-space: nowrap; }
+.rbfw-cpn-ico {
+	width: 30px; height: 30px; border-radius: 7px; cursor: pointer;
+	border: 1px solid #E2E5E9; background: #fff; color: #64748B;
+	margin-left: 5px; font-size: 12px;
+	transition: all .15s ease;
+}
+.rbfw-cpn-ico:hover { background: var(--cpn-accent); border-color: var(--cpn-accent); color: #fff; }
+.rbfw-cpn-ico.danger:hover { background: #D92D20; border-color: #D92D20; }
+
+.rbfw-cpn-empty { text-align: center; padding: 48px 20px !important; }
+.rbfw-cpn-empty i { font-size: 34px; color: #CBD5E1; display: block; margin-bottom: 12px; }
+.rbfw-cpn-empty strong { display: block; font-size: 15px; color: var(--cpn-heading); margin-bottom: 4px; }
+.rbfw-cpn-empty span { display: block; color: var(--cpn-muted); margin-bottom: 16px; font-size: 13px; }
+
+/* ── Buttons ───────────────────────────────────────────────────── */
+.rbfw-cpn-btn {
+	display: inline-flex; align-items: center; gap: 7px;
+	border: 1px solid transparent; border-radius: 6px;
+	padding: 9px 18px; font-size: 13px; font-weight: 600;
+	cursor: pointer; transition: all .15s ease;
+}
+.rbfw-cpn-btn.primary { background: var(--cpn-primary); border-color: var(--cpn-primary); color: #fff; }
+.rbfw-cpn-btn.accent  { background: var(--cpn-accent);  border-color: var(--cpn-accent);  color: #fff; box-shadow: 0 2px 8px rgba(34,113,177,.30); }
+.rbfw-cpn-btn.ghost   { background: #fff; border-color: #D5D9DE; color: #3D4A5C; }
+.rbfw-cpn-btn:hover:not(:disabled) { opacity: .9; transform: translateY(-1px); }
+.rbfw-cpn-btn:disabled { opacity: .45; cursor: not-allowed; }
+.rbfw-cpn-btn[hidden] { display: none; }
+
+/* ── Modal shell ───────────────────────────────────────────────── */
+.rbfw-cpn-modal {
+	display: none; position: fixed; inset: 0; z-index: 100000;
+	background: rgba(10, 10, 30, 0.62); backdrop-filter: blur(3px);
+	align-items: flex-start; justify-content: center;
+	overflow-y: auto; padding: 34px 16px;
+}
+.rbfw-cpn-modal.is-open { display: flex; }
+.rbfw-cpn-box {
+	background: #fff; border-radius: 12px; width: 1000px; max-width: 96vw;
+	box-shadow: 0 24px 64px rgba(0, 0, 0, 0.32); overflow: hidden;
+	display: flex; flex-direction: column;
+}
+.rbfw-cpn-modal-head { border-radius: 12px 12px 0 0; }
+/* Scope the round close-button style to the HEADER only — the footer "Cancel" also
+   carries .rbfw-cpn-close (for the shared click handler) and must stay a normal button. */
+.rbfw-cpn-modal-head .rbfw-cpn-close {
+	margin-left: auto; background: rgba(255,255,255,.18); border: none;
+	width: 34px; height: 34px; border-radius: 50%;
+	color: #fff; font-size: 21px; line-height: 1; cursor: pointer;
+	display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.rbfw-cpn-modal-head .rbfw-cpn-close:hover { background: rgba(255,255,255,.3); }
+.rbfw-cpn-stepcaption { min-height: 17px; }
+
+/* progress bar under the header */
+.rbfw-cpn-progress { height: 3px; background: #EDF0F3; }
+.rbfw-cpn-progress i {
+	display: block; height: 100%; width: 20%;
+	background: linear-gradient(90deg, #3F13A4, #2271B1);
+	transition: width .28s cubic-bezier(.16,1,.3,1);
+}
+
+/* ── Wizard body: left rail + panes ────────────────────────────── */
+.rbfw-cpn-modal-body { display: flex; align-items: stretch; min-height: 430px; }
+
+.rbfw-cpn-rail {
+	width: 230px; flex-shrink: 0;
+	background: #FAFBFC; border-right: 1px solid #EDF0F3;
+	padding: 16px 12px; display: flex; flex-direction: column; gap: 4px;
+}
+.rbfw-cpn-railitem {
+	display: flex; align-items: center; gap: 11px;
+	padding: 10px 12px; border: none; background: transparent;
+	border-radius: 7px; cursor: pointer; text-align: left; width: 100%;
+	transition: background .18s ease, color .18s ease;
+}
+.rbfw-cpn-railitem:hover { background: #D6E4F0; }
+.rbfw-cpn-railitem.is-active { background: var(--cpn-accent); box-shadow: 0 2px 8px rgba(34,113,177,.30); }
+.rbfw-cpn-railitem.is-active .rbfw-cpn-railtxt strong,
+.rbfw-cpn-railitem.is-active .rbfw-cpn-railtxt small { color: #fff; }
+.rbfw-cpn-railitem.is-active .rbfw-cpn-railnum { background: rgba(255,255,255,.22); color: #fff; }
+
+.rbfw-cpn-railnum {
+	width: 26px; height: 26px; border-radius: 50%; flex-shrink: 0;
+	background: #E4E8ED; color: #64748B;
+	display: flex; align-items: center; justify-content: center;
+	font-size: 11.5px; font-weight: 800;
+}
+.rbfw-cpn-railnum i { display: none; font-size: 11px; }
+.rbfw-cpn-railitem.is-done .rbfw-cpn-railnum { background: #E6F6EC; color: #17803D; }
+.rbfw-cpn-railitem.is-done .rbfw-cpn-railnum .n { display: none; }
+.rbfw-cpn-railitem.is-done .rbfw-cpn-railnum i { display: block; }
+
+.rbfw-cpn-railtxt { display: flex; flex-direction: column; min-width: 0; }
+.rbfw-cpn-railtxt strong { font-size: 13px; font-weight: 600; color: #3D4A5C; line-height: 1.3; }
+.rbfw-cpn-railtxt small { font-size: 11px; color: #8A94A6; }
+
+.rbfw-cpn-panes { flex: 1; min-width: 0; padding: 22px 26px; overflow-y: auto; max-height: 62vh; }
+.rbfw-cpn-pane { display: none; }
+.rbfw-cpn-pane.is-active { display: block; animation: rbfwCpnFade .22s ease; }
+@keyframes rbfwCpnFade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+
+/* section heading — mirrors the settings page group <h2> */
+.rbfw-cpn-sec {
+	display: flex; align-items: center; gap: 8px;
+	font-size: 15px; font-weight: 700; color: var(--cpn-heading);
+	margin: 0 0 14px; padding: 12px 16px;
+	background: #F8FAFC; border-radius: 6px; line-height: 1.3;
+}
+.rbfw-cpn-sec i { color: var(--cpn-accent); font-size: 15px; }
+
+.rbfw-cpn-hint { color: var(--cpn-muted); font-size: 12.5px; line-height: 1.55; margin: -4px 0 14px; }
+.rbfw-cpn-hint.sm { margin: 0 0 8px; font-size: 11.5px; }
+
+/* ── Fields ────────────────────────────────────────────────────── */
+.rbfw-cpn-row { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
+.rbfw-cpn-row > label { flex: 1 1 190px; display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.rbfw-cpn-row > label.f2 { flex: 2 1 300px; }
+.rbfw-cpn-row .lb { font-size: 12.5px; font-weight: 600; color: #374151; }
+.rbfw-cpn-row .lb .req { color: #D92D20; }
+.rbfw-cpn-row .lb i.ok { color: #17803D; }
+.rbfw-cpn-row .lb i.no { color: #D92D20; }
+.rbfw-cpn-row small { font-size: 11px; color: var(--cpn-muted); line-height: 1.45; }
+
+.rbfw-cpn-row input[type=text],
+.rbfw-cpn-row input[type=number],
+.rbfw-cpn-row input[type=date],
+.rbfw-cpn-row select,
+.rbfw-cpn-row textarea {
+	width: 100%; border: 1.5px solid #D5D9DE; border-radius: 8px;
+	padding: 9px 12px; font-size: 13px; background: #fff; color: #1D2327;
+	transition: border-color .15s ease, box-shadow .15s ease;
+}
+.rbfw-cpn-row input:focus,
+.rbfw-cpn-row select:focus,
+.rbfw-cpn-row textarea:focus {
+	outline: none; border-color: var(--cpn-accent);
+	box-shadow: 0 0 0 3px rgba(34, 113, 177, 0.12);
+}
+.rbfw-cpn-row input.has-error { border-color: #D92D20; box-shadow: 0 0 0 3px rgba(217,45,32,.10); }
+.rbfw-cpn-row select[multiple] { padding: 6px; }
+
+/* discount-type cards */
+.rbfw-cpn-types { display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+.rbfw-cpn-type { flex: 1 1 180px; cursor: pointer; }
+.rbfw-cpn-type input { position: absolute; opacity: 0; pointer-events: none; }
+.rbfw-cpn-type .card {
+	display: flex; flex-direction: column; align-items: flex-start; gap: 3px;
+	border: 1.5px solid #E2E5E9; border-radius: 10px; padding: 14px 16px;
+	background: #fff; transition: all .16s ease; height: 100%;
+}
+.rbfw-cpn-type .card i { font-size: 16px; color: #8A94A6; margin-bottom: 4px; }
+.rbfw-cpn-type .card strong { font-size: 13px; color: var(--cpn-heading); }
+.rbfw-cpn-type .card small { font-size: 11px; color: var(--cpn-muted); }
+.rbfw-cpn-type:hover .card { border-color: #B9C4CF; }
+.rbfw-cpn-type input:checked + .card {
+	border-color: var(--cpn-accent); background: #F4F9FD;
+	box-shadow: 0 2px 8px rgba(34,113,177,.14);
+}
+.rbfw-cpn-type input:checked + .card i { color: var(--cpn-accent); }
+
+/* switches */
+.rbfw-cpn-switches { display: flex; gap: 14px; flex-wrap: wrap; }
+.rbfw-cpn-switch {
+	flex: 1 1 280px; display: flex; align-items: center; gap: 12px; cursor: pointer;
+	border: 1px solid #E2E5E9; border-radius: 10px; padding: 12px 14px; background: #fff;
+	transition: border-color .16s ease, background .16s ease;
+}
+.rbfw-cpn-switch:hover { border-color: #B9C4CF; }
+.rbfw-cpn-switch input { position: absolute; opacity: 0; pointer-events: none; }
+.rbfw-cpn-switch .track {
+	position: relative; width: 42px; height: 24px; border-radius: 24px;
+	background: #D1D5DB; flex-shrink: 0; transition: background .2s ease;
+}
+.rbfw-cpn-switch .track::before {
+	content: ""; position: absolute; top: 3px; left: 3px;
+	width: 18px; height: 18px; border-radius: 50%; background: #fff;
+	box-shadow: 0 1px 3px rgba(0,0,0,.2); transition: transform .2s ease;
+}
+.rbfw-cpn-switch input:checked + .track { background: #17803D; }
+.rbfw-cpn-switch input:checked + .track::before { transform: translateX(18px); }
+.rbfw-cpn-switch .txt { display: flex; flex-direction: column; }
+.rbfw-cpn-switch .txt strong { font-size: 13px; color: var(--cpn-heading); }
+.rbfw-cpn-switch .txt small { font-size: 11px; color: var(--cpn-muted); }
+
+/* checkbox grids */
+.rbfw-cpn-grid {
+	flex: 1 1 260px; border: 1px solid #E2E5E9; border-radius: 10px;
+	padding: 12px 14px; margin: 0; min-width: 0; background: #fff;
+}
+.rbfw-cpn-grid legend { font-size: 12.5px; font-weight: 600; color: #374151; padding: 0 4px; }
+.rbfw-cpn-grid-items { display: flex; flex-direction: column; gap: 2px; max-height: 168px; overflow-y: auto; }
+.rbfw-cpn-chk { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: #3D4A5C; padding: 3px 0; cursor: pointer; }
+.rbfw-cpn-none { color: #9CA3AF; font-size: 12px; }
+
+/* ── Review step ───────────────────────────────────────────────── */
+.rbfw-cpn-review { display: flex; flex-direction: column; gap: 10px; }
+.rbfw-cpn-rev-group {
+	border: 1px solid #E2E5E9; border-radius: 10px; overflow: hidden; background: #fff;
+}
+.rbfw-cpn-rev-group h4 {
+	margin: 0; padding: 10px 14px; background: #F8FAFC;
+	font-size: 12px; font-weight: 700; color: #64748B;
+	text-transform: uppercase; letter-spacing: .05em;
+	border-bottom: 1px solid var(--cpn-line);
+}
+.rbfw-cpn-rev-row {
+	display: flex; justify-content: space-between; gap: 16px;
+	padding: 9px 14px; font-size: 12.5px; border-bottom: 1px solid #F6F7F9;
+}
+.rbfw-cpn-rev-row:last-child { border-bottom: none; }
+.rbfw-cpn-rev-row span { color: var(--cpn-muted); flex-shrink: 0; }
+.rbfw-cpn-rev-row b { color: var(--cpn-heading); font-weight: 600; text-align: right; word-break: break-word; }
+
+/* ── Footer ────────────────────────────────────────────────────── */
+.rbfw-cpn-modal-foot {
+	display: flex; align-items: center; gap: 14px;
+	padding: 14px 24px; border-top: 1px solid #EDF0F3; background: #FAFBFC;
+}
+.rbfw-cpn-nav { margin-left: auto; display: flex; gap: 8px; }
+.rbfw-cpn-msg { font-size: 12.5px; font-weight: 500; }
+.rbfw-cpn-msg.ok  { color: #166534; }
+.rbfw-cpn-msg.err { color: #B42318; }
+
+/* inline per-field validation error (shown directly under the field) */
+.rbfw-cpn-fielderr {
+	display: flex; align-items: center; gap: 5px;
+	color: #B42318; font-size: 11.5px; font-weight: 500; margin-top: 5px;
+}
+.rbfw-cpn-fielderr::before { content: "\f06a"; font-family: "Font Awesome 6 Free"; font-weight: 900; font-size: 11px; }
+
+/* ── Token multi-select (click → dropdown → chips) ─────────────── */
+.rbfw-tok-native { display: none !important; }        /* still serializes; just hidden */
+.rbfw-tok { position: relative; }
+.rbfw-tok-control {
+	display: flex; flex-wrap: wrap; align-items: center; gap: 5px;
+	min-height: 40px; padding: 5px 8px;
+	border: 1.5px solid #D5D9DE; border-radius: 8px; background: #fff; cursor: text;
+	transition: border-color .15s ease, box-shadow .15s ease;
+}
+.rbfw-tok.is-open .rbfw-tok-control { border-color: var(--cpn-accent); box-shadow: 0 0 0 3px rgba(34,113,177,.12); }
+.rbfw-tok-chip {
+	display: inline-flex; align-items: center; gap: 6px;
+	background: #EEF4FB; color: #1E5C8F; border: 1px solid #CFE0F0;
+	border-radius: 6px; padding: 3px 6px 3px 9px; font-size: 12px; font-weight: 600; max-width: 100%;
+}
+.rbfw-tok.is-ex .rbfw-tok-chip { background: #FDECEC; color: #B42318; border-color: #F4CFCF; }
+.rbfw-tok-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rbfw-tok-chip b {
+	cursor: pointer; font-weight: 700; font-size: 14px; line-height: 1;
+	color: inherit; opacity: .7;
+}
+.rbfw-tok-chip b:hover { opacity: 1; }
+.rbfw-tok-search {
+	flex: 1; min-width: 90px; border: none !important; outline: none !important;
+	box-shadow: none !important; padding: 4px 2px !important; font-size: 13px; background: transparent;
+}
+.rbfw-tok-caret { color: #8A94A6; font-size: 12px; margin-left: auto; padding: 0 2px; pointer-events: none; }
+.rbfw-tok-menu {
+	position: absolute; z-index: 20; left: 0; right: 0; top: calc(100% + 4px);
+	max-height: 220px; overflow-y: auto; background: #fff;
+	border: 1px solid #E2E5E9; border-radius: 8px; box-shadow: 0 12px 28px rgba(16,24,40,.16);
+	padding: 5px;
+}
+.rbfw-tok-menu[hidden] { display: none; }
+.rbfw-tok-opt {
+	display: flex; align-items: center; gap: 8px;
+	padding: 8px 10px; border-radius: 6px; font-size: 12.5px; color: #3D4A5C; cursor: pointer;
+}
+.rbfw-tok-opt:hover, .rbfw-tok-opt.is-active { background: #EEF4FB; color: #1E5C8F; }
+.rbfw-tok.is-ex .rbfw-tok-opt:hover, .rbfw-tok.is-ex .rbfw-tok-opt.is-active { background: #FDECEC; color: #B42318; }
+.rbfw-tok-opt.is-picked { display: none; }            /* hide already-selected options */
+.rbfw-tok-empty { padding: 10px; text-align: center; color: #9CA3AF; font-size: 12px; }
+.rbfw-tok-empty[hidden] { display: none; }
+
+/* ── Responsive ────────────────────────────────────────────────── */
+@media (max-width: 860px) {
+	.rbfw-cpn-modal-body { flex-direction: column; }
+	.rbfw-cpn-rail {
+		width: 100%; flex-direction: row; overflow-x: auto;
+		border-right: none; border-bottom: 1px solid #EDF0F3; padding: 10px;
+	}
+	.rbfw-cpn-railitem { flex-shrink: 0; }
+	.rbfw-cpn-railtxt { display: none; }
+	.rbfw-cpn-panes { max-height: none; }
+	.rbfw-cpn-panel-head { flex-wrap: wrap; }
+	.rbfw-cpn-btn-add { margin-left: 0; }
+	.rbfw-cpn-table thead { display: none; }
+	.rbfw-cpn-table td { display: block; border: none; padding: 6px 16px; }
+	.rbfw-cpn-table tbody tr { display: block; border-bottom: 1px solid var(--cpn-line); padding: 10px 0; }
+	.rbfw-cpn-table .ta-r { text-align: left; }
+}

--- a/admin/js/mkb-admin.js
+++ b/admin/js/mkb-admin.js
@@ -522,6 +522,11 @@
 
             }
 
+            // Return-date release applies only to date-range rentals; hide it for
+            // Single Day and Appointment. (The multiple-item section is handled per
+            // branch above via .rbfw_switch_md_type_item_qty.)
+            jQuery('.rbfw_stock_return_date_section').toggle(item_type !== 'bike_car_sd' && item_type !== 'appointment');
+
             // Extra service sections: one category per rental type (on type change).
             window.rbfwUpdateExtraServiceSectionVisibility(item_type);
 

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -2178,6 +2178,14 @@
             var _invShow = (type !== 'resort' && type !== 'appointment');
             $pricing.find('.rbfw-me-inventory-card').toggleClass('rbfw-me-hidden', !_invShow);
 
+            // Inventory sub-sections that only apply to specific rent types:
+            //  - Return-date release: date-range rentals only (hide for Single Day & Appointment).
+            //  - Multiple-item selection: multi-day Bike/Car, Dress, Equipment & Others only.
+            $pricing.find('.rbfw_stock_return_date_section').toggle(type !== 'bike_car_sd' && type !== 'appointment');
+            $pricing.find('.rbfw_switch_md_type_item_qty').toggle(
+                type === 'bike_car_md' || type === 'dress' || type === 'equipment' || type === 'others'
+            );
+
             // Location card (Advanced step): available for every rent type
             // ( multi-location feature ).
             $wrap.find('.rbfw-me-location-card').removeClass('rbfw-me-hidden');

--- a/admin/js/rbfw_coupon_admin.js
+++ b/admin/js/rbfw_coupon_admin.js
@@ -1,0 +1,492 @@
+/**
+ * Coupons manager — multi-step wizard.
+ *
+ * Field names are identical to the flat form the AJAX handler already validates
+ * (RBFW_Coupon_Admin::ajax_save), so the wizard is purely a presentation layer: it
+ * serializes the whole <form> in one go regardless of which step is visible.
+ */
+(function ($) {
+	'use strict';
+
+	var STEPS = 5;
+	var LAST = STEPS - 1;
+
+	var $modal, $form, $rail, $panes, $progress, $msg, $prev, $next, $save, $caption;
+	var step = 0;
+
+	function t(key, fallback) {
+		return (typeof rbfwCoupon !== 'undefined' && rbfwCoupon[key]) ? rbfwCoupon[key] : fallback;
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Step navigation                                                      */
+	/* ------------------------------------------------------------------ */
+
+	function captionFor(i) {
+		var $item = $rail.find('.rbfw-cpn-railitem').eq(i);
+		var title = $item.find('strong').text();
+		return 'Step ' + (i + 1) + ' of ' + STEPS + ' · ' + title;
+	}
+
+	function paint() {
+		$panes.find('.rbfw-cpn-pane').removeClass('is-active')
+			.filter('[data-pane="' + step + '"]').addClass('is-active');
+
+		$rail.find('.rbfw-cpn-railitem').each(function (i) {
+			$(this).toggleClass('is-active', i === step)
+				   .toggleClass('is-done', i < step);
+		});
+
+		$progress.find('i').css('width', (((step + 1) / STEPS) * 100) + '%');
+		$caption.text(captionFor(step));
+
+		$prev.prop('disabled', step === 0);
+		$next.prop('hidden', step === LAST);
+		$save.prop('hidden', step !== LAST);
+
+		$panes.scrollTop(0);
+	}
+
+	function go(target) {
+		if (target > step) {
+			// Validate every step between here and the target.
+			for (var i = step; i < target; i++) {
+				if (!validateStep(i)) { step = i; paint(); return; }
+			}
+		}
+		step = Math.max(0, Math.min(LAST, target));
+		if (step === LAST) buildReview();
+		paint();
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Validation (mirrors the server-side rules in ajax_save)              */
+	/* ------------------------------------------------------------------ */
+
+	/** Show a validation error directly UNDER the offending field (not in the footer). */
+	function fail($el, message) {
+		clearFieldErrors();
+		if ($el && $el.length) {
+			$el.addClass('has-error');
+			var $label = $el.closest('label');
+			var $err = $('<span class="rbfw-cpn-fielderr" role="alert"></span>').text(message);
+			($label.length ? $label : $el).append($err);
+			$el.one('input change', clearFieldErrors);
+			try { $el.trigger('focus'); } catch (e) {}
+		}
+		return false;
+	}
+
+	function clearFieldErrors() {
+		$form.find('.rbfw-cpn-fielderr').remove();
+		$form.find('.has-error').removeClass('has-error');
+	}
+
+	function validateStep(i) {
+		setMsg('', '');
+		clearFieldErrors();
+		if (i !== 0) return true;
+
+		var $code = $form.find('[name=code]');
+		if (!$.trim($code.val())) return fail($code, t('i18n_need_code', 'Please enter a coupon code.'));
+
+		var $val = $form.find('[name=discount_value]');
+		var v = parseFloat($val.val());
+		if (isNaN(v) || v <= 0) return fail($val, t('i18n_need_val', 'Enter a discount value greater than zero.'));
+
+		if (typeVal() === 'percentage' && v > 100) return fail($val, t('i18n_pct_max', 'A percentage discount cannot exceed 100%.'));
+
+		return true;
+	}
+
+	function setMsg(text, cls) {
+		$msg.removeClass('ok err').addClass(cls || '').text(text || '');
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Type-dependent UI                                                    */
+	/* ------------------------------------------------------------------ */
+
+	function typeVal() {
+		return $form.find('[name=discount_type]:checked').val() || 'percentage';
+	}
+
+	function syncType() {
+		var type = typeVal();
+		$('#rbfw-cpn-cap-wrap').toggle(type === 'percentage');
+
+		var label = 'Value';
+		if (type === 'percentage') label = 'Percentage (%)';
+		else if (type === 'fixed') label = 'Amount (' + t('currency', '') + ')';
+		else if (type === 'free_days') label = 'Free days / hours';
+		$form.find('[data-value-label]').html(label + ' <b class="req">*</b>');
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Review step                                                          */
+	/* ------------------------------------------------------------------ */
+
+	function checkedLabels(name) {
+		var out = [];
+		$form.find('[name="' + name + '[]"]:checked').each(function () {
+			out.push($.trim($(this).next('span').text()));
+		});
+		return out;
+	}
+
+	function selectedLabels(name) {
+		var out = [];
+		$form.find('select[name="' + name + '[]"] option:selected').each(function () {
+			out.push($.trim($(this).text()));
+		});
+		return out;
+	}
+
+	function val(name) { return $.trim($form.find('[name="' + name + '"]').val() || ''); }
+	function on(name) { return $form.find('[name="' + name + '"]').is(':checked'); }
+
+	function group(title, rows) {
+		var visible = rows.filter(function (r) { return r[1] !== ''; });
+		if (!visible.length) return '';
+		var html = '<div class="rbfw-cpn-rev-group"><h4>' + title + '</h4>';
+		visible.forEach(function (r) {
+			html += '<div class="rbfw-cpn-rev-row"><span>' + r[0] + '</span><b>' + $('<i>').text(r[1]).html() + '</b></div>';
+		});
+		return html + '</div>';
+	}
+
+	function buildReview() {
+		var type = typeVal();
+		var v = val('discount_value');
+		var amount = type === 'percentage' ? v + '%'
+			: type === 'fixed' ? t('currency', '') + v
+			: v + ' day(s)';
+
+		var ALL = t('i18n_all', 'All rentals');
+		var NONE = t('i18n_none', 'None');
+		var UNL = t('i18n_unlimited', 'Unlimited');
+
+		var inc = selectedLabels('target_items').concat(selectedLabels('target_rent_types')).concat(selectedLabels('target_locations'));
+		var exc = selectedLabels('exclude_items').concat(selectedLabels('exclude_rent_types')).concat(selectedLabels('exclude_locations'));
+
+		var from = val('valid_from'), to = val('valid_to');
+		var validity = (from || to) ? ((from || '…') + ' → ' + (to || '…')) : t('i18n_always', 'Always');
+
+		var days = checkedLabels('weekdays');
+		var roles = checkedLabels('allowed_roles');
+
+		var html = '';
+		html += group('Basics', [
+			['Code', val('code').toUpperCase()],
+			['Status', $form.find('[name=status]').val() === 'publish' ? 'Active' : 'Inactive'],
+			['Discount', amount],
+			['Max discount cap', (type === 'percentage' && val('max_discount') && val('max_discount') !== '0') ? t('currency', '') + val('max_discount') : ''],
+			['Applies automatically', on('auto_apply') ? 'Yes (no code needed)' : 'No — code required'],
+			['Priority', on('auto_apply') ? (val('priority') || '0') : ''],
+			['Stacking', on('allow_combine') ? 'Can combine with other coupons' : 'Cannot be combined']
+		]);
+		html += group('Targeting', [
+			['Includes', inc.length ? inc.join(', ') : ALL],
+			['Excludes', exc.length ? exc.join(', ') : NONE]
+		]);
+		html += group('Spend & date rules', [
+			['Minimum amount', (val('min_amount') && val('min_amount') !== '0') ? t('currency', '') + val('min_amount') : ''],
+			['Maximum amount', (val('max_amount') && val('max_amount') !== '0') ? t('currency', '') + val('max_amount') : ''],
+			['Validity', validity],
+			['Allowed weekdays', days.length ? days.join(', ') : 'Every day'],
+			['Blackout dates', val('blackout_dates')]
+		]);
+		html += group('Limits & eligibility', [
+			['Total uses', (val('usage_limit') && val('usage_limit') !== '0') ? val('usage_limit') : UNL],
+			['Per user', (val('usage_limit_per_user') && val('usage_limit_per_user') !== '0') ? val('usage_limit_per_user') : UNL],
+			['Per day', (val('usage_limit_per_day') && val('usage_limit_per_day') !== '0') ? val('usage_limit_per_day') : UNL],
+			['Allowed roles', roles.length ? roles.join(', ') : t('i18n_everyone', 'Everyone')],
+			['Allowed emails', val('allowed_emails')],
+			['First booking only', on('first_booking_only') ? 'Yes' : '']
+		]);
+
+		$('#rbfw-cpn-review').html(html);
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Open / populate                                                      */
+	/* ------------------------------------------------------------------ */
+
+	function setChecks(name, values) {
+		values = (values || []).map(String);
+		$form.find('[name="' + name + '[]"]').each(function () {
+			$(this).prop('checked', values.indexOf(String($(this).val())) !== -1);
+		});
+	}
+
+	function setMulti(name, values) {
+		values = (values || []).map(String);
+		$form.find('select[name="' + name + '[]"] option').each(function () {
+			$(this).prop('selected', values.indexOf(String($(this).val())) !== -1);
+		});
+	}
+
+	function open(data) {
+		data = data || {};
+
+		$form[0].reset();
+		$form.find('input[type=checkbox]').prop('checked', false);
+		$form.find('select[multiple] option').prop('selected', false);
+		$form.find('.has-error').removeClass('has-error');
+		setMsg('', '');
+
+		$('#rbfw-cpn-modal-title').text(data.id ? t('i18n_edit', 'Edit Coupon') : t('i18n_add', 'Add Coupon'));
+		$form.find('[name=coupon_id]').val(data.id || 0);
+
+		['code', 'status', 'discount_value', 'max_discount', 'priority',
+		 'min_amount', 'max_amount', 'valid_from', 'valid_to', 'blackout_dates',
+		 'usage_limit', 'usage_limit_per_user', 'usage_limit_per_day', 'allowed_emails'
+		].forEach(function (k) {
+			if (data[k] !== undefined && data[k] !== null) $form.find('[name="' + k + '"]').val(data[k]);
+		});
+
+		$form.find('[name=discount_type][value="' + (data.discount_type || 'percentage') + '"]').prop('checked', true);
+
+		['auto_apply', 'allow_combine', 'first_booking_only'].forEach(function (k) {
+			$form.find('[name="' + k + '"]').prop('checked', data[k] === 'yes');
+		});
+
+		// Targeting fields are all <select multiple> (token pickers).
+		setMulti('target_items', data.target_items);
+		setMulti('exclude_items', data.exclude_items);
+		setMulti('target_rent_types', data.target_rent_types);
+		setMulti('exclude_rent_types', data.exclude_rent_types);
+		setMulti('target_locations', data.target_locations);
+		setMulti('exclude_locations', data.exclude_locations);
+		// Weekdays + roles stay checkbox grids.
+		setChecks('weekdays', data.weekdays);
+		setChecks('allowed_roles', data.allowed_roles);
+
+		clearFieldErrors();
+		Tokens.refreshAll();   // repaint chips from the native selects we just set
+
+		syncType();
+		step = 0;
+		paint();
+		$modal.addClass('is-open').attr('aria-hidden', 'false');
+		setTimeout(function () { $form.find('[name=code]').trigger('focus'); }, 60);
+	}
+
+	function close() {
+		$modal.removeClass('is-open').attr('aria-hidden', 'true');
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Persistence                                                          */
+	/* ------------------------------------------------------------------ */
+
+	function save() {
+		for (var i = 0; i < STEPS; i++) {
+			if (!validateStep(i)) { step = i; paint(); return; }
+		}
+
+		var data = $form.serializeArray();
+		data.push({ name: 'action', value: 'rbfw_coupon_save' });
+		data.push({ name: 'nonce', value: rbfwCoupon.nonce });
+
+		$save.prop('disabled', true);
+		setMsg('', '');
+
+		$.post(rbfwCoupon.ajaxurl, data, function (res) {
+			if (res && res.success) {
+				setMsg(res.data.message, 'ok');
+				setTimeout(function () { window.location.reload(); }, 500);
+			} else {
+				setMsg((res && res.data && res.data.message) ? res.data.message : 'Error', 'err');
+				$save.prop('disabled', false);
+			}
+		}).fail(function () {
+			setMsg(t('i18n_network', 'Network error. Please try again.'), 'err');
+			$save.prop('disabled', false);
+		});
+	}
+
+	function rowAction(action, id) {
+		$.post(rbfwCoupon.ajaxurl, { action: action, nonce: rbfwCoupon.nonce, coupon_id: id }, function () {
+			window.location.reload();
+		});
+	}
+
+	/* ------------------------------------------------------------------ */
+	/* Token multi-select (click → searchable dropdown → chips)             */
+	/*                                                                      */
+	/* The native <select multiple> stays in the DOM as the single source   */
+	/* of truth (so serializeArray keeps posting name[] unchanged); this    */
+	/* only paints chips + a filterable menu over it.                       */
+	/* ------------------------------------------------------------------ */
+
+	var Tokens = (function () {
+
+		function build($sel) {
+			if ($sel.data('tokBound')) return;
+			$sel.data('tokBound', true);
+
+			var placeholder = $sel.data('placeholder') || '';
+			var emptyText   = $sel.data('empty') || 'No matches';
+			var isEx        = /(^|_)exclude/.test($sel.attr('name') || '');
+
+			var $tok     = $('<div class="rbfw-tok"></div>').toggleClass('is-ex', isEx);
+			var $control = $('<div class="rbfw-tok-control"></div>');
+			var $search  = $('<input type="text" class="rbfw-tok-search" autocomplete="off">');
+			var $caret   = $('<i class="fas fa-chevron-down rbfw-tok-caret"></i>');
+			var $menu    = $('<div class="rbfw-tok-menu" hidden></div>');
+			var $empty   = $('<div class="rbfw-tok-empty" hidden></div>').text(emptyText);
+
+			$sel.find('option').each(function () {
+				$('<div class="rbfw-tok-opt"></div>')
+					.attr('data-value', $(this).attr('value'))
+					.text($(this).text())
+					.appendTo($menu);
+			});
+			$menu.append($empty);
+			$control.append($search).append($caret);
+			$tok.append($control).append($menu);
+			$sel.after($tok);
+
+			function setSelected(value, on) {
+				$sel.find('option').each(function () {
+					if ($(this).attr('value') === String(value)) $(this).prop('selected', on);
+				});
+			}
+
+			function filter(q) {
+				q = (q || '').toLowerCase();
+				var visible = 0;
+				$menu.find('.rbfw-tok-opt').each(function () {
+					var $o = $(this);
+					var match = !$o.hasClass('is-picked') && $o.text().toLowerCase().indexOf(q) !== -1;
+					$o.toggle(match);
+					if (match) visible++;
+				});
+				$empty.prop('hidden', visible > 0);
+			}
+
+			function repaint() {
+				$control.find('.rbfw-tok-chip').remove();
+				var picked = {};
+				$sel.find('option:selected').each(function () {
+					var $o = $(this);
+					picked[$o.attr('value')] = 1;
+					var $chip = $('<span class="rbfw-tok-chip"></span>').data('value', $o.attr('value'));
+					$('<span></span>').text($o.text()).appendTo($chip);
+					$('<b aria-hidden="true">&times;</b>').appendTo($chip);
+					$search.before($chip);
+				});
+				$menu.find('.rbfw-tok-opt').each(function () {
+					$(this).toggleClass('is-picked', !!picked[$(this).attr('data-value')]);
+				});
+				$search.attr('placeholder', $control.find('.rbfw-tok-chip').length ? '' : placeholder);
+				filter($search.val());
+			}
+
+			function openMenu() { $tok.addClass('is-open'); $menu.prop('hidden', false); filter($search.val()); }
+			function closeMenu() { $tok.removeClass('is-open'); $menu.prop('hidden', true); }
+
+			function pick(value) { setSelected(value, true); $search.val(''); repaint(); $sel.trigger('change'); }
+			function unpick(value) { setSelected(value, false); repaint(); $sel.trigger('change'); }
+
+			$control.on('click', function (e) {
+				if ($(e.target).closest('.rbfw-tok-chip b').length) return;
+				$search.trigger('focus');
+			});
+			$search.on('focus', openMenu);
+			$search.on('input', function () { openMenu(); filter($(this).val()); });
+			$menu.on('click', '.rbfw-tok-opt', function () {
+				if (!$(this).hasClass('is-picked')) { pick($(this).attr('data-value')); $search.trigger('focus'); }
+			});
+			$control.on('click', '.rbfw-tok-chip b', function (e) {
+				e.stopPropagation();
+				unpick($(this).closest('.rbfw-tok-chip').data('value'));
+			});
+			$search.on('keydown', function (e) {
+				if (e.key === 'Enter') {
+					e.preventDefault(); e.stopPropagation();   // never let the wizard advance
+					var $first = $menu.find('.rbfw-tok-opt:visible').first();
+					if ($first.length) pick($first.attr('data-value'));
+				} else if (e.key === 'Escape') {
+					e.stopPropagation(); closeMenu();
+				} else if (e.key === 'Backspace' && !$search.val()) {
+					var $last = $control.find('.rbfw-tok-chip').last();
+					if ($last.length) unpick($last.data('value'));
+				}
+			});
+
+			$sel.data('tokRefresh', repaint);
+			repaint();
+		}
+
+		$(document).on('click', function (e) {
+			if (!$(e.target).closest('.rbfw-tok').length) {
+				$('.rbfw-tok').removeClass('is-open').find('.rbfw-tok-menu').prop('hidden', true);
+			}
+		});
+
+		return {
+			init: function () { $('#rbfw-cpn-form select[data-token]').each(function () { build($(this)); }); },
+			refreshAll: function () {
+				$('#rbfw-cpn-form select[data-token]').each(function () {
+					var fn = $(this).data('tokRefresh');
+					if (fn) fn();
+				});
+			}
+		};
+	})();
+
+	/* ------------------------------------------------------------------ */
+	/* Boot                                                                 */
+	/* ------------------------------------------------------------------ */
+
+	$(function () {
+		$modal = $('#rbfw-cpn-modal');
+		if (!$modal.length) return;
+
+		$form     = $('#rbfw-cpn-form');
+		$rail     = $modal.find('.rbfw-cpn-rail');
+		$panes    = $modal.find('.rbfw-cpn-panes');
+		$progress = $modal.find('.rbfw-cpn-progress');
+		$msg      = $modal.find('.rbfw-cpn-msg');
+		$prev     = $modal.find('[data-prev]');
+		$next     = $modal.find('[data-next]');
+		$save     = $modal.find('[data-save]');
+		$caption  = $modal.find('.rbfw-cpn-stepcaption');
+
+		Tokens.init();
+
+		$(document).on('click', '.rbfw-cpn-add', function () { open({}); });
+		$(document).on('click', '.rbfw-cpn-edit', function () { open($(this).closest('tr').data('coupon')); });
+		$(document).on('click', '.rbfw-cpn-close', close);
+
+		$modal.on('click', function (e) { if (e.target === this) close(); });
+		$(document).on('keydown', function (e) {
+			if (e.key === 'Escape' && $modal.hasClass('is-open')) close();
+		});
+
+		$next.on('click', function () { go(step + 1); });
+		$prev.on('click', function () { go(step - 1); });
+		$save.on('click', save);
+		$rail.on('click', '.rbfw-cpn-railitem', function () { go(parseInt($(this).data('step'), 10)); });
+
+		$form.on('change', '[name=discount_type]', syncType);
+
+		// A stray Enter must advance the wizard, never submit the form.
+		$form.on('submit', function (e) { e.preventDefault(); });
+		$form.on('keydown', 'input', function (e) {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				if (step === LAST) save(); else go(step + 1);
+			}
+		});
+
+		$(document).on('click', '.rbfw-cpn-toggle', function () { rowAction('rbfw_coupon_toggle', $(this).data('id')); });
+		$(document).on('click', '.rbfw-cpn-delete', function () {
+			if (window.confirm(t('i18n_confirm', 'Delete this coupon permanently?'))) {
+				rowAction('rbfw_coupon_delete', $(this).data('id'));
+			}
+		});
+	});
+})(jQuery);

--- a/admin/settings/Inventory.php
+++ b/admin/settings/Inventory.php
@@ -230,9 +230,13 @@
 
                 $stock_manage_on_return_date = get_post_meta( $post_id, 'stock_manage_on_return_date', true ) ? get_post_meta( $post_id, 'stock_manage_on_return_date', true ) : 'no';
 
+                // Return-date inventory release only applies to date-range (multi-day) rentals.
+                // Hide it for Single Day and Appointment, which have no scheduled return date.
+                $rbfw_item_type = get_post_meta( $post_id, 'rbfw_item_type', true ) ? get_post_meta( $post_id, 'rbfw_item_type', true ) : 'bike_car_sd';
+                $hide_return    = in_array( $rbfw_item_type, array( 'bike_car_sd', 'appointment' ), true );
 
                 ?>
-                    <section>
+                    <section class="rbfw_stock_return_date_section"<?php echo $hide_return ? ' style="display:none"' : ''; ?>>
                         <div>
                             <label for="">Inventory Management by Return Date</label>
                             <p>(Items become available for booking again on the scheduled return date.)</p>
@@ -252,8 +256,13 @@
 
 			public function quantity_box_toggle( $post_id ) {
 				$rbfw_enable_md_type_item_qty = get_post_meta( $post_id, 'rbfw_enable_md_type_item_qty', true ) ? get_post_meta( $post_id, 'rbfw_enable_md_type_item_qty', true ) : 'no';
+
+				// Multiple-item selection only works for multi-day Bike/Car, Dress, Equipment & Others.
+				// Hide it for every other type (Single Day, Appointment, Resort, Multiple Items).
+				$rbfw_item_type = get_post_meta( $post_id, 'rbfw_item_type', true ) ? get_post_meta( $post_id, 'rbfw_item_type', true ) : 'bike_car_sd';
+				$show_multi     = in_array( $rbfw_item_type, array( 'bike_car_md', 'dress', 'equipment', 'others' ), true );
 				?>
-                <section>
+                <section class="rbfw_switch_md_type_item_qty"<?php echo $show_multi ? '' : ' style="display:none"'; ?>>
                     <div>
                         <label><?php esc_html_e( 'Enable Multiple Item Choosing Option', 'booking-and-rental-manager-for-woocommerce' ); ?></label>
                         <p><?php esc_html_e( 'It enables the multiple item quantity selection option. It will work when the type is Bike/Car for multiple day, Dress, Equipment & Others.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>

--- a/admin/settings/RBFW_Coupon_Settings.php
+++ b/admin/settings/RBFW_Coupon_Settings.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * "Coupons" tab on the Rental global settings page.
+ *
+ * Registers the tab via rbfw_settings_sec_reg and its fields via rbfw_settings_field (the same
+ * pattern RBFW_Payment_Settings uses). The section id IS the wp_option row name, so everything
+ * lands in `rbfw_coupon_settings` — which is exactly what RBFW_Coupon_Engine::is_enabled() and
+ * ::setting() read.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Settings' ) ) :
+	class RBFW_Coupon_Settings {
+
+		const OPTION = 'rbfw_coupon_settings';
+
+		public function __construct() {
+			add_filter( 'rbfw_settings_sec_reg', array( $this, 'register_section' ), 16 );
+			add_filter( 'rbfw_settings_field', array( $this, 'register_fields' ), 16 );
+		}
+
+		public function register_section( $sections ) {
+			$sections[] = array(
+				'id'    => self::OPTION,
+				'title' => '<i class="fas fa-ticket"></i>' . esc_html__( 'Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+			);
+			return $sections;
+		}
+
+		public function register_fields( $settings_fields ) {
+			$manage_url = admin_url( 'edit.php?post_type=rbfw_item&page=rbfw_coupons' );
+
+			$settings_fields[ self::OPTION ] = array(
+				array(
+					'name'    => 'rbfw_coupon_enable',
+					'label'   => __( 'Enable Coupon Engine', 'booking-and-rental-manager-for-woocommerce' ),
+					'desc'    => __( 'Turn the coupon &amp; automatic-discount engine on. Works in both WooCommerce and Standalone booking modes.', 'booking-and-rental-manager-for-woocommerce' ),
+					'type'    => 'checkbox',
+					'default' => 'on',
+				),
+				array(
+					'name'     => 'rbfw_coupon_manage_link',
+					'label'    => __( 'Manage Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+					'type'     => 'html',
+					'desc'     => '<a class="button button-primary" href="' . esc_url( $manage_url ) . '">'
+						. esc_html__( 'Open Coupons Manager', 'booking-and-rental-manager-for-woocommerce' ) . '</a>'
+						. '<p style="margin:8px 0 0;color:#6b7280;font-size:12px;">'
+						. esc_html__( 'Create coupon codes and automatic discount rules, with per-rental targeting, date/spend conditions and usage limits.', 'booking-and-rental-manager-for-woocommerce' )
+						. '</p>',
+				),
+				array(
+					'name'    => 'rbfw_coupon_label',
+					'label'   => __( 'Coupon Field Label', 'booking-and-rental-manager-for-woocommerce' ),
+					'desc'    => __( 'Shown above the coupon input on the booking form / cart.', 'booking-and-rental-manager-for-woocommerce' ),
+					'type'    => 'text',
+					'default' => __( 'Have a coupon?', 'booking-and-rental-manager-for-woocommerce' ),
+				),
+				array(
+					'name'    => 'rbfw_coupon_placeholder',
+					'label'   => __( 'Coupon Field Placeholder', 'booking-and-rental-manager-for-woocommerce' ),
+					'type'    => 'text',
+					'default' => __( 'Enter coupon code', 'booking-and-rental-manager-for-woocommerce' ),
+				),
+				array(
+					'name'    => 'rbfw_coupon_show_field',
+					'label'   => __( 'Show Coupon Field', 'booking-and-rental-manager-for-woocommerce' ),
+					'desc'    => __( 'Where customers can enter a code. Automatic (no-code) discounts always apply regardless of this setting.', 'booking-and-rental-manager-for-woocommerce' ),
+					'type'    => 'select',
+					'default' => 'yes',
+					'options' => array(
+						'yes' => __( 'Yes — show the coupon field', 'booking-and-rental-manager-for-woocommerce' ),
+						'no'  => __( 'No — automatic discounts only', 'booking-and-rental-manager-for-woocommerce' ),
+					),
+				),
+				array(
+					'name'    => 'rbfw_coupon_default_combine',
+					'label'   => __( 'Allow Stacking by Default', 'booking-and-rental-manager-for-woocommerce' ),
+					'desc'    => __( 'Pre-tick "Allow combining with other coupons" when creating a new coupon. Each coupon still controls its own stacking.', 'booking-and-rental-manager-for-woocommerce' ),
+					'type'    => 'checkbox',
+					'default' => 'off',
+				),
+			);
+
+			return $settings_fields;
+		}
+	}
+
+	new RBFW_Coupon_Settings();
+endif;

--- a/assets/mp_script/rbfw_coupon.js
+++ b/assets/mp_script/rbfw_coupon.js
@@ -1,0 +1,248 @@
+/**
+ * Unified coupon field.
+ *
+ * Works in both booking modes, choosing its endpoint from rbfw_ajax_front.booking_mode:
+ *   - standalone -> rbfw_apply_coupon_native (validate + preview only; the authoritative
+ *                   recompute happens server-side in RBFW_Native_Checkout::process()).
+ *   - woocommerce -> rbfw_apply_coupon / rbfw_remove_coupon (stores the code in the WC session,
+ *                   then reloads so WooCommerce re-renders totals from the reduced line prices).
+ *
+ * IMPORTANT: this script never rewrites the `.total` element. rbfw_native_checkout.js reads it
+ * and posts it as `rbfw_total`; discounting it here would double-apply the coupon. The saving is
+ * shown in the coupon's own summary row, and exposed on window.rbfwCouponState so the native
+ * checkout modal can display the discounted figure.
+ */
+(function ($) {
+	'use strict';
+
+	window.rbfwCouponState = { code: '', discount: 0 };
+
+	function vars() {
+		return typeof rbfw_coupon_vars !== 'undefined' ? rbfw_coupon_vars : null;
+	}
+
+	function isStandalone() {
+		return typeof rbfw_ajax_front !== 'undefined' && rbfw_ajax_front.booking_mode === 'standalone';
+	}
+
+	/** Prefer the shared nonce bag so the cache-safe nonce-refresh guard can renew it. */
+	function nonce() {
+		if (typeof rbfw_ajax_front !== 'undefined' && rbfw_ajax_front.nonce_apply_coupon) {
+			return rbfw_ajax_front.nonce_apply_coupon;
+		}
+		var v = vars();
+		return v ? v.nonce : '';
+	}
+
+	function ajaxUrl() {
+		if (typeof rbfw_ajax_front !== 'undefined' && rbfw_ajax_front.rbfw_ajaxurl) {
+			return rbfw_ajax_front.rbfw_ajaxurl;
+		}
+		var v = vars();
+		return v ? v.ajaxurl : '';
+	}
+
+	function readNumber($el) {
+		if (!$el || !$el.length) return 0;
+		var n = parseFloat(($el.text() || '0').replace(/[^0-9.]/g, ''));
+		return isNaN(n) ? 0 : n;
+	}
+
+	function formOf($wrap) {
+		return $wrap.closest('.mp_rbfw_ticket_form');
+	}
+
+	/** The booking subtotal (rental + services), falling back to the grand total. */
+	function readSubtotal($form) {
+		var $s = $form.find('.subtotal .price-figure').first();
+		if (!$s.length) $s = $form.find('.subtotal span').first();
+		if (!$s.length) $s = $form.find('.total .price-figure').first();
+		return readNumber($s);
+	}
+
+	function readTotal($form) {
+		var $t = $form.find('.total .price-figure').first();
+		if (!$t.length) $t = $form.find('.total span').first();
+		return readNumber($t);
+	}
+
+	function setMsg($wrap, text, type) {
+		$wrap.find('.rbfw-coupon__msg')
+			.removeClass('is-error is-success')
+			.addClass(type ? 'is-' + type : '')
+			.text(text || '');
+	}
+
+	function showSummary($wrap, code, discountHtml, totalHtml) {
+		var v = vars() || {};
+		var tpl = v.i18n_saved || 'Coupon %1$s applied — you save %2$s';
+		var txt = tpl.replace('%1$s', code).replace('%2$s', discountHtml);
+		if (totalHtml) {
+			txt += ' · ' + (v.i18n_new_total || 'New total:') + ' ' + totalHtml;
+		}
+		$wrap.find('.rbfw-coupon__applied').text(txt);
+		$wrap.find('.rbfw-coupon__summary').prop('hidden', false);
+	}
+
+	function clearSummary($wrap) {
+		$wrap.find('.rbfw-coupon__applied').text('');
+		$wrap.find('.rbfw-coupon__summary').prop('hidden', true);
+	}
+
+	function busy($wrap, on) {
+		$wrap.find('.rbfw-coupon__apply, .rbfw-coupon__remove').prop('disabled', !!on);
+		$wrap.toggleClass('is-busy', !!on);
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Standalone
+	 * ------------------------------------------------------------------ */
+
+	function nativeRequest($wrap, code, isPreview) {
+		var $form = formOf($wrap);
+		if (!$form.length) return null;
+
+		var data = $form.serializeArray();
+		data.push({ name: 'action', value: 'rbfw_apply_coupon_native' });
+		data.push({ name: 'nonce', value: nonce() });
+		data.push({ name: 'code', value: code });
+		data.push({ name: 'preview', value: isPreview ? '1' : '0' });
+		data.push({ name: 'rbfw_subtotal', value: readSubtotal($form) });
+		data.push({ name: 'rbfw_total', value: readTotal($form) });
+		return $.post(ajaxUrl(), data);
+	}
+
+	function nativeApply($wrap, code, isPreview) {
+		var req = nativeRequest($wrap, code, isPreview);
+		if (!req) return;
+		busy($wrap, true);
+
+		req.done(function (res) {
+			if (res && res.success) {
+				var d = res.data;
+				window.rbfwCouponState = { code: d.code || '', discount: parseFloat(d.discount) || 0 };
+
+				if (window.rbfwCouponState.discount > 0) {
+					$wrap.find('.rbfw-coupon__code').val(code || d.code || '');
+					showSummary($wrap, d.code, d.discount_html, d.total_html);
+					setMsg($wrap, isPreview ? '' : d.message, isPreview ? '' : 'success');
+				} else {
+					clearSummary($wrap);
+					if (!isPreview) setMsg($wrap, d.message, 'error');
+				}
+			} else if (!isPreview) {
+				var m = res && res.data && res.data.message ? res.data.message : 'Could not apply the coupon.';
+				window.rbfwCouponState = { code: '', discount: 0 };
+				$wrap.find('.rbfw-coupon__code').val('');
+				clearSummary($wrap);
+				setMsg($wrap, m, 'error');
+			}
+		}).fail(function () {
+			if (!isPreview) setMsg($wrap, 'Network error. Please try again.', 'error');
+		}).always(function () {
+			busy($wrap, false);
+		});
+	}
+
+	/* ---------------------------------------------------------------------
+	 * WooCommerce
+	 * ------------------------------------------------------------------ */
+
+	function wcPost($wrap, action, code) {
+		busy($wrap, true);
+		$.post(ajaxUrl(), { action: action, nonce: nonce(), code: code || '' })
+			.done(function (res) {
+				if (res && res.success) {
+					setMsg($wrap, res.data.message, 'success');
+					window.location.reload();
+				} else {
+					var m = res && res.data && res.data.message ? res.data.message : 'Could not apply the coupon.';
+					setMsg($wrap, m, 'error');
+					busy($wrap, false);
+				}
+			})
+			.fail(function () {
+				setMsg($wrap, 'Network error. Please try again.', 'error');
+				busy($wrap, false);
+			});
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Wiring
+	 * ------------------------------------------------------------------ */
+
+	$(function () {
+		var v = vars();
+		if (!v) return;
+
+		$(document).on('click', '.rbfw-coupon__apply', function (e) {
+			e.preventDefault();
+			var $wrap = $(this).closest('[data-rbfw-coupon]');
+			var code = $.trim($wrap.find('.rbfw-coupon__input').val() || '');
+			if (!code) {
+				setMsg($wrap, v.i18n_enter_code || 'Please enter a coupon code.', 'error');
+				return;
+			}
+			if (isStandalone()) {
+				nativeApply($wrap, code, false);
+			} else {
+				wcPost($wrap, 'rbfw_apply_coupon', code);
+			}
+		});
+
+		$(document).on('click', '.rbfw-coupon__remove', function (e) {
+			e.preventDefault();
+			var $wrap = $(this).closest('[data-rbfw-coupon]');
+			if (isStandalone()) {
+				window.rbfwCouponState = { code: '', discount: 0 };
+				$wrap.find('.rbfw-coupon__input').val('');
+				$wrap.find('.rbfw-coupon__code').val('');
+				clearSummary($wrap);
+				setMsg($wrap, '', '');
+				// An automatic rule may still apply once the manual code is gone.
+				if (v.has_auto === '1') nativeApply($wrap, '', true);
+			} else {
+				wcPost($wrap, 'rbfw_remove_coupon', '');
+			}
+		});
+
+		// Enter key inside the coupon input must not submit the booking form.
+		$(document).on('keydown', '.rbfw-coupon__input', function (e) {
+			if (e.key === 'Enter' || e.keyCode === 13) {
+				e.preventDefault();
+				$(this).closest('[data-rbfw-coupon]').find('.rbfw-coupon__apply').trigger('click');
+			}
+		});
+
+		if (!isStandalone()) return;
+
+		// Standalone only: the discount depends on the live booking price, so re-resolve
+		// (debounced) whenever the totals change, and surface automatic rules on load.
+		var timer = null;
+		function rerun() {
+			clearTimeout(timer);
+			timer = setTimeout(function () {
+				$('[data-rbfw-coupon][data-rbfw-coupon-mode="native"]').each(function () {
+					var $wrap = $(this);
+					var code = $.trim($wrap.find('.rbfw-coupon__code').val() || '');
+					if (code || v.has_auto === '1') {
+						nativeApply($wrap, code, true);
+					}
+				});
+			}, 450);
+		}
+
+		$('[data-rbfw-coupon][data-rbfw-coupon-mode="native"]').each(function () {
+			var $form = formOf($(this));
+			if (!$form.length) return;
+
+			var totalEl = $form.find('.total').get(0);
+			if (totalEl && typeof MutationObserver !== 'undefined') {
+				new MutationObserver(rerun).observe(totalEl, { childList: true, subtree: true, characterData: true });
+			}
+			$form.on('change', 'input, select', rerun);
+		});
+
+		if (v.has_auto === '1') rerun();
+	});
+})(jQuery);

--- a/assets/mp_script/rbfw_native_checkout.js
+++ b/assets/mp_script/rbfw_native_checkout.js
@@ -16,6 +16,10 @@
 
 	var $activeForm = null;
 
+	// Coupon state for the current modal session (owned here, entered in the modal).
+	var appliedCouponCode = '';
+	var appliedCouponDiscount = 0;
+
 	function readTotal($form) {
 		var $fig = $form.find('.total .price-figure').first();
 		if (!$fig.length) {
@@ -26,16 +30,98 @@
 		return isNaN(num) ? 0 : num;
 	}
 
+	function currency() {
+		return (typeof rbfw_ajax_front !== 'undefined' && rbfw_ajax_front.currency_symbol) ? rbfw_ajax_front.currency_symbol : '';
+	}
+
+	/** Refresh the modal's Total = gross booking total − applied coupon discount. */
+	function updateModalTotal() {
+		if (!$activeForm) { return; }
+		var payable = Math.max(0, readTotal($activeForm) - appliedCouponDiscount);
+		$('#rbfw-native-checkout-modal').find('[data-rbfw-native-total]').text(currency() + payable.toFixed(2));
+	}
+
+	function resetCoupon($modal) {
+		appliedCouponCode = '';
+		appliedCouponDiscount = 0;
+		$modal.find('[data-rbfw-native-coupon-input]').val('');
+		$modal.find('[data-rbfw-native-coupon-msg]').removeClass('error success').text('');
+		$modal.find('[data-rbfw-native-coupon-applied]').prop('hidden', true);
+	}
+
+	function applyCoupon() {
+		var $modal = $('#rbfw-native-checkout-modal');
+		var $wrap = $modal.find('[data-rbfw-native-coupon]');
+		var $msg = $modal.find('[data-rbfw-native-coupon-msg]');
+		var code = $.trim($modal.find('[data-rbfw-native-coupon-input]').val() || '');
+		if (!$activeForm) { return; }
+		if (!code) {
+			$msg.removeClass('success').addClass('error').text('Please enter a coupon code.');
+			return;
+		}
+
+		// Validate + price the coupon against the live booking form, server-side.
+		var gross = readTotal($activeForm);
+		var data = $activeForm.serializeArray();
+		data.push({ name: 'action', value: 'rbfw_apply_coupon_native' });
+		data.push({ name: 'nonce', value: rbfw_ajax_front.nonce_apply_coupon });
+		data.push({ name: 'code', value: code });
+		data.push({ name: 'preview', value: '0' });
+		data.push({ name: 'rbfw_subtotal', value: gross });
+		data.push({ name: 'rbfw_total', value: gross });
+
+		$wrap.addClass('is-busy');
+		$msg.removeClass('error success').text('');
+
+		$.post(rbfw_ajax_front.rbfw_ajaxurl, data)
+			.done(function (res) {
+				if (res && res.success && parseFloat(res.data.discount) > 0) {
+					appliedCouponCode = res.data.code || code;
+					appliedCouponDiscount = parseFloat(res.data.discount) || 0;
+					$modal.find('[data-rbfw-native-coupon-summary]').text(
+						(res.data.code || code) + '  −' + (res.data.discount_html || '')
+					);
+					$modal.find('[data-rbfw-native-coupon-applied]').prop('hidden', false);
+					$msg.removeClass('error').addClass('success').text(res.data.message || 'Coupon applied.');
+					updateModalTotal();
+				} else if (res && res.success) {
+					appliedCouponCode = '';
+					appliedCouponDiscount = 0;
+					$modal.find('[data-rbfw-native-coupon-applied]').prop('hidden', true);
+					$msg.removeClass('success').addClass('error').text(res.data.message || 'No discount applies to this booking.');
+					updateModalTotal();
+				} else {
+					appliedCouponCode = '';
+					appliedCouponDiscount = 0;
+					var m = res && res.data && res.data.message ? res.data.message : 'Coupon could not be applied.';
+					$modal.find('[data-rbfw-native-coupon-applied]').prop('hidden', true);
+					$msg.removeClass('success').addClass('error').text(m);
+					updateModalTotal();
+				}
+			})
+			.fail(function () {
+				$msg.removeClass('success').addClass('error').text('Network error. Please try again.');
+			})
+			.always(function () {
+				$wrap.removeClass('is-busy');
+			});
+	}
+
+	function removeCoupon() {
+		var $modal = $('#rbfw-native-checkout-modal');
+		resetCoupon($modal);
+		updateModalTotal();
+	}
+
 	function openModal($form) {
 		$activeForm = $form;
-		var total = readTotal($form);
 		var $modal = $('#rbfw-native-checkout-modal');
 		if (!$modal.length) {
 			return;
 		}
-		$modal.find('[data-rbfw-native-total]').text(
-			(rbfw_ajax_front.currency_symbol || '') + total.toFixed(2)
-		);
+		// Fresh coupon state each time the modal opens.
+		resetCoupon($modal);
+		updateModalTotal();
 		$modal.find('[data-rbfw-native-message]').removeClass('error success').text('');
 		$modal.attr('aria-hidden', 'false').fadeIn(120);
 	}
@@ -71,6 +157,10 @@
 		data.push({ name: 'rbfw_billing_email', value: email });
 		data.push({ name: 'rbfw_billing_phone', value: phone });
 		data.push({ name: 'rbfw_total', value: readTotal($activeForm) });
+		// The applied coupon code (server re-validates + recomputes the discount authoritatively).
+		if (appliedCouponCode) {
+			data.push({ name: 'rbfw_coupon_code', value: appliedCouponCode });
+		}
 
 		// Payment method (Pro): the selector lives in the modal, not the booking form,
 		// so push the chosen gateway explicitly when present.
@@ -124,6 +214,15 @@
 
 		$(document).on('click', '[data-rbfw-native-close]', closeModal);
 		$(document).on('click', '[data-rbfw-native-submit]', submitBooking);
+		$(document).on('click', '[data-rbfw-native-coupon-apply]', applyCoupon);
+		$(document).on('click', '[data-rbfw-native-coupon-remove]', removeCoupon);
+		// Enter inside the coupon input applies the coupon (never submits the booking).
+		$(document).on('keydown', '[data-rbfw-native-coupon-input]', function (e) {
+			if (e.key === 'Enter' || e.keyCode === 13) {
+				e.preventDefault();
+				applyCoupon();
+			}
+		});
 		$(document).on('keydown', function (e) {
 			if (e.key === 'Escape') {
 				closeModal();

--- a/assets/mp_script/sd_script.js
+++ b/assets/mp_script/sd_script.js
@@ -137,12 +137,12 @@
 
             if (time_slot_switch === 'yes') {
                 if (start_date === '' || start_time === '') {
-                    alert('please enter date');
+                    alert((window.rbfw_translation||{}).enter_date || 'Please enter the date');
                     return;
                 }
             } else {
                 if (start_date === '') {
-                    alert('please enter date');
+                    alert((window.rbfw_translation||{}).enter_date || 'Please enter the date');
                     return;
                 }
             }
@@ -162,7 +162,7 @@
             let rbfw_bikecarsd_selected_date = jQuery('#rbfw_bikecarsd_selected_date').val();
             let time_slot_switch = jQuery('#rbfw_time_slot_switch').val();
             if(rbfw_bikecarsd_selected_date==''){
-                alert("please enter pickup date");
+                alert((window.rbfw_translation||{}).enter_pickup_date || 'Please enter the pickup date');
                 return;
             }
 
@@ -188,7 +188,7 @@
                 if(time_slot_switch == 'yes'){
                     start_time = jQuery('.rbfw-select.rbfw-time-price.pickup_time').val();
                     if(start_time == ''){
-                        alert("Please enter pickup time");
+                        alert((window.rbfw_translation||{}).enter_pickup_time || 'Please enter the pickup time');
                         return;
                     }
                 }

--- a/css/rbfw_coupon.css
+++ b/css/rbfw_coupon.css
@@ -1,0 +1,113 @@
+/* Unified coupon field — booking form (standalone) + WooCommerce cart/checkout. */
+.rbfw-coupon {
+	margin: 14px 0;
+	padding: 14px 16px;
+	border: 1px dashed #d7dae0;
+	border-radius: 10px;
+	background: #fbfbfc;
+}
+
+.rbfw-coupon__label {
+	display: block;
+	font-size: 13px;
+	font-weight: 600;
+	color: #374151;
+	margin-bottom: 8px;
+}
+
+.rbfw-coupon__row {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.rbfw-coupon__input {
+	flex: 1 1 160px;
+	min-width: 0;
+	border: 1.5px solid #d1d5db;
+	border-radius: 8px;
+	padding: 9px 12px;
+	font-size: 14px;
+	background: #fff;
+	text-transform: uppercase;
+}
+
+.rbfw-coupon__input:focus {
+	outline: none;
+	border-color: var(--color_theme, #f12971);
+	box-shadow: 0 0 0 3px rgba(241, 41, 113, 0.12);
+}
+
+.rbfw-coupon__apply,
+.rbfw-coupon__remove {
+	flex: 0 0 auto;
+	cursor: pointer;
+	border: none;
+	border-radius: 8px;
+	padding: 9px 18px;
+	font-size: 13px;
+	font-weight: 600;
+	color: #fff;
+	background: var(--color_theme, #f12971);
+	transition: opacity 0.15s ease;
+}
+
+.rbfw-coupon__remove {
+	background: transparent;
+	color: #6b7280;
+	text-decoration: underline;
+	padding: 2px 4px;
+	font-weight: 500;
+}
+
+.rbfw-coupon__apply:hover,
+.rbfw-coupon__remove:hover {
+	opacity: 0.85;
+}
+
+.rbfw-coupon.is-busy {
+	opacity: 0.65;
+	pointer-events: none;
+}
+
+.rbfw-coupon__msg {
+	margin-top: 8px;
+	font-size: 12.5px;
+	line-height: 1.5;
+	min-height: 0;
+}
+
+.rbfw-coupon__msg:empty {
+	margin-top: 0;
+}
+
+.rbfw-coupon__msg.is-error {
+	color: #b42318;
+}
+
+.rbfw-coupon__msg.is-success {
+	color: #166534;
+}
+
+.rbfw-coupon__summary {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	flex-wrap: wrap;
+	margin-top: 10px;
+	padding: 9px 12px;
+	border-radius: 8px;
+	background: #ecfdf3;
+	border: 1px solid #abefc6;
+}
+
+.rbfw-coupon__summary[hidden] {
+	display: none;
+}
+
+.rbfw-coupon__applied {
+	font-size: 13px;
+	font-weight: 600;
+	color: #166534;
+}

--- a/inc/RBFW_Dependencies.php
+++ b/inc/RBFW_Dependencies.php
@@ -49,6 +49,7 @@ if (! class_exists('RBFW_Dependencies')) {
 				'nonce_bikecarsd_sold_out_times'                  => wp_create_nonce('rbfw_bikecarsd_sold_out_times_action'),
 				'nonce_bikecarmd_ajax_min_max_and_offdays_info'   => wp_create_nonce('rbfw_bikecarmd_ajax_min_max_and_offdays_info_action'),
 				'nonce_native_checkout'                           => wp_create_nonce('rbfw_native_checkout_action'),
+				'nonce_apply_coupon'                              => wp_create_nonce('rbfw_apply_coupon_action'),
 			);
 		}
 
@@ -207,6 +208,8 @@ if (! class_exists('RBFW_Dependencies')) {
 				'nonce_bikecarmd_ajax_min_max_and_offdays_info'        => wp_create_nonce('rbfw_bikecarmd_ajax_min_max_and_offdays_info_action'),
 				// WooCommerce-optional booking flow.
 				'nonce_native_checkout'        => wp_create_nonce('rbfw_native_checkout_action'),
+				// Unified coupon engine (both modes).
+				'nonce_apply_coupon'           => wp_create_nonce('rbfw_apply_coupon_action'),
 				'booking_mode'                 => rbfw_booking_mode(),
 				'has_woocommerce'              => rbfw_has_woocommerce() ? '1' : '0',
 				'currency_symbol'              => get_woocommerce_currency_symbol(),
@@ -317,6 +320,12 @@ if (! class_exists('RBFW_Dependencies')) {
 				'number_of' => __('Number of', 'booking-and-rental-manager-for-woocommerce'),
 				'duration' => __('Duration', 'booking-and-rental-manager-for-woocommerce'),
 				'pickup_dropoff_date' => __('Please enter pickup date and dropoff date', 'booking-and-rental-manager-for-woocommerce'),
+				// Previously hard-coded in sd_script.js / js/rbfw_script.js (now translatable).
+				'enter_date' => __('Please enter the date', 'booking-and-rental-manager-for-woocommerce'),
+				'enter_pickup_date' => __('Please enter the pickup date', 'booking-and-rental-manager-for-woocommerce'),
+				'enter_pickup_time' => __('Please enter the pickup time', 'booking-and-rental-manager-for-woocommerce'),
+				'no_data_found' => __('Sorry, no data found!', 'booking-and-rental-manager-for-woocommerce'),
+				'no_match_found' => __('No Match Result Found!', 'booking-and-rental-manager-for-woocommerce'),
 			));
 
 
@@ -334,6 +343,22 @@ if (! class_exists('RBFW_Dependencies')) {
 			// only acts when rbfw_ajax_front.booking_mode === 'standalone'. Must be enqueued
 			// on the frontend (this method) — the native checkout modal lives on the item page.
 			wp_enqueue_script('rbfw_native_checkout', RBFW_PLUGIN_URL . '/assets/mp_script/rbfw_native_checkout.js', array('jquery'), time(), true);
+
+			// Unified coupon field (works in both booking modes; the script picks its endpoint
+			// from rbfw_ajax_front.booking_mode).
+			if (class_exists('RBFW_Coupon_Frontend') && RBFW_Coupon_Frontend::enabled()) {
+				wp_enqueue_style('rbfw_coupon', RBFW_PLUGIN_URL . '/css/rbfw_coupon.css', array(), time(), 'all');
+				wp_enqueue_script('rbfw_coupon', RBFW_PLUGIN_URL . '/assets/mp_script/rbfw_coupon.js', array('jquery'), time(), true);
+				wp_localize_script('rbfw_coupon', 'rbfw_coupon_vars', array(
+					'ajaxurl'         => admin_url('admin-ajax.php'),
+					'nonce'           => wp_create_nonce('rbfw_apply_coupon_action'),
+					'has_auto'        => RBFW_Coupon_Frontend::has_auto_coupons() ? '1' : '0',
+					'i18n_enter_code' => __('Please enter a coupon code.', 'booking-and-rental-manager-for-woocommerce'),
+					/* translators: 1: coupon code, 2: discount amount */
+					'i18n_saved'      => __('Coupon %1$s applied — you save %2$s', 'booking-and-rental-manager-for-woocommerce'),
+					'i18n_new_total'  => __('New total:', 'booking-and-rental-manager-for-woocommerce'),
+				));
+			}
 
 			// [rbfw_booking_search] multi-item booking search.
 			wp_enqueue_script('rbfw_booking_search', RBFW_PLUGIN_URL . '/assets/mp_script/rbfw_booking_search.js', array('jquery', 'jquery-ui-datepicker'), time(), true);

--- a/inc/booking/RBFW_Booking_Actions.php
+++ b/inc/booking/RBFW_Booking_Actions.php
@@ -294,6 +294,14 @@ if ( ! class_exists( 'RBFW_Booking_Actions' ) ) {
 			$lines[] = esc_html__( 'Item:', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $d['item'];
 			$lines[] = esc_html__( 'Dates:', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $d['dates'];
 			$lines[] = esc_html__( 'Quantity:', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $d['quantity'];
+			if ( ! empty( $d['discount_raw'] ) || ! empty( $d['coupon_code'] ) ) {
+				$lines[] = esc_html__( 'Subtotal:', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $d['subtotal'];
+				$coupon_line = esc_html__( 'Discount:', 'booking-and-rental-manager-for-woocommerce' );
+				if ( ! empty( $d['coupon_code'] ) ) {
+					$coupon_line .= ' (' . $d['coupon_code'] . ')';
+				}
+				$lines[] = $coupon_line . ' -' . $d['discount'];
+			}
 			$lines[] = esc_html__( 'Total:', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $d['total'];
 			$lines[] = esc_html__( 'Status:', 'booking-and-rental-manager-for-woocommerce' ) . ' ' . $d['status_label'];
 			$lines[] = '';
@@ -321,6 +329,14 @@ if ( ! class_exists( 'RBFW_Booking_Actions' ) ) {
 
 			$total = (float) get_post_meta( $booking_id, 'rbfw_total', true );
 
+			$coupon_code  = (string) get_post_meta( $booking_id, 'rbfw_coupon_code', true );
+			$discount_raw = (float) get_post_meta( $booking_id, 'rbfw_discount', true );
+			$subtotal_raw = get_post_meta( $booking_id, 'rbfw_subtotal', true );
+			$subtotal_raw = ( '' === $subtotal_raw ) ? ( $total + $discount_raw ) : (float) $subtotal_raw;
+			$money        = static function ( $amount ) {
+				return html_entity_decode( wp_strip_all_tags( wc_price( $amount ) ), ENT_QUOTES, 'UTF-8' );
+			};
+
 			return array(
 				'reference'    => (string) get_post_meta( $booking_id, 'rbfw_reference', true ),
 				'item'         => (string) get_post_meta( $booking_id, 'rbfw_item_name', true ),
@@ -329,7 +345,11 @@ if ( ! class_exists( 'RBFW_Booking_Actions' ) ) {
 				'phone'        => (string) get_post_meta( $booking_id, 'rbfw_customer_phone', true ),
 				'dates'        => $dates ? $dates : '—',
 				'quantity'     => (string) max( 1, absint( get_post_meta( $booking_id, 'rbfw_quantity', true ) ) ),
-				'total'        => html_entity_decode( wp_strip_all_tags( wc_price( $total ) ), ENT_QUOTES, 'UTF-8' ),
+				'subtotal'     => $money( $subtotal_raw ),
+				'discount'     => $money( $discount_raw ),
+				'discount_raw' => $discount_raw,
+				'coupon_code'  => $coupon_code,
+				'total'        => $money( $total ),
 				'status_label' => isset( $statuses[ $status ] ) ? $statuses[ $status ] : ucfirst( $status ),
 			);
 		}
@@ -441,6 +461,19 @@ if ( ! class_exists( 'RBFW_Booking_Actions' ) ) {
 			</table>
 
 			<table class="rbfw-total-table">
+				<?php if ( ! empty( $d['discount_raw'] ) || ! empty( $d['coupon_code'] ) ) : ?>
+				<tr>
+					<td><?php esc_html_e( 'Subtotal', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
+					<td style="text-align:right;"><?php echo esc_html( $d['subtotal'] ); ?></td>
+				</tr>
+				<tr>
+					<td>
+						<?php esc_html_e( 'Discount', 'booking-and-rental-manager-for-woocommerce' ); ?>
+						<?php if ( ! empty( $d['coupon_code'] ) ) : ?><small>(<?php echo esc_html( $d['coupon_code'] ); ?>)</small><?php endif; ?>
+					</td>
+					<td style="text-align:right;">&minus;<?php echo esc_html( $d['discount'] ); ?></td>
+				</tr>
+				<?php endif; ?>
 				<tr class="rbfw-total-row">
 					<td><?php esc_html_e( 'Total', 'booking-and-rental-manager-for-woocommerce' ); ?></td>
 					<td style="text-align:right;"><?php echo esc_html( $d['total'] ); ?></td>

--- a/inc/booking/RBFW_Native_Checkout.php
+++ b/inc/booking/RBFW_Native_Checkout.php
@@ -77,17 +77,53 @@ if ( ! class_exists( 'RBFW_Native_Checkout' ) ) {
 
 			// 6. Total — computed live on the frontend and posted back. Phase 1 trusts the
 			// sanitized value; server-side recomputation/validation lands with the payment phase.
-			$total = isset( $_POST['rbfw_total'] ) ? (float) preg_replace( '/[^0-9.]/', '', wp_unslash( $_POST['rbfw_total'] ) ) : 0.0;
+			$subtotal = isset( $_POST['rbfw_total'] ) ? (float) preg_replace( '/[^0-9.]/', '', wp_unslash( $_POST['rbfw_total'] ) ) : 0.0;
+			$subtotal = max( 0, $subtotal );
+
+			// 6b. Coupon — ALWAYS authoritative server-side. Only the coupon CODE is accepted from
+			// the client; the discount value is recomputed from the coupon's own configuration, so a
+			// tampered `rbfw_coupon_discount` in the POST is ignored entirely. Automatic (no-code)
+			// rules resolve here too. (The base subtotal above remains client-derived — that is the
+			// pre-existing gap noted at step 6 and is unchanged by this feature.)
+			$coupon_code     = '';
+			$coupon_discount = 0.0;
+			$coupon_applied  = array();
+
+			if ( class_exists( 'RBFW_Coupon_Engine' ) && RBFW_Coupon_Engine::is_enabled() ) {
+				$posted_code = isset( $_POST['rbfw_coupon_code'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_coupon_code'] ) ) : '';
+				$ctx         = RBFW_Coupon_Context::from_native_post( $raw );
+				$resolution  = RBFW_Coupon_Engine::resolve( $ctx, $posted_code );
+
+				// A code was typed but is not (or no longer) valid — refuse rather than silently
+				// charging full price after the customer saw a discounted total.
+				if ( '' !== trim( $posted_code ) && '' !== $resolution['manual_error'] ) {
+					wp_send_json_error( array( 'message' => $resolution['manual_error'] ) );
+				}
+
+				$coupon_discount = min( (float) $resolution['total_discount'], $subtotal );
+				$coupon_applied  = $resolution['applied'];
+				$codes           = array();
+				foreach ( $coupon_applied as $a ) {
+					$codes[] = $a['code'];
+				}
+				$coupon_code = implode( ', ', $codes );
+			}
+
+			$total = max( 0, $subtotal - $coupon_discount );
 
 			// 7. Persist via the booking manager.
 			$result = RBFW_Booking_Manager::create_booking( $item_id, array(
-				'customer'    => array( 'name' => $name, 'email' => $email, 'phone' => $phone ),
-				'dates'       => $dates,
-				'total'       => $total,
-				'item_type'   => $item_type,
-				'quantity'    => $quantity,
-				'ticket_info' => $ticket_info,
-				'raw'         => $raw,
+				'customer'        => array( 'name' => $name, 'email' => $email, 'phone' => $phone ),
+				'dates'           => $dates,
+				'subtotal'        => $subtotal,
+				'discount'        => $coupon_discount,
+				'coupon_code'     => $coupon_code,
+				'coupon_applied'  => $coupon_applied,
+				'total'           => $total,
+				'item_type'       => $item_type,
+				'quantity'        => $quantity,
+				'ticket_info'     => $ticket_info,
+				'raw'             => $raw,
 			) );
 
 			if ( is_wp_error( $result ) ) {

--- a/inc/booking/RBFW_Standalone_Booking_Service.php
+++ b/inc/booking/RBFW_Standalone_Booking_Service.php
@@ -75,6 +75,17 @@ if ( ! class_exists( 'RBFW_Standalone_Booking_Service' ) ) {
 			update_post_meta( $post_id, 'rbfw_start_time', isset( $dates['start_time'] ) ? sanitize_text_field( $dates['start_time'] ) : '' );
 			update_post_meta( $post_id, 'rbfw_end_time', isset( $dates['end_time'] ) ? sanitize_text_field( $dates['end_time'] ) : '' );
 			update_post_meta( $post_id, 'rbfw_quantity', $quantity );
+
+			// Money breakdown. `rbfw_total` stays the payable grand total (what the payment phase
+			// charges); subtotal/discount record how it was reached. Values are computed
+			// server-side in RBFW_Native_Checkout::process() — never taken from the client.
+			$subtotal    = isset( $payload['subtotal'] ) ? max( 0, (float) $payload['subtotal'] ) : $total;
+			$discount    = isset( $payload['discount'] ) ? max( 0, (float) $payload['discount'] ) : 0.0;
+			$coupon_code = isset( $payload['coupon_code'] ) ? sanitize_text_field( $payload['coupon_code'] ) : '';
+
+			update_post_meta( $post_id, 'rbfw_subtotal', $subtotal );
+			update_post_meta( $post_id, 'rbfw_discount', $discount );
+			update_post_meta( $post_id, 'rbfw_coupon_code', $coupon_code );
 			update_post_meta( $post_id, 'rbfw_total', $total );
 			update_post_meta( $post_id, 'rbfw_currency', get_woocommerce_currency() );
 			update_post_meta( $post_id, 'rbfw_status', $status );
@@ -91,6 +102,25 @@ if ( ! class_exists( 'RBFW_Standalone_Booking_Service' ) ) {
 			$ticket_info = isset( $payload['ticket_info'] ) && is_array( $payload['ticket_info'] ) ? $payload['ticket_info'] : array();
 			if ( ! empty( $ticket_info ) && function_exists( 'rbfw_create_inventory_meta' ) ) {
 				rbfw_create_inventory_meta( $ticket_info, $item_id, $post_id, $status );
+			}
+
+			// Record coupon redemptions. Done at creation (like the inventory reservation above) so
+			// usage limits cannot be bypassed by never completing payment. RBFW_Coupon_Usage::record()
+			// is idempotent per (coupon, booking), so re-entry can never double count.
+			$coupon_applied = isset( $payload['coupon_applied'] ) && is_array( $payload['coupon_applied'] ) ? $payload['coupon_applied'] : array();
+			if ( $coupon_applied && class_exists( 'RBFW_Coupon_Usage' ) ) {
+				foreach ( $coupon_applied as $applied ) {
+					$cid = isset( $applied['id'] ) ? absint( $applied['id'] ) : 0;
+					if ( $cid ) {
+						RBFW_Coupon_Usage::record(
+							$cid,
+							array( 'type' => 'booking', 'id' => $post_id ),
+							get_current_user_id(),
+							$email,
+							isset( $applied['amount'] ) ? (float) $applied['amount'] : 0.0
+						);
+					}
+				}
 			}
 
 			/**

--- a/inc/coupon/RBFW_Coupon.php
+++ b/inc/coupon/RBFW_Coupon.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Coupon model — a thin, typed wrapper around a single `rbfw_coupon` post + its meta.
+ *
+ * Loading:
+ *   RBFW_Coupon::load_by_code( 'SUMMER10' )   → ?RBFW_Coupon  (active coupons only)
+ *   RBFW_Coupon::get_active_auto_coupons()     → RBFW_Coupon[] (auto-apply rules, priority DESC)
+ *
+ * All getters return already-typed values (int/float/bool/array) so the engine never has to
+ * re-cast meta. Config keys are documented in the plan's data-model table.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon' ) ) {
+	class RBFW_Coupon {
+
+		/** @var int */
+		protected $id = 0;
+
+		/** @var array Cached meta bag (key => raw value). */
+		protected $meta = array();
+
+		public function __construct( $post_id ) {
+			$this->id = absint( $post_id );
+		}
+
+		/**
+		 * Normalize a user-entered code to its canonical form (trim + uppercase).
+		 * The same normalization is applied on save, so lookups are exact.
+		 */
+		public static function normalize_code( $code ) {
+			$code = is_string( $code ) ? $code : '';
+			// Multibyte-safe uppercasing; collapse internal whitespace is intentionally NOT done
+			// (codes may legitimately contain spaces if an owner chooses).
+			$code = trim( wp_strip_all_tags( $code ) );
+			return function_exists( 'mb_strtoupper' ) ? mb_strtoupper( $code, 'UTF-8' ) : strtoupper( $code );
+		}
+
+		/**
+		 * Load an ACTIVE coupon by its code. Returns null when the code is empty, unknown,
+		 * or the coupon post is not published (inactive).
+		 *
+		 * @return RBFW_Coupon|null
+		 */
+		public static function load_by_code( $code ) {
+			$code = self::normalize_code( $code );
+			if ( '' === $code ) {
+				return null;
+			}
+
+			$query = new WP_Query( array(
+				'post_type'              => RBFW_Coupon_Post_Type::POST_TYPE,
+				'post_status'            => 'publish',
+				'posts_per_page'         => 1,
+				'no_found_rows'          => true,
+				'ignore_sticky_posts'    => true,
+				'update_post_term_cache' => false,
+				'fields'                 => 'ids',
+				'meta_query'             => array(
+					array(
+						'key'     => 'rbfw_code',
+						'value'   => $code,
+						'compare' => '=',
+					),
+				),
+			) );
+
+			if ( empty( $query->posts ) ) {
+				return null;
+			}
+
+			return new self( (int) $query->posts[0] );
+		}
+
+		const AUTO_CACHE = 'rbfw_has_auto_coupons';
+
+		/**
+		 * Whether ANY active automatic rule exists. Cached, and used as a cheap short-circuit so
+		 * stores without coupons never pay for building a coupon context on every cart
+		 * recalculation / booking submit.
+		 */
+		public static function has_auto_coupons() {
+			$cached = get_transient( self::AUTO_CACHE );
+			if ( false !== $cached ) {
+				return '1' === $cached;
+			}
+
+			$q = new WP_Query( array(
+				'post_type'      => RBFW_Coupon_Post_Type::POST_TYPE,
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array( 'key' => 'rbfw_auto_apply', 'value' => 'yes', 'compare' => '=' ),
+				),
+			) );
+
+			$has = ! empty( $q->posts );
+			set_transient( self::AUTO_CACHE, $has ? '1' : '0', HOUR_IN_SECONDS );
+			return $has;
+		}
+
+		/** Safe as a direct call and as a `deleted_post` / `save_post_*` hook callback. */
+		public static function flush_auto_cache( $post_id = 0, $post = null ) {
+			if ( $post instanceof WP_Post && RBFW_Coupon_Post_Type::POST_TYPE !== $post->post_type ) {
+				return;
+			}
+			delete_transient( self::AUTO_CACHE );
+		}
+
+		/**
+		 * Every active automatic (no-code) coupon, ordered by priority (highest first).
+		 *
+		 * @return RBFW_Coupon[]
+		 */
+		public static function get_active_auto_coupons() {
+			$query = new WP_Query( array(
+				'post_type'              => RBFW_Coupon_Post_Type::POST_TYPE,
+				'post_status'            => 'publish',
+				'posts_per_page'         => 100,
+				'no_found_rows'          => true,
+				'ignore_sticky_posts'    => true,
+				'update_post_term_cache' => false,
+				'fields'                 => 'ids',
+				'meta_query'             => array(
+					array(
+						'key'     => 'rbfw_auto_apply',
+						'value'   => 'yes',
+						'compare' => '=',
+					),
+				),
+			) );
+
+			$coupons = array();
+			foreach ( $query->posts as $pid ) {
+				$coupons[] = new self( (int) $pid );
+			}
+
+			// Priority DESC (higher wins); stable on ties.
+			usort( $coupons, static function ( $a, $b ) {
+				return $b->get_priority() <=> $a->get_priority();
+			} );
+
+			return $coupons;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Identity
+		 * ---------------------------------------------------------------------- */
+
+		public function get_id() {
+			return $this->id;
+		}
+
+		public function exists() {
+			return $this->id > 0 && get_post_type( $this->id ) === RBFW_Coupon_Post_Type::POST_TYPE;
+		}
+
+		public function is_active() {
+			return get_post_status( $this->id ) === 'publish';
+		}
+
+		public function get_code() {
+			$code = $this->meta( 'rbfw_code' );
+			if ( '' === $code ) {
+				$code = self::normalize_code( get_the_title( $this->id ) );
+			}
+			return $code;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Raw meta access (cached per instance)
+		 * ---------------------------------------------------------------------- */
+
+		public function meta( $key, $default = '' ) {
+			if ( ! array_key_exists( $key, $this->meta ) ) {
+				$val                = get_post_meta( $this->id, $key, true );
+				$this->meta[ $key ] = ( '' === $val || null === $val ) ? $default : $val;
+			}
+			return $this->meta[ $key ];
+		}
+
+		protected function meta_array( $key ) {
+			$val = $this->meta( $key, array() );
+			return is_array( $val ) ? $val : array();
+		}
+
+		protected function meta_bool( $key ) {
+			return 'yes' === $this->meta( $key, 'no' );
+		}
+
+		protected function meta_float( $key ) {
+			return (float) $this->meta( $key, 0 );
+		}
+
+		protected function meta_int( $key ) {
+			return (int) $this->meta( $key, 0 );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Discount definition
+		 * ---------------------------------------------------------------------- */
+
+		/** @return string percentage|fixed|free_days */
+		public function get_discount_type() {
+			$type = $this->meta( 'rbfw_discount_type', 'percentage' );
+			return in_array( $type, array( 'percentage', 'fixed', 'free_days' ), true ) ? $type : 'percentage';
+		}
+
+		public function get_discount_value() {
+			return max( 0, $this->meta_float( 'rbfw_discount_value' ) );
+		}
+
+		public function get_max_discount() {
+			return max( 0, $this->meta_float( 'rbfw_max_discount' ) );
+		}
+
+		public function is_auto_apply() {
+			return $this->meta_bool( 'rbfw_auto_apply' );
+		}
+
+		public function get_priority() {
+			return $this->meta_int( 'rbfw_priority' );
+		}
+
+		public function allows_combine() {
+			return $this->meta_bool( 'rbfw_allow_combine' );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Targeting (name-based rent types + item ids + location slugs)
+		 * ---------------------------------------------------------------------- */
+
+		public function get_target_items() {
+			return array_map( 'absint', $this->meta_array( 'rbfw_target_items' ) );
+		}
+
+		public function get_exclude_items() {
+			return array_map( 'absint', $this->meta_array( 'rbfw_exclude_items' ) );
+		}
+
+		public function get_target_rent_types() {
+			return array_map( 'strval', $this->meta_array( 'rbfw_target_rent_types' ) );
+		}
+
+		public function get_exclude_rent_types() {
+			return array_map( 'strval', $this->meta_array( 'rbfw_exclude_rent_types' ) );
+		}
+
+		public function get_target_locations() {
+			return array_map( 'strval', $this->meta_array( 'rbfw_target_locations' ) );
+		}
+
+		public function get_exclude_locations() {
+			return array_map( 'strval', $this->meta_array( 'rbfw_exclude_locations' ) );
+		}
+
+		/** True when the coupon has no include filters → applies to every rental line. */
+		public function targets_everything() {
+			return ! $this->get_target_items()
+				&& ! $this->get_target_rent_types()
+				&& ! $this->get_target_locations();
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Spend + date rules
+		 * ---------------------------------------------------------------------- */
+
+		public function get_min_amount() {
+			return max( 0, $this->meta_float( 'rbfw_min_amount' ) );
+		}
+
+		public function get_max_amount() {
+			return max( 0, $this->meta_float( 'rbfw_max_amount' ) );
+		}
+
+		public function get_valid_from() {
+			return $this->meta( 'rbfw_valid_from', '' );
+		}
+
+		public function get_valid_to() {
+			return $this->meta( 'rbfw_valid_to', '' );
+		}
+
+		/** @return int[] 0-6 (Sun-Sat). Empty = every weekday allowed. */
+		public function get_weekdays() {
+			return array_map( 'absint', $this->meta_array( 'rbfw_weekdays' ) );
+		}
+
+		/** @return string[] Y-m-d blackout dates. */
+		public function get_blackout_dates() {
+			return array_map( 'strval', $this->meta_array( 'rbfw_blackout_dates' ) );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Usage limits + eligibility
+		 * ---------------------------------------------------------------------- */
+
+		public function get_usage_limit() {
+			return max( 0, $this->meta_int( 'rbfw_usage_limit' ) );
+		}
+
+		public function get_usage_limit_per_user() {
+			return max( 0, $this->meta_int( 'rbfw_usage_limit_per_user' ) );
+		}
+
+		public function get_usage_limit_per_day() {
+			return max( 0, $this->meta_int( 'rbfw_usage_limit_per_day' ) );
+		}
+
+		public function get_allowed_roles() {
+			return array_map( 'strval', $this->meta_array( 'rbfw_allowed_roles' ) );
+		}
+
+		public function get_allowed_emails() {
+			return array_map( 'strtolower', array_map( 'strval', $this->meta_array( 'rbfw_allowed_emails' ) ) );
+		}
+
+		public function is_first_booking_only() {
+			return $this->meta_bool( 'rbfw_first_booking_only' );
+		}
+
+		public function get_usage_count() {
+			return $this->meta_int( 'rbfw_usage_count' );
+		}
+	}
+}

--- a/inc/coupon/RBFW_Coupon_Admin.php
+++ b/inc/coupon/RBFW_Coupon_Admin.php
@@ -1,0 +1,880 @@
+<?php
+/**
+ * Coupons manager — admin list + CRUD for the unified coupon engine.
+ *
+ * Menu: Rent Item → Coupons (registered on the free plugin's `rbfw_admin_menu_after_settings`
+ * extension hook, so it sits right after Settings).
+ *
+ * All writes go through AJAX guarded by check_ajax_referer('rbfw_coupon_nonce') +
+ * current_user_can( rbfw_bookings_capability() ). Every field is whitelisted/sanitized on save;
+ * every value is escaped on output.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Admin' ) ) {
+	class RBFW_Coupon_Admin {
+
+		const SLUG  = 'rbfw_coupons';
+		const NONCE = 'rbfw_coupon_nonce';
+
+		/** @var string Screen hook returned by add_submenu_page(), used to gate asset loading. */
+		private $hook = '';
+
+		public function __construct() {
+			add_action( 'rbfw_admin_menu_after_settings', array( $this, 'menu' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
+			add_action( 'wp_ajax_rbfw_coupon_save', array( $this, 'ajax_save' ) );
+			add_action( 'wp_ajax_rbfw_coupon_delete', array( $this, 'ajax_delete' ) );
+			add_action( 'wp_ajax_rbfw_coupon_toggle', array( $this, 'ajax_toggle' ) );
+		}
+
+		public function menu() {
+			$this->hook = add_submenu_page(
+				'edit.php?post_type=rbfw_item',
+				__( 'Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+				__( 'Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+				rbfw_bookings_capability(),
+				self::SLUG,
+				array( $this, 'render_page' )
+			);
+		}
+
+		/** Page-scoped assets only (same $hook gating the rest of the plugin's admin pages use). */
+		public function enqueue( $hook ) {
+			if ( $hook !== $this->hook && false === strpos( (string) $hook, self::SLUG ) ) {
+				return;
+			}
+
+			wp_enqueue_style( 'fontawesome.v6', RBFW_PLUGIN_URL . '/assets/font-awesome/all.min.css', array(), '6.0' );
+			wp_enqueue_style(
+				'rbfw-coupon-admin',
+				RBFW_PLUGIN_URL . '/admin/css/rbfw_coupon_admin.css',
+				array(),
+				filemtime( RBFW_PLUGIN_DIR . '/admin/css/rbfw_coupon_admin.css' )
+			);
+			wp_enqueue_script(
+				'rbfw-coupon-admin',
+				RBFW_PLUGIN_URL . '/admin/js/rbfw_coupon_admin.js',
+				array( 'jquery' ),
+				filemtime( RBFW_PLUGIN_DIR . '/admin/js/rbfw_coupon_admin.js' ),
+				true
+			);
+			wp_localize_script( 'rbfw-coupon-admin', 'rbfwCoupon', array(
+				'ajaxurl'        => admin_url( 'admin-ajax.php' ),
+				'nonce'          => wp_create_nonce( self::NONCE ),
+				'i18n_add'       => __( 'Add Coupon', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_edit'      => __( 'Edit Coupon', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_confirm'   => __( 'Delete this coupon permanently? This cannot be undone.', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_need_code' => __( 'Please enter a coupon code.', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_need_val'  => __( 'Enter a discount value greater than zero.', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_pct_max'   => __( 'A percentage discount cannot exceed 100%.', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_network'   => __( 'Network error. Please try again.', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_all'       => __( 'All rentals', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_none'      => __( 'None', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_unlimited' => __( 'Unlimited', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_always'    => __( 'Always', 'booking-and-rental-manager-for-woocommerce' ),
+				'i18n_everyone'  => __( 'Everyone', 'booking-and-rental-manager-for-woocommerce' ),
+				'currency'       => html_entity_decode( get_woocommerce_currency_symbol() ),
+			) );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Security
+		 * ---------------------------------------------------------------------- */
+
+		private function guard() {
+			check_ajax_referer( self::NONCE, 'nonce' );
+			if ( ! current_user_can( rbfw_bookings_capability() ) ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Unauthorized.', 'booking-and-rental-manager-for-woocommerce' ) ), 403 );
+			}
+		}
+
+		/** Any coupon mutation may change whether automatic rules exist. */
+		private function flush_caches() {
+			if ( class_exists( 'RBFW_Coupon_Frontend' ) ) {
+				RBFW_Coupon_Frontend::flush_auto_cache();
+			}
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Option sources
+		 * ---------------------------------------------------------------------- */
+
+		private function item_options() {
+			$out   = array();
+			$items = get_posts( array(
+				'post_type'      => 'rbfw_item',
+				'post_status'    => 'publish',
+				'posts_per_page' => 200,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			) );
+			foreach ( $items as $p ) {
+				$out[ $p->ID ] = $p->post_title;
+			}
+			return $out;
+		}
+
+		/** Rent types are stored NAME-based on items (rbfw_categories), so we key by name. */
+		private function rent_type_options() {
+			$out   = array();
+			$terms = get_terms( array( 'taxonomy' => 'rbfw_item_caregory', 'hide_empty' => false ) );
+			if ( ! is_wp_error( $terms ) ) {
+				foreach ( $terms as $t ) {
+					$out[ $t->name ] = $t->name;
+				}
+			}
+			return $out;
+		}
+
+		/** Locations are matched by term slug. */
+		private function location_options() {
+			$out   = array();
+			$terms = get_terms( array( 'taxonomy' => 'rbfw_item_location', 'hide_empty' => false ) );
+			if ( ! is_wp_error( $terms ) ) {
+				foreach ( $terms as $t ) {
+					$out[ $t->slug ] = $t->name;
+				}
+			}
+			return $out;
+		}
+
+		private function role_options() {
+			$out = array();
+			if ( ! function_exists( 'get_editable_roles' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/user.php';
+			}
+			foreach ( get_editable_roles() as $key => $role ) {
+				$out[ $key ] = translate_user_role( $role['name'] );
+			}
+			return $out;
+		}
+
+		private function weekday_options() {
+			return array(
+				0 => __( 'Sunday', 'booking-and-rental-manager-for-woocommerce' ),
+				1 => __( 'Monday', 'booking-and-rental-manager-for-woocommerce' ),
+				2 => __( 'Tuesday', 'booking-and-rental-manager-for-woocommerce' ),
+				3 => __( 'Wednesday', 'booking-and-rental-manager-for-woocommerce' ),
+				4 => __( 'Thursday', 'booking-and-rental-manager-for-woocommerce' ),
+				5 => __( 'Friday', 'booking-and-rental-manager-for-woocommerce' ),
+				6 => __( 'Saturday', 'booking-and-rental-manager-for-woocommerce' ),
+			);
+		}
+
+		private function all_coupons() {
+			return get_posts( array(
+				'post_type'      => RBFW_Coupon_Post_Type::POST_TYPE,
+				'post_status'    => array( 'publish', 'draft' ),
+				'posts_per_page' => 500,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			) );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * AJAX: save / delete / toggle
+		 * ---------------------------------------------------------------------- */
+
+		public function ajax_save() {
+			$this->guard();
+
+			$post = wp_unslash( $_POST ); // sanitized field-by-field below.
+
+			$id   = isset( $post['coupon_id'] ) ? absint( $post['coupon_id'] ) : 0;
+			$code = RBFW_Coupon::normalize_code( isset( $post['code'] ) ? sanitize_text_field( $post['code'] ) : '' );
+
+			if ( '' === $code ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Coupon code is required.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+			if ( $this->code_exists( $code, $id ) ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'That coupon code already exists.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			$type = isset( $post['discount_type'] ) ? sanitize_text_field( $post['discount_type'] ) : 'percentage';
+			if ( ! in_array( $type, array( 'percentage', 'fixed', 'free_days' ), true ) ) {
+				$type = 'percentage';
+			}
+
+			$value = isset( $post['discount_value'] ) ? (float) $post['discount_value'] : 0;
+			if ( $value <= 0 ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Discount value must be greater than zero.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+			if ( 'percentage' === $type && $value > 100 ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'A percentage discount cannot exceed 100%.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			$status = ( isset( $post['status'] ) && 'draft' === $post['status'] ) ? 'draft' : 'publish';
+
+			$postarr = array(
+				'post_type'   => RBFW_Coupon_Post_Type::POST_TYPE,
+				'post_title'  => $code,
+				'post_status' => $status,
+			);
+
+			if ( $id ) {
+				$postarr['ID'] = $id;
+				$result        = wp_update_post( $postarr, true );
+			} else {
+				$result = wp_insert_post( $postarr, true );
+			}
+			if ( is_wp_error( $result ) || ! $result ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Could not save the coupon.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+			$cid = (int) ( $id ? $id : $result );
+
+			// --- Whitelisted, typed meta ---
+			update_post_meta( $cid, 'rbfw_code', $code );
+			update_post_meta( $cid, 'rbfw_discount_type', $type );
+			update_post_meta( $cid, 'rbfw_discount_value', $value );
+			update_post_meta( $cid, 'rbfw_max_discount', isset( $post['max_discount'] ) ? max( 0, (float) $post['max_discount'] ) : 0 );
+
+			update_post_meta( $cid, 'rbfw_auto_apply', $this->yn( $post, 'auto_apply' ) );
+			update_post_meta( $cid, 'rbfw_priority', isset( $post['priority'] ) ? (int) $post['priority'] : 0 );
+			update_post_meta( $cid, 'rbfw_allow_combine', $this->yn( $post, 'allow_combine' ) );
+
+			update_post_meta( $cid, 'rbfw_target_items', $this->ints( $post, 'target_items' ) );
+			update_post_meta( $cid, 'rbfw_exclude_items', $this->ints( $post, 'exclude_items' ) );
+			update_post_meta( $cid, 'rbfw_target_rent_types', $this->texts( $post, 'target_rent_types' ) );
+			update_post_meta( $cid, 'rbfw_exclude_rent_types', $this->texts( $post, 'exclude_rent_types' ) );
+			update_post_meta( $cid, 'rbfw_target_locations', $this->slugs( $post, 'target_locations' ) );
+			update_post_meta( $cid, 'rbfw_exclude_locations', $this->slugs( $post, 'exclude_locations' ) );
+
+			update_post_meta( $cid, 'rbfw_min_amount', isset( $post['min_amount'] ) ? max( 0, (float) $post['min_amount'] ) : 0 );
+			update_post_meta( $cid, 'rbfw_max_amount', isset( $post['max_amount'] ) ? max( 0, (float) $post['max_amount'] ) : 0 );
+
+			update_post_meta( $cid, 'rbfw_valid_from', $this->date( $post, 'valid_from' ) );
+			update_post_meta( $cid, 'rbfw_valid_to', $this->date( $post, 'valid_to' ) );
+			update_post_meta( $cid, 'rbfw_weekdays', $this->weekdays( $post ) );
+			update_post_meta( $cid, 'rbfw_blackout_dates', $this->date_list( isset( $post['blackout_dates'] ) ? $post['blackout_dates'] : '' ) );
+
+			update_post_meta( $cid, 'rbfw_usage_limit', isset( $post['usage_limit'] ) ? max( 0, (int) $post['usage_limit'] ) : 0 );
+			update_post_meta( $cid, 'rbfw_usage_limit_per_user', isset( $post['usage_limit_per_user'] ) ? max( 0, (int) $post['usage_limit_per_user'] ) : 0 );
+			update_post_meta( $cid, 'rbfw_usage_limit_per_day', isset( $post['usage_limit_per_day'] ) ? max( 0, (int) $post['usage_limit_per_day'] ) : 0 );
+
+			update_post_meta( $cid, 'rbfw_allowed_roles', $this->keys( $post, 'allowed_roles' ) );
+			update_post_meta( $cid, 'rbfw_allowed_emails', $this->email_list( isset( $post['allowed_emails'] ) ? $post['allowed_emails'] : '' ) );
+			update_post_meta( $cid, 'rbfw_first_booking_only', $this->yn( $post, 'first_booking_only' ) );
+
+			// Initialise the counter row on create so the atomic increment always finds it.
+			if ( ! $id ) {
+				add_post_meta( $cid, 'rbfw_usage_count', 0, true );
+			}
+
+			$this->flush_caches();
+
+			wp_send_json_success( array(
+				'message' => esc_html__( 'Coupon saved.', 'booking-and-rental-manager-for-woocommerce' ),
+				'id'      => $cid,
+			) );
+		}
+
+		public function ajax_delete() {
+			$this->guard();
+			$id = isset( $_POST['coupon_id'] ) ? absint( $_POST['coupon_id'] ) : 0;
+			if ( ! $id || get_post_type( $id ) !== RBFW_Coupon_Post_Type::POST_TYPE ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Invalid coupon.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+			wp_delete_post( $id, true );
+			$this->flush_caches();
+			wp_send_json_success( array( 'message' => esc_html__( 'Coupon deleted.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+		}
+
+		public function ajax_toggle() {
+			$this->guard();
+			$id = isset( $_POST['coupon_id'] ) ? absint( $_POST['coupon_id'] ) : 0;
+			if ( ! $id || get_post_type( $id ) !== RBFW_Coupon_Post_Type::POST_TYPE ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Invalid coupon.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+			$new = ( get_post_status( $id ) === 'publish' ) ? 'draft' : 'publish';
+			wp_update_post( array( 'ID' => $id, 'post_status' => $new ) );
+			$this->flush_caches();
+			wp_send_json_success( array( 'status' => $new ) );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Sanitizers
+		 * ---------------------------------------------------------------------- */
+
+		private function code_exists( $code, $exclude_id = 0 ) {
+			$q = new WP_Query( array(
+				'post_type'      => RBFW_Coupon_Post_Type::POST_TYPE,
+				'post_status'    => array( 'publish', 'draft' ),
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'fields'         => 'ids',
+				'post__not_in'   => $exclude_id ? array( $exclude_id ) : array(),
+				'meta_query'     => array(
+					array( 'key' => 'rbfw_code', 'value' => $code, 'compare' => '=' ),
+				),
+			) );
+			return ! empty( $q->posts );
+		}
+
+		private function yn( $post, $key ) {
+			return ( isset( $post[ $key ] ) && in_array( (string) $post[ $key ], array( 'yes', 'on', '1', 'true' ), true ) ) ? 'yes' : 'no';
+		}
+
+		private function ints( $post, $key ) {
+			if ( empty( $post[ $key ] ) || ! is_array( $post[ $key ] ) ) {
+				return array();
+			}
+			return array_values( array_filter( array_map( 'absint', $post[ $key ] ) ) );
+		}
+
+		private function texts( $post, $key ) {
+			if ( empty( $post[ $key ] ) || ! is_array( $post[ $key ] ) ) {
+				return array();
+			}
+			return array_values( array_filter( array_map( 'sanitize_text_field', $post[ $key ] ) ) );
+		}
+
+		private function slugs( $post, $key ) {
+			if ( empty( $post[ $key ] ) || ! is_array( $post[ $key ] ) ) {
+				return array();
+			}
+			return array_values( array_filter( array_map( 'sanitize_title', $post[ $key ] ) ) );
+		}
+
+		private function keys( $post, $key ) {
+			if ( empty( $post[ $key ] ) || ! is_array( $post[ $key ] ) ) {
+				return array();
+			}
+			return array_values( array_filter( array_map( 'sanitize_key', $post[ $key ] ) ) );
+		}
+
+		private function weekdays( $post ) {
+			if ( empty( $post['weekdays'] ) || ! is_array( $post['weekdays'] ) ) {
+				return array();
+			}
+			$out = array();
+			foreach ( $post['weekdays'] as $d ) {
+				$d = (int) $d;
+				if ( $d >= 0 && $d <= 6 ) {
+					$out[] = $d;
+				}
+			}
+			return array_values( array_unique( $out ) );
+		}
+
+		/** Validate a single Y-m-d date, returning '' when invalid/empty. */
+		private function date( $post, $key ) {
+			$raw = isset( $post[ $key ] ) ? sanitize_text_field( $post[ $key ] ) : '';
+			return $this->valid_date( $raw );
+		}
+
+		private function valid_date( $raw ) {
+			if ( '' === $raw ) {
+				return '';
+			}
+			$d = DateTime::createFromFormat( 'Y-m-d', $raw );
+			return ( $d && $d->format( 'Y-m-d' ) === $raw ) ? $raw : '';
+		}
+
+		/** Comma / newline separated Y-m-d list. */
+		private function date_list( $raw ) {
+			$parts = preg_split( '/[\s,;]+/', (string) $raw, -1, PREG_SPLIT_NO_EMPTY );
+			$out   = array();
+			foreach ( (array) $parts as $p ) {
+				$d = $this->valid_date( sanitize_text_field( $p ) );
+				if ( $d ) {
+					$out[] = $d;
+				}
+			}
+			return array_values( array_unique( $out ) );
+		}
+
+		private function email_list( $raw ) {
+			$parts = preg_split( '/[\s,;]+/', (string) $raw, -1, PREG_SPLIT_NO_EMPTY );
+			$out   = array();
+			foreach ( (array) $parts as $p ) {
+				$e = sanitize_email( $p );
+				if ( $e && is_email( $e ) ) {
+					$out[] = strtolower( $e );
+				}
+			}
+			return array_values( array_unique( $out ) );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Render
+		 * ---------------------------------------------------------------------- */
+
+		/** The full config of a coupon, as JSON for the edit modal. */
+		private function coupon_json( $post ) {
+			$c = new RBFW_Coupon( $post->ID );
+			return array(
+				'id'                   => $post->ID,
+				'code'                 => $c->get_code(),
+				'status'               => $post->post_status,
+				'discount_type'        => $c->get_discount_type(),
+				'discount_value'       => $c->get_discount_value(),
+				'max_discount'         => $c->get_max_discount(),
+				'auto_apply'           => $c->is_auto_apply() ? 'yes' : 'no',
+				'priority'             => $c->get_priority(),
+				'allow_combine'        => $c->allows_combine() ? 'yes' : 'no',
+				'target_items'         => $c->get_target_items(),
+				'exclude_items'        => $c->get_exclude_items(),
+				'target_rent_types'    => $c->get_target_rent_types(),
+				'exclude_rent_types'   => $c->get_exclude_rent_types(),
+				'target_locations'     => $c->get_target_locations(),
+				'exclude_locations'    => $c->get_exclude_locations(),
+				'min_amount'           => $c->get_min_amount(),
+				'max_amount'           => $c->get_max_amount(),
+				'valid_from'           => $c->get_valid_from(),
+				'valid_to'             => $c->get_valid_to(),
+				'weekdays'             => $c->get_weekdays(),
+				'blackout_dates'       => implode( ', ', $c->get_blackout_dates() ),
+				'usage_limit'          => $c->get_usage_limit(),
+				'usage_limit_per_user' => $c->get_usage_limit_per_user(),
+				'usage_limit_per_day'  => $c->get_usage_limit_per_day(),
+				'allowed_roles'        => $c->get_allowed_roles(),
+				'allowed_emails'       => implode( ', ', $c->get_allowed_emails() ),
+				'first_booking_only'   => $c->is_first_booking_only() ? 'yes' : 'no',
+			);
+		}
+
+		private function describe_value( RBFW_Coupon $c ) {
+			switch ( $c->get_discount_type() ) {
+				case 'fixed':
+					return wp_strip_all_tags( wc_price( $c->get_discount_value() ) );
+				case 'free_days':
+					/* translators: %s: number of free units */
+					return sprintf( esc_html__( '%s free day(s)', 'booking-and-rental-manager-for-woocommerce' ), (float) $c->get_discount_value() );
+				default:
+					return (float) $c->get_discount_value() . '%';
+			}
+		}
+
+		private function describe_targets( RBFW_Coupon $c ) {
+			if ( $c->targets_everything() ) {
+				return esc_html__( 'All rentals', 'booking-and-rental-manager-for-woocommerce' );
+			}
+			$bits = array();
+			if ( $c->get_target_items() ) {
+				/* translators: %d: number of rental items */
+				$bits[] = sprintf( esc_html__( '%d item(s)', 'booking-and-rental-manager-for-woocommerce' ), count( $c->get_target_items() ) );
+			}
+			if ( $c->get_target_rent_types() ) {
+				$bits[] = implode( ', ', array_slice( $c->get_target_rent_types(), 0, 3 ) );
+			}
+			if ( $c->get_target_locations() ) {
+				/* translators: %d: number of locations */
+				$bits[] = sprintf( esc_html__( '%d location(s)', 'booking-and-rental-manager-for-woocommerce' ), count( $c->get_target_locations() ) );
+			}
+			return implode( ' · ', $bits );
+		}
+
+		public function render_page() {
+			if ( ! current_user_can( rbfw_bookings_capability() ) ) {
+				wp_die( esc_html__( 'You do not have permission to view this page.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			$coupons       = $this->all_coupons();
+			$items         = $this->item_options();
+			$rent_types    = $this->rent_type_options();
+			$locations     = $this->location_options();
+			$roles         = $this->role_options();
+			$weekdays      = $this->weekday_options();
+			$engine_on     = RBFW_Coupon_Engine::is_enabled();
+			$default_combi = RBFW_Coupon_Engine::setting( 'rbfw_coupon_default_combine', 'off' ) === 'on';
+			$settings_url  = admin_url( 'edit.php?post_type=rbfw_item&page=rbfw_settings_page' );
+
+			$active      = 0;
+			$redemptions = 0;
+			$saved       = 0.0;
+			foreach ( $coupons as $p ) {
+				if ( 'publish' === $p->post_status ) {
+					$active++;
+				}
+				$redemptions += (int) get_post_meta( $p->ID, 'rbfw_usage_count', true );
+				$saved       += (float) get_post_meta( $p->ID, 'rbfw_usage_amount_total', true );
+			}
+			$mode_label = RBFW_Function::booking_mode() === 'woocommerce'
+				? __( 'WooCommerce', 'booking-and-rental-manager-for-woocommerce' )
+				: __( 'Standalone', 'booking-and-rental-manager-for-woocommerce' );
+			?>
+			<div class="wrap rbfw-cpn">
+				<div class="rbfw-cpn-panel">
+					<div class="rbfw-cpn-panel-head">
+						<div class="rbfw-cpn-head-icon"><i class="fas fa-ticket"></i></div>
+						<div class="rbfw-cpn-head-text">
+							<h2><?php esc_html_e( 'Coupons &amp; Automatic Discounts', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+							<p><?php esc_html_e( 'One engine for both booking modes — per-rental targeting, date &amp; spend conditions, usage limits.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+						</div>
+						<button type="button" class="rbfw-cpn-btn-add rbfw-cpn-add">
+							<i class="fas fa-plus"></i> <?php esc_html_e( 'Add Coupon', 'booking-and-rental-manager-for-woocommerce' ); ?>
+						</button>
+					</div>
+
+					<div class="rbfw-cpn-panel-body">
+						<?php if ( ! $engine_on ) : ?>
+							<div class="rbfw-cpn-notice">
+								<i class="fas fa-triangle-exclamation"></i>
+								<span>
+									<?php esc_html_e( 'The coupon engine is disabled — coupons will not apply on the frontend.', 'booking-and-rental-manager-for-woocommerce' ); ?>
+									<a href="<?php echo esc_url( $settings_url ); ?>"><?php esc_html_e( 'Enable it in Settings → Coupons', 'booking-and-rental-manager-for-woocommerce' ); ?></a>
+								</span>
+							</div>
+						<?php endif; ?>
+
+						<div class="rbfw-cpn-stats">
+							<div class="rbfw-cpn-stat">
+								<div class="rbfw-cpn-stat-ico blue"><i class="fas fa-ticket"></i></div>
+								<div><span><?php echo esc_html( count( $coupons ) ); ?></span><label><?php esc_html_e( 'Total Coupons', 'booking-and-rental-manager-for-woocommerce' ); ?></label></div>
+							</div>
+							<div class="rbfw-cpn-stat">
+								<div class="rbfw-cpn-stat-ico green"><i class="fas fa-circle-check"></i></div>
+								<div><span><?php echo esc_html( $active ); ?></span><label><?php esc_html_e( 'Active', 'booking-and-rental-manager-for-woocommerce' ); ?></label></div>
+							</div>
+							<div class="rbfw-cpn-stat">
+								<div class="rbfw-cpn-stat-ico pink"><i class="fas fa-arrow-trend-down"></i></div>
+								<div><span><?php echo esc_html( $redemptions ); ?></span><label><?php esc_html_e( 'Redemptions', 'booking-and-rental-manager-for-woocommerce' ); ?></label></div>
+							</div>
+							<div class="rbfw-cpn-stat">
+								<div class="rbfw-cpn-stat-ico purple"><i class="fas fa-sack-dollar"></i></div>
+								<div><span><?php echo wp_kses_post( wc_price( $saved ) ); ?></span><label><?php esc_html_e( 'Customer Savings', 'booking-and-rental-manager-for-woocommerce' ); ?></label></div>
+							</div>
+							<div class="rbfw-cpn-stat">
+								<div class="rbfw-cpn-stat-ico slate"><i class="fas fa-cart-shopping"></i></div>
+								<div><span class="sm"><?php echo esc_html( $mode_label ); ?></span><label><?php esc_html_e( 'Booking Mode', 'booking-and-rental-manager-for-woocommerce' ); ?></label></div>
+							</div>
+						</div>
+
+						<div class="rbfw-cpn-tablecard">
+							<table class="rbfw-cpn-table">
+								<thead><tr>
+									<th><?php esc_html_e( 'Code', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Discount', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Applies To', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Validity', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Usage', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+									<th><?php esc_html_e( 'Status', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+									<th class="ta-r"><?php esc_html_e( 'Actions', 'booking-and-rental-manager-for-woocommerce' ); ?></th>
+								</tr></thead>
+								<tbody>
+								<?php if ( ! $coupons ) : ?>
+									<tr><td colspan="7" class="rbfw-cpn-empty">
+										<i class="fas fa-ticket"></i>
+										<strong><?php esc_html_e( 'No coupons yet', 'booking-and-rental-manager-for-woocommerce' ); ?></strong>
+										<span><?php esc_html_e( 'Create your first coupon code or an automatic discount rule.', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<button type="button" class="rbfw-cpn-btn primary rbfw-cpn-add"><i class="fas fa-plus"></i> <?php esc_html_e( 'Add Coupon', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+									</td></tr>
+								<?php endif; ?>
+								<?php
+								foreach ( $coupons as $p ) :
+									$c     = new RBFW_Coupon( $p->ID );
+									$limit = $c->get_usage_limit();
+									$used  = $c->get_usage_count();
+									$from  = $c->get_valid_from();
+									$to    = $c->get_valid_to();
+									$pct   = ( $limit > 0 ) ? min( 100, ( $used / $limit ) * 100 ) : 0;
+									?>
+									<tr data-coupon="<?php echo esc_attr( wp_json_encode( $this->coupon_json( $p ) ) ); ?>">
+										<td>
+											<div class="rbfw-cpn-code"><?php echo esc_html( $c->get_code() ); ?></div>
+											<div class="rbfw-cpn-tags">
+												<?php if ( $c->is_auto_apply() ) : ?>
+													<span class="rbfw-cpn-badge auto"><i class="fas fa-bolt"></i><?php esc_html_e( 'AUTO', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+												<?php endif; ?>
+												<?php if ( $c->allows_combine() ) : ?>
+													<span class="rbfw-cpn-badge stack"><i class="fas fa-layer-group"></i><?php esc_html_e( 'STACKS', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+												<?php endif; ?>
+											</div>
+										</td>
+										<td><span class="rbfw-cpn-amount"><?php echo esc_html( $this->describe_value( $c ) ); ?></span></td>
+										<td><span class="rbfw-cpn-muted"><?php echo esc_html( $this->describe_targets( $c ) ); ?></span></td>
+										<td>
+											<span class="rbfw-cpn-muted">
+											<?php
+											if ( $from || $to ) {
+												echo esc_html( ( $from ? $from : '…' ) . ' → ' . ( $to ? $to : '…' ) );
+											} else {
+												esc_html_e( 'Always', 'booking-and-rental-manager-for-woocommerce' );
+											}
+											?>
+											</span>
+										</td>
+										<td>
+											<div class="rbfw-cpn-usage"><?php echo esc_html( $used . ( $limit ? ' / ' . $limit : '' ) ); ?></div>
+											<?php if ( $limit > 0 ) : ?>
+												<div class="rbfw-cpn-bar"><i style="width:<?php echo esc_attr( $pct ); ?>%"></i></div>
+											<?php endif; ?>
+										</td>
+										<td>
+											<span class="rbfw-cpn-status <?php echo 'publish' === $p->post_status ? 'on' : 'off'; ?>">
+												<?php echo 'publish' === $p->post_status ? esc_html__( 'Active', 'booking-and-rental-manager-for-woocommerce' ) : esc_html__( 'Inactive', 'booking-and-rental-manager-for-woocommerce' ); ?>
+											</span>
+										</td>
+										<td class="ta-r rbfw-cpn-actions">
+											<button type="button" class="rbfw-cpn-ico rbfw-cpn-edit" data-id="<?php echo esc_attr( $p->ID ); ?>" title="<?php esc_attr_e( 'Edit', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-pen"></i></button>
+											<button type="button" class="rbfw-cpn-ico rbfw-cpn-toggle" data-id="<?php echo esc_attr( $p->ID ); ?>" title="<?php esc_attr_e( 'Activate / Deactivate', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-power-off"></i></button>
+											<button type="button" class="rbfw-cpn-ico danger rbfw-cpn-delete" data-id="<?php echo esc_attr( $p->ID ); ?>" title="<?php esc_attr_e( 'Delete', 'booking-and-rental-manager-for-woocommerce' ); ?>"><i class="fas fa-trash"></i></button>
+										</td>
+									</tr>
+								<?php endforeach; ?>
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+
+				<?php $this->render_modal( $items, $rent_types, $locations, $roles, $weekdays, $default_combi ); ?>
+			</div>
+			<?php
+		}
+
+		/**
+		 * A searchable multi-select "token" field: click → dropdown list → pick → chip, repeat.
+		 *
+		 * The native <select multiple> stays in the DOM (visually hidden) and remains the single
+		 * source of truth, so $form.serializeArray() keeps posting `name[]` exactly as before and
+		 * ajax_save() is unchanged. The JS only paints chips + a filterable menu on top of it.
+		 */
+		private function token_select( $name, $options, $legend, $mode = 'in', $placeholder = '' ) {
+			$placeholder = $placeholder ? $placeholder : __( 'Click to choose…', 'booking-and-rental-manager-for-woocommerce' );
+			?>
+			<label>
+				<span class="lb">
+					<i class="fas <?php echo 'in' === $mode ? 'fa-circle-plus ok' : 'fa-circle-minus no'; ?>"></i>
+					<?php echo esc_html( $legend ); ?>
+				</span>
+				<select class="rbfw-tok-native"
+						name="<?php echo esc_attr( $name ); ?>[]"
+						multiple
+						data-token
+						data-placeholder="<?php echo esc_attr( $placeholder ); ?>"
+						data-empty="<?php esc_attr_e( 'No matches found', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+					<?php foreach ( $options as $val => $label ) : ?>
+						<option value="<?php echo esc_attr( $val ); ?>"><?php echo esc_html( $label ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				<?php if ( ! $options ) : ?>
+					<small><?php esc_html_e( 'None available yet.', 'booking-and-rental-manager-for-woocommerce' ); ?></small>
+				<?php endif; ?>
+			</label>
+			<?php
+		}
+
+		/** A bordered checkbox grid used for roles / weekdays. */
+		private function checkbox_grid( $name, $options, $legend, $hint = '' ) {
+			?>
+			<fieldset class="rbfw-cpn-grid">
+				<legend><?php echo esc_html( $legend ); ?></legend>
+				<?php if ( $hint ) : ?><p class="rbfw-cpn-hint sm"><?php echo esc_html( $hint ); ?></p><?php endif; ?>
+				<div class="rbfw-cpn-grid-items">
+					<?php foreach ( $options as $val => $label ) : ?>
+						<label class="rbfw-cpn-chk">
+							<input type="checkbox" name="<?php echo esc_attr( $name ); ?>[]" value="<?php echo esc_attr( $val ); ?>">
+							<span><?php echo esc_html( $label ); ?></span>
+						</label>
+					<?php endforeach; ?>
+					<?php if ( ! $options ) : ?>
+						<em class="rbfw-cpn-none"><?php esc_html_e( 'None available', 'booking-and-rental-manager-for-woocommerce' ); ?></em>
+					<?php endif; ?>
+				</div>
+			</fieldset>
+			<?php
+		}
+
+		/** Multi-step wizard. Field names are unchanged — ajax_save() consumes them as-is. */
+		private function render_modal( $items, $rent_types, $locations, $roles, $weekdays, $default_combi ) {
+			$steps = array(
+				array( 'key' => 'basics',    'icon' => 'fa-sliders',        'title' => __( 'Basics', 'booking-and-rental-manager-for-woocommerce' ),    'sub' => __( 'Code & discount', 'booking-and-rental-manager-for-woocommerce' ) ),
+				array( 'key' => 'targeting', 'icon' => 'fa-crosshairs',     'title' => __( 'Targeting', 'booking-and-rental-manager-for-woocommerce' ), 'sub' => __( 'Which rentals', 'booking-and-rental-manager-for-woocommerce' ) ),
+				array( 'key' => 'rules',     'icon' => 'fa-calendar-check', 'title' => __( 'Rules', 'booking-and-rental-manager-for-woocommerce' ),     'sub' => __( 'Spend & dates', 'booking-and-rental-manager-for-woocommerce' ) ),
+				array( 'key' => 'limits',    'icon' => 'fa-user-shield',    'title' => __( 'Limits', 'booking-and-rental-manager-for-woocommerce' ),    'sub' => __( 'Usage & eligibility', 'booking-and-rental-manager-for-woocommerce' ) ),
+				array( 'key' => 'review',    'icon' => 'fa-clipboard-check','title' => __( 'Review', 'booking-and-rental-manager-for-woocommerce' ),    'sub' => __( 'Confirm & save', 'booking-and-rental-manager-for-woocommerce' ) ),
+			);
+			?>
+			<div id="rbfw-cpn-modal" class="rbfw-cpn-modal" aria-hidden="true">
+				<div class="rbfw-cpn-box" role="dialog" aria-modal="true" aria-labelledby="rbfw-cpn-modal-title">
+
+					<div class="rbfw-cpn-modal-head">
+						<div class="rbfw-cpn-head-icon"><i class="fas fa-ticket"></i></div>
+						<div class="rbfw-cpn-head-text">
+							<h2 id="rbfw-cpn-modal-title"><?php esc_html_e( 'Add Coupon', 'booking-and-rental-manager-for-woocommerce' ); ?></h2>
+							<p class="rbfw-cpn-stepcaption"></p>
+						</div>
+						<button type="button" class="rbfw-cpn-close" aria-label="<?php esc_attr_e( 'Close', 'booking-and-rental-manager-for-woocommerce' ); ?>">&times;</button>
+					</div>
+
+					<div class="rbfw-cpn-progress"><i></i></div>
+
+					<form id="rbfw-cpn-form" class="rbfw-cpn-modal-body" novalidate>
+						<input type="hidden" name="coupon_id" value="0">
+
+						<nav class="rbfw-cpn-rail" role="tablist">
+							<?php foreach ( $steps as $i => $s ) : ?>
+								<button type="button" class="rbfw-cpn-railitem<?php echo 0 === $i ? ' is-active' : ''; ?>" data-step="<?php echo esc_attr( $i ); ?>" role="tab">
+									<span class="rbfw-cpn-railnum"><span class="n"><?php echo esc_html( $i + 1 ); ?></span><i class="fas fa-check"></i></span>
+									<span class="rbfw-cpn-railtxt">
+										<strong><?php echo esc_html( $s['title'] ); ?></strong>
+										<small><?php echo esc_html( $s['sub'] ); ?></small>
+									</span>
+								</button>
+							<?php endforeach; ?>
+						</nav>
+
+						<div class="rbfw-cpn-panes">
+
+							<!-- STEP 1 — Basics -->
+							<section class="rbfw-cpn-pane is-active" data-pane="0">
+								<h3 class="rbfw-cpn-sec"><i class="fas fa-sliders"></i><?php esc_html_e( 'Coupon basics', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+								<div class="rbfw-cpn-row">
+									<label class="f2"><span class="lb"><?php esc_html_e( 'Coupon Code', 'booking-and-rental-manager-for-woocommerce' ); ?> <b class="req">*</b></span>
+										<input type="text" name="code" placeholder="SUMMER20" autocomplete="off">
+										<small><?php esc_html_e( 'Also used as the internal name for automatic rules.', 'booking-and-rental-manager-for-woocommerce' ); ?></small>
+									</label>
+									<label><span class="lb"><?php esc_html_e( 'Status', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<select name="status">
+											<option value="publish"><?php esc_html_e( 'Active', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+											<option value="draft"><?php esc_html_e( 'Inactive', 'booking-and-rental-manager-for-woocommerce' ); ?></option>
+										</select>
+									</label>
+								</div>
+
+								<div class="rbfw-cpn-types">
+									<label class="rbfw-cpn-type">
+										<input type="radio" name="discount_type" value="percentage" checked>
+										<span class="card"><i class="fas fa-percent"></i><strong><?php esc_html_e( 'Percentage', 'booking-and-rental-manager-for-woocommerce' ); ?></strong><small><?php esc_html_e( '% off the rental subtotal', 'booking-and-rental-manager-for-woocommerce' ); ?></small></span>
+									</label>
+									<label class="rbfw-cpn-type">
+										<input type="radio" name="discount_type" value="fixed">
+										<span class="card"><i class="fas fa-tag"></i><strong><?php esc_html_e( 'Fixed amount', 'booking-and-rental-manager-for-woocommerce' ); ?></strong><small><?php esc_html_e( 'A flat sum off', 'booking-and-rental-manager-for-woocommerce' ); ?></small></span>
+									</label>
+									<label class="rbfw-cpn-type">
+										<input type="radio" name="discount_type" value="free_days">
+										<span class="card"><i class="fas fa-calendar-day"></i><strong><?php esc_html_e( 'Free days', 'booking-and-rental-manager-for-woocommerce' ); ?></strong><small><?php esc_html_e( 'Waive N rental days', 'booking-and-rental-manager-for-woocommerce' ); ?></small></span>
+									</label>
+								</div>
+
+								<div class="rbfw-cpn-row">
+									<label><span class="lb" data-value-label><?php esc_html_e( 'Value', 'booking-and-rental-manager-for-woocommerce' ); ?> <b class="req">*</b></span>
+										<input type="number" name="discount_value" step="0.01" min="0" placeholder="20">
+									</label>
+									<label id="rbfw-cpn-cap-wrap"><span class="lb"><?php esc_html_e( 'Maximum Discount (cap)', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="number" name="max_discount" step="0.01" min="0" placeholder="<?php esc_attr_e( '0 = no cap', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+										<small><?php esc_html_e( 'Caps how much a percentage coupon can take off.', 'booking-and-rental-manager-for-woocommerce' ); ?></small>
+									</label>
+									<label><span class="lb"><?php esc_html_e( 'Priority', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="number" name="priority" step="1" value="0">
+										<small><?php esc_html_e( 'Higher wins when several automatic rules match.', 'booking-and-rental-manager-for-woocommerce' ); ?></small>
+									</label>
+								</div>
+
+								<div class="rbfw-cpn-switches">
+									<label class="rbfw-cpn-switch">
+										<input type="checkbox" name="auto_apply" value="yes"><span class="track"></span>
+										<span class="txt"><strong><?php esc_html_e( 'Apply automatically', 'booking-and-rental-manager-for-woocommerce' ); ?></strong><small><?php esc_html_e( 'Customers get it without entering a code.', 'booking-and-rental-manager-for-woocommerce' ); ?></small></span>
+									</label>
+									<label class="rbfw-cpn-switch">
+										<input type="checkbox" name="allow_combine" value="yes" <?php checked( $default_combi ); ?>><span class="track"></span>
+										<span class="txt"><strong><?php esc_html_e( 'Allow stacking', 'booking-and-rental-manager-for-woocommerce' ); ?></strong><small><?php esc_html_e( 'Can combine with other coupons that also allow it.', 'booking-and-rental-manager-for-woocommerce' ); ?></small></span>
+									</label>
+								</div>
+							</section>
+
+							<!-- STEP 2 — Targeting -->
+							<section class="rbfw-cpn-pane" data-pane="1">
+								<h3 class="rbfw-cpn-sec"><i class="fas fa-crosshairs"></i><?php esc_html_e( 'Per-rental targeting', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+								<p class="rbfw-cpn-hint"><?php esc_html_e( 'Leave everything empty to apply to all rentals. Include rules are combined (any match wins); exclude rules always override.', 'booking-and-rental-manager-for-woocommerce' ); ?></p>
+
+								<div class="rbfw-cpn-row">
+									<?php $this->token_select( 'target_items', $items, __( 'Include Rental Items', 'booking-and-rental-manager-for-woocommerce' ), 'in', __( 'Search rentals…', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+									<?php $this->token_select( 'exclude_items', $items, __( 'Exclude Rental Items', 'booking-and-rental-manager-for-woocommerce' ), 'ex', __( 'Search rentals…', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+								</div>
+								<div class="rbfw-cpn-row">
+									<?php $this->token_select( 'target_rent_types', $rent_types, __( 'Include Rent Types', 'booking-and-rental-manager-for-woocommerce' ), 'in', __( 'Search rent types…', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+									<?php $this->token_select( 'exclude_rent_types', $rent_types, __( 'Exclude Rent Types', 'booking-and-rental-manager-for-woocommerce' ), 'ex', __( 'Search rent types…', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+								</div>
+								<div class="rbfw-cpn-row">
+									<?php $this->token_select( 'target_locations', $locations, __( 'Include Locations', 'booking-and-rental-manager-for-woocommerce' ), 'in', __( 'Search locations…', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+									<?php $this->token_select( 'exclude_locations', $locations, __( 'Exclude Locations', 'booking-and-rental-manager-for-woocommerce' ), 'ex', __( 'Search locations…', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+								</div>
+							</section>
+
+							<!-- STEP 3 — Rules -->
+							<section class="rbfw-cpn-pane" data-pane="2">
+								<h3 class="rbfw-cpn-sec"><i class="fas fa-calendar-check"></i><?php esc_html_e( 'Spend &amp; date rules', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+								<div class="rbfw-cpn-row">
+									<label><span class="lb"><?php esc_html_e( 'Minimum Booking Amount', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="number" name="min_amount" step="0.01" min="0" placeholder="<?php esc_attr_e( '0 = none', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+									</label>
+									<label><span class="lb"><?php esc_html_e( 'Maximum Booking Amount', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="number" name="max_amount" step="0.01" min="0" placeholder="<?php esc_attr_e( '0 = none', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+									</label>
+									<label><span class="lb"><?php esc_html_e( 'Valid From', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="date" name="valid_from">
+									</label>
+									<label><span class="lb"><?php esc_html_e( 'Valid To', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="date" name="valid_to">
+									</label>
+								</div>
+								<div class="rbfw-cpn-row">
+									<?php $this->checkbox_grid( 'weekdays', $weekdays, __( 'Allowed Booking Weekdays', 'booking-and-rental-manager-for-woocommerce' ), __( 'Empty = every day allowed.', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+									<label><span class="lb"><?php esc_html_e( 'Blackout Dates', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<textarea name="blackout_dates" rows="5" placeholder="2026-12-24, 2026-12-25"></textarea>
+										<small><?php esc_html_e( 'Y-m-d, separated by commas or new lines. Invalid dates are ignored.', 'booking-and-rental-manager-for-woocommerce' ); ?></small>
+									</label>
+								</div>
+							</section>
+
+							<!-- STEP 4 — Limits -->
+							<section class="rbfw-cpn-pane" data-pane="3">
+								<h3 class="rbfw-cpn-sec"><i class="fas fa-user-shield"></i><?php esc_html_e( 'Usage limits &amp; eligibility', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+								<div class="rbfw-cpn-row">
+									<label><span class="lb"><?php esc_html_e( 'Total Usage Limit', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="number" name="usage_limit" step="1" min="0" placeholder="<?php esc_attr_e( '0 = unlimited', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+									</label>
+									<label><span class="lb"><?php esc_html_e( 'Limit Per User', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="number" name="usage_limit_per_user" step="1" min="0" placeholder="<?php esc_attr_e( '0 = unlimited', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+									</label>
+									<label><span class="lb"><?php esc_html_e( 'Limit Per Day', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<input type="number" name="usage_limit_per_day" step="1" min="0" placeholder="<?php esc_attr_e( '0 = unlimited', 'booking-and-rental-manager-for-woocommerce' ); ?>">
+									</label>
+								</div>
+								<div class="rbfw-cpn-row">
+									<?php $this->checkbox_grid( 'allowed_roles', $roles, __( 'Allowed User Roles', 'booking-and-rental-manager-for-woocommerce' ), __( 'Empty = everyone, including guests.', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
+									<label><span class="lb"><?php esc_html_e( 'Allowed Emails', 'booking-and-rental-manager-for-woocommerce' ); ?></span>
+										<textarea name="allowed_emails" rows="5" placeholder="a@example.com, b@example.com"></textarea>
+										<small><?php esc_html_e( 'Empty = any customer. Invalid addresses are ignored.', 'booking-and-rental-manager-for-woocommerce' ); ?></small>
+									</label>
+								</div>
+								<div class="rbfw-cpn-switches">
+									<label class="rbfw-cpn-switch">
+										<input type="checkbox" name="first_booking_only" value="yes"><span class="track"></span>
+										<span class="txt"><strong><?php esc_html_e( 'First booking only', 'booking-and-rental-manager-for-woocommerce' ); ?></strong><small><?php esc_html_e( 'Only customers with no previous booking or order.', 'booking-and-rental-manager-for-woocommerce' ); ?></small></span>
+									</label>
+								</div>
+							</section>
+
+							<!-- STEP 5 — Review -->
+							<section class="rbfw-cpn-pane" data-pane="4">
+								<h3 class="rbfw-cpn-sec"><i class="fas fa-clipboard-check"></i><?php esc_html_e( 'Review &amp; save', 'booking-and-rental-manager-for-woocommerce' ); ?></h3>
+								<div class="rbfw-cpn-review" id="rbfw-cpn-review"></div>
+							</section>
+						</div>
+					</form>
+
+					<div class="rbfw-cpn-modal-foot">
+						<button type="button" class="rbfw-cpn-btn ghost rbfw-cpn-close"><?php esc_html_e( 'Cancel', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+						<span class="rbfw-cpn-msg"></span>
+						<div class="rbfw-cpn-nav">
+							<button type="button" class="rbfw-cpn-btn ghost" data-prev disabled><i class="fas fa-arrow-left"></i> <?php esc_html_e( 'Back', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+							<button type="button" class="rbfw-cpn-btn accent" data-next><?php esc_html_e( 'Next', 'booking-and-rental-manager-for-woocommerce' ); ?> <i class="fas fa-arrow-right"></i></button>
+							<button type="button" class="rbfw-cpn-btn primary" data-save hidden><i class="fas fa-floppy-disk"></i> <?php esc_html_e( 'Save Coupon', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<?php
+		}
+	}
+
+	new RBFW_Coupon_Admin();
+}

--- a/inc/coupon/RBFW_Coupon_Context.php
+++ b/inc/coupon/RBFW_Coupon_Context.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Coupon Context — the single normalized shape both booking modes feed into the engine.
+ *
+ * This is what makes "one engine, both modes" hold: RBFW_Coupon_Engine only ever sees this
+ * array, so validate()/calculate_discount() are written once and reused by WooCommerce and
+ * Standalone alike.
+ *
+ *   [
+ *     'items'    => [ [ item_id, rent_type, rent_type_names[], locations[], qty,
+ *                       duration_units, unit, duration_price, line_total, line_key ] ... ],
+ *     'subtotal' => float,        // sum of line_total across items
+ *     'user_id'  => int,
+ *     'email'    => string,
+ *     'date'     => 'Y-m-d',      // earliest booking start date (weekday / blackout basis)
+ *     'mode'     => 'woocommerce'|'standalone',
+ *   ]
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Context' ) ) {
+	class RBFW_Coupon_Context {
+
+		/**
+		 * Build the context from the live WooCommerce cart.
+		 *
+		 * Reads the per-line data already computed by rbfw_add_cart_item_func (rbfw_tp etc.).
+		 * Only rental lines (cart items carrying an `rbfw_id` that is an rbfw_item) are included.
+		 *
+		 * @return array
+		 */
+		public static function from_wc_cart() {
+			$items    = array();
+			$subtotal = 0.0;
+			$dates    = array();
+
+			if ( function_exists( 'WC' ) && WC()->cart ) {
+				foreach ( WC()->cart->get_cart() as $key => $ci ) {
+					$item_id = isset( $ci['rbfw_id'] ) ? absint( $ci['rbfw_id'] ) : 0;
+					if ( ! $item_id || get_post_type( $item_id ) !== 'rbfw_item' ) {
+						continue;
+					}
+
+					$qty        = isset( $ci['rbfw_item_quantity'] ) ? absint( $ci['rbfw_item_quantity'] ) : ( isset( $ci['quantity'] ) ? absint( $ci['quantity'] ) : 1 );
+					$line_total = isset( $ci['rbfw_tp'] ) ? (float) $ci['rbfw_tp'] : 0.0;
+					$line_total = max( 0, $line_total );
+
+					// The discountable BASE is the rental subtotal: the line total minus the
+					// mandatory management/handling fee. (The security deposit is never part of
+					// rbfw_tp — it is added separately as a WooCommerce cart fee.) Defining it this
+					// way makes WooCommerce and Standalone agree, and guarantees base <= line_total
+					// so a coupon can never drive a line negative even when a large external
+					// multi-day discount has already reduced rbfw_tp.
+					$management = isset( $ci['rbfw_management_price'] ) && is_numeric( $ci['rbfw_management_price'] )
+						? max( 0, (float) $ci['rbfw_management_price'] )
+						: 0.0;
+					$base_price = max( 0, $line_total - $management );
+
+					// duration_price drives only the free_days per-unit rate; never above the base.
+					$duration_price = min( self::resolve_duration_price( $ci, $base_price ), $base_price );
+					$duration_units = self::resolve_duration_units( $ci );
+
+					$desc = self::item_descriptor( $item_id );
+
+					$items[] = array(
+						'item_id'         => $item_id,
+						'rent_type'       => $desc['rent_type'],
+						'rent_type_names' => $desc['rent_type_names'],
+						'locations'       => $desc['locations'],
+						'qty'             => max( 1, $qty ),
+						'duration_units'  => $duration_units,
+						'unit'            => isset( $ci['duration_type'] ) ? (string) $ci['duration_type'] : '',
+						'duration_price'  => max( 0, $duration_price ),
+						'base_price'      => $base_price,
+						'line_total'      => $line_total,
+						'line_key'        => (string) $key,
+					);
+					$subtotal += $line_total;
+
+					$start = self::extract_line_start_date( $ci );
+					if ( $start ) {
+						$dates[] = $start;
+					}
+				}
+			}
+
+			return self::finalize( $items, $subtotal, $dates, 'woocommerce', self::current_email() );
+		}
+
+		/**
+		 * Build the context from a Standalone (native checkout) POST payload — exactly one item.
+		 *
+		 * The standalone form computes prices client-side; v1 uses the posted duration price as
+		 * the discount BASE (a ceiling) and the engine recomputes the discount VALUE server-side.
+		 * The base subtotal itself remains partly client-derived (documented pre-existing gap).
+		 *
+		 * @param array $post Sanitized POST array.
+		 * @return array
+		 */
+		public static function from_native_post( $post ) {
+			$post    = is_array( $post ) ? $post : array();
+			$item_id = isset( $post['rbfw_post_id'] ) ? absint( $post['rbfw_post_id'] ) : 0;
+
+			$items    = array();
+			$subtotal = 0.0;
+
+			if ( $item_id && get_post_type( $item_id ) === 'rbfw_item' ) {
+				$qty  = isset( $post['rbfw_item_quantity'] ) ? absint( $post['rbfw_item_quantity'] ) : 1;
+				$days = 1.0;
+				foreach ( array( 'rbfw_total_days', 'total_days', 'rbfw_duration_days' ) as $dk ) {
+					if ( isset( $post[ $dk ] ) && '' !== $post[ $dk ] ) {
+						$days = (float) self::to_number( $post[ $dk ] );
+						break;
+					}
+				}
+				$days = $days > 0 ? $days : 1.0;
+
+				// Base price: the booking SUBTOTAL (rental + services + variations, excluding the
+				// management fee and the security deposit) — the same definition the WooCommerce
+				// context uses. Falls back to the posted grand total. Client-derived, so it is only
+				// ever a ceiling: the engine recomputes the discount VALUE server-side.
+				$base = 0.0;
+				foreach ( array( 'rbfw_subtotal', 'rbfw_sub_total', 'rbfw_total' ) as $pk ) {
+					if ( isset( $post[ $pk ] ) && '' !== $post[ $pk ] ) {
+						$base = (float) self::to_number( $post[ $pk ] );
+						break;
+					}
+				}
+				$base = max( 0, $base );
+
+				// Duration-only figure (drives the free_days per-unit rate); never above the base.
+				$duration = $base;
+				if ( isset( $post['rbfw_duration_price'] ) && '' !== $post['rbfw_duration_price'] ) {
+					$duration = min( max( 0, (float) self::to_number( $post['rbfw_duration_price'] ) ), $base );
+				}
+
+				$desc = self::item_descriptor( $item_id );
+
+				$items[] = array(
+					'item_id'         => $item_id,
+					'rent_type'       => $desc['rent_type'],
+					'rent_type_names' => $desc['rent_type_names'],
+					'locations'       => $desc['locations'],
+					'qty'             => max( 1, $qty ),
+					'duration_units'  => $days,
+					'unit'            => '',
+					'duration_price'  => $duration,
+					'base_price'      => $base,
+					'line_total'      => $base,
+					'line_key'        => 'native_0',
+				);
+				$subtotal = $base;
+			}
+
+			$dates = array();
+			foreach ( array( 'rbfw_bikecarsd_selected_date', 'rbfw_pickup_start_date' ) as $dk ) {
+				if ( ! empty( $post[ $dk ] ) ) {
+					$dates[] = sanitize_text_field( $post[ $dk ] );
+					break;
+				}
+			}
+
+			$email = isset( $post['rbfw_billing_email'] ) ? sanitize_email( $post['rbfw_billing_email'] ) : self::current_email();
+
+			return self::finalize( $items, $subtotal, $dates, 'standalone', $email );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Helpers
+		 * ---------------------------------------------------------------------- */
+
+		protected static function finalize( $items, $subtotal, $dates, $mode, $email ) {
+			$ctx = array(
+				'items'    => $items,
+				'subtotal' => round( (float) $subtotal, wc_get_price_decimals() ),
+				'user_id'  => get_current_user_id(),
+				'email'    => $email,
+				'date'     => self::earliest_date( $dates ),
+				'mode'     => $mode,
+			);
+
+			/**
+			 * Filter the normalized coupon context before validation.
+			 *
+			 * @param array $ctx The context array.
+			 */
+			return apply_filters( 'rbfw_coupon_validate_context', $ctx );
+		}
+
+		/**
+		 * Item targeting descriptor: rent type slug, category NAMES (name-based, matching the
+		 * rbfw_categories convention), and location term slugs.
+		 *
+		 * @return array{rent_type:string,rent_type_names:string[],locations:string[]}
+		 */
+		public static function item_descriptor( $item_id ) {
+			$item_id   = absint( $item_id );
+			$rent_type = (string) get_post_meta( $item_id, 'rbfw_item_type', true );
+
+			$names = get_post_meta( $item_id, 'rbfw_categories', true );
+			$names = is_array( $names ) ? array_values( array_map( 'strval', $names ) ) : array();
+
+			$locations = array();
+			$terms     = wp_get_post_terms( $item_id, 'rbfw_item_location', array( 'fields' => 'slugs' ) );
+			if ( ! is_wp_error( $terms ) && is_array( $terms ) ) {
+				$locations = array_map( 'strval', $terms );
+			}
+
+			return array(
+				'rent_type'       => $rent_type,
+				'rent_type_names' => $names,
+				'locations'       => $locations,
+			);
+		}
+
+		/**
+		 * The duration (base) price of a WooCommerce cart line. rbfw_add_cart_item_func() stores it
+		 * under a DIFFERENT key per rent type:
+		 *   - multi-day / others / multiple_items → rbfw_duration_price
+		 *   - single-day (bike_car_sd)            → rbfw_bikecarsd_duration_price
+		 *   - resort                              → rbfw_room_duration_price
+		 * Falls back to the full line total when none is present.
+		 */
+		protected static function resolve_duration_price( $ci, $line_total ) {
+			$keys = array( 'rbfw_duration_price', 'rbfw_bikecarsd_duration_price', 'rbfw_room_duration_price' );
+			foreach ( $keys as $k ) {
+				if ( isset( $ci[ $k ] ) && '' !== $ci[ $k ] && is_numeric( $ci[ $k ] ) ) {
+					return max( 0, (float) $ci[ $k ] );
+				}
+			}
+			return $line_total;
+		}
+
+		/**
+		 * Billed units for a line. `total_days` is only set on the multi-day/others/multiple_items
+		 * paths; single-day and resort lines have none, so derive nights from the date span.
+		 * Always >= 1 so the free_days per-unit rate can never divide by zero.
+		 */
+		protected static function resolve_duration_units( $ci ) {
+			if ( isset( $ci['total_days'] ) && is_numeric( $ci['total_days'] ) && (float) $ci['total_days'] > 0 ) {
+				return (float) $ci['total_days'];
+			}
+			$start = isset( $ci['rbfw_start_date'] ) ? strtotime( (string) $ci['rbfw_start_date'] ) : 0;
+			$end   = isset( $ci['rbfw_end_date'] ) ? strtotime( (string) $ci['rbfw_end_date'] ) : 0;
+			if ( $start && $end && $end > $start ) {
+				$days = ( $end - $start ) / DAY_IN_SECONDS;
+				return max( 1.0, round( $days ) );
+			}
+			return 1.0;
+		}
+
+		protected static function extract_line_start_date( $ci ) {
+			foreach ( array( 'rbfw_start_date', 'rbfw_pickup_start_date', 'rbfw_bikecarsd_selected_date' ) as $k ) {
+				if ( ! empty( $ci[ $k ] ) ) {
+					return sanitize_text_field( is_array( $ci[ $k ] ) ? reset( $ci[ $k ] ) : $ci[ $k ] );
+				}
+			}
+			if ( ! empty( $ci['rbfw_ticket_info'] ) && is_array( $ci['rbfw_ticket_info'] ) ) {
+				foreach ( $ci['rbfw_ticket_info'] as $ti ) {
+					if ( ! empty( $ti['rbfw_start_date'] ) ) {
+						return sanitize_text_field( $ti['rbfw_start_date'] );
+					}
+				}
+			}
+			return '';
+		}
+
+		/** Earliest parseable date among the collected line dates, as Y-m-d; today (GMT) if none. */
+		protected static function earliest_date( $dates ) {
+			$stamps = array();
+			foreach ( (array) $dates as $d ) {
+				$ts = strtotime( (string) $d );
+				if ( $ts ) {
+					$stamps[] = $ts;
+				}
+			}
+			$ts = $stamps ? min( $stamps ) : time();
+			return gmdate( 'Y-m-d', $ts );
+		}
+
+		protected static function current_email() {
+			if ( is_user_logged_in() ) {
+				$u = wp_get_current_user();
+				if ( $u && $u->user_email ) {
+					return $u->user_email;
+				}
+			}
+			// Only the real WooCommerce customer has get_billing_email(); the standalone WC()
+			// fallback shim (WooCommerce fully deactivated) does not — guard against it.
+			if ( function_exists( 'WC' ) && is_object( WC()->customer ) && method_exists( WC()->customer, 'get_billing_email' ) ) {
+				$e = WC()->customer->get_billing_email();
+				if ( $e ) {
+					return $e;
+				}
+			}
+			return '';
+		}
+
+		protected static function to_number( $v ) {
+			return preg_replace( '/[^0-9.\-]/', '', (string) $v );
+		}
+	}
+}

--- a/inc/coupon/RBFW_Coupon_Engine.php
+++ b/inc/coupon/RBFW_Coupon_Engine.php
@@ -1,0 +1,540 @@
+<?php
+/**
+ * Coupon Engine — the mode-agnostic brain. Validates a coupon against a normalized context,
+ * computes the per-line discount, and reconciles manual + automatic coupons with stacking.
+ *
+ * Everything here is authoritative and server-side: the engine trusts only the coupon CODE and
+ * the coupon's own configuration — never a client-sent discount amount. Both booking modes call
+ * the same resolve() so behaviour is identical.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Engine' ) ) {
+	class RBFW_Coupon_Engine {
+
+		/* -------------------------------------------------------------------------
+		 * Global on/off
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * The Settings API checkbox stores 'on' when checked and 'off' when unchecked (it renders a
+		 * hidden "off" input). Before the tab is ever saved the key is absent — default to enabled.
+		 */
+		public static function is_enabled() {
+			$opt    = get_option( 'rbfw_coupon_settings' );
+			$enable = ( is_array( $opt ) && isset( $opt['rbfw_coupon_enable'] ) ) ? $opt['rbfw_coupon_enable'] : 'on';
+			return (bool) apply_filters( 'rbfw_coupon_engine_enabled', 'on' === $enable );
+		}
+
+		/** A setting from the Coupons settings tab. */
+		public static function setting( $key, $default = '' ) {
+			$opt = get_option( 'rbfw_coupon_settings' );
+			return ( is_array( $opt ) && isset( $opt[ $key ] ) && '' !== $opt[ $key ] ) ? $opt[ $key ] : $default;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Validation
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * @return array{valid:bool,reason:string}
+		 */
+		public static function validate( RBFW_Coupon $coupon, array $ctx ) {
+			$fail = static function ( $reason ) {
+				return array( 'valid' => false, 'reason' => $reason );
+			};
+
+			if ( ! $coupon->exists() || ! $coupon->is_active() ) {
+				return $fail( esc_html__( 'This coupon is not available.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			// Validity window is evaluated against "now" (coupon live?), in GMT.
+			$today = gmdate( 'Y-m-d' );
+			$from  = $coupon->get_valid_from();
+			$to    = $coupon->get_valid_to();
+			if ( $from && $today < $from ) {
+				return $fail( esc_html__( 'This coupon is not active yet.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+			if ( $to && $today > $to ) {
+				return $fail( esc_html__( 'This coupon has expired.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			// Booking-date based rules use the context date (earliest booking start).
+			$booking_date = isset( $ctx['date'] ) ? $ctx['date'] : $today;
+			$weekdays     = $coupon->get_weekdays();
+			if ( $weekdays ) {
+				$w = (int) gmdate( 'w', strtotime( $booking_date ) );
+				if ( ! in_array( $w, $weekdays, true ) ) {
+					return $fail( esc_html__( 'This coupon is not valid for the selected booking day.', 'booking-and-rental-manager-for-woocommerce' ) );
+				}
+			}
+			if ( in_array( $booking_date, $coupon->get_blackout_dates(), true ) ) {
+				return $fail( esc_html__( 'This coupon cannot be used for the selected date.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			// Targeting — the coupon must apply to at least one line in the cart/booking.
+			$targeted = self::get_targeted_lines( $coupon, $ctx );
+			if ( empty( $targeted ) ) {
+				return $fail( esc_html__( 'This coupon does not apply to the selected item(s).', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			// Spend window (evaluated on the whole booking subtotal).
+			$subtotal = isset( $ctx['subtotal'] ) ? (float) $ctx['subtotal'] : 0.0;
+			$min      = $coupon->get_min_amount();
+			$max      = $coupon->get_max_amount();
+			if ( $min > 0 && $subtotal < $min ) {
+				return $fail( sprintf(
+					/* translators: %s: minimum amount */
+					esc_html__( 'A minimum booking amount of %s is required for this coupon.', 'booking-and-rental-manager-for-woocommerce' ),
+					wp_strip_all_tags( wc_price( $min ) )
+				) );
+			}
+			if ( $max > 0 && $subtotal > $max ) {
+				return $fail( esc_html__( 'This coupon is not valid for a booking of this amount.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			// Eligibility.
+			$user_id = isset( $ctx['user_id'] ) ? absint( $ctx['user_id'] ) : 0;
+			$email   = isset( $ctx['email'] ) ? strtolower( (string) $ctx['email'] ) : '';
+
+			$roles = $coupon->get_allowed_roles();
+			if ( $roles ) {
+				$user       = $user_id ? get_userdata( $user_id ) : null;
+				$user_roles = ( $user && ! empty( $user->roles ) ) ? (array) $user->roles : array();
+				if ( ! array_intersect( $roles, $user_roles ) ) {
+					return $fail( esc_html__( 'This coupon is not available for your account.', 'booking-and-rental-manager-for-woocommerce' ) );
+				}
+			}
+
+			$emails = $coupon->get_allowed_emails();
+			if ( $emails && ! in_array( $email, $emails, true ) ) {
+				return $fail( esc_html__( 'This coupon is restricted to specific customers.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			if ( $coupon->is_first_booking_only() && self::has_prior_bookings( $user_id, $email ) ) {
+				return $fail( esc_html__( 'This coupon is valid on your first booking only.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			// Usage limits.
+			$cid = $coupon->get_id();
+			if ( $coupon->get_usage_limit() > 0 && RBFW_Coupon_Usage::count_total( $cid ) >= $coupon->get_usage_limit() ) {
+				return $fail( esc_html__( 'This coupon has reached its usage limit.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+			if ( $coupon->get_usage_limit_per_user() > 0
+				&& RBFW_Coupon_Usage::count_for_user( $cid, $user_id, $email ) >= $coupon->get_usage_limit_per_user() ) {
+				return $fail( esc_html__( 'You have already used this coupon the maximum number of times.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+			if ( $coupon->get_usage_limit_per_day() > 0
+				&& RBFW_Coupon_Usage::count_for_day( $cid ) >= $coupon->get_usage_limit_per_day() ) {
+				return $fail( esc_html__( 'This coupon has reached its daily usage limit. Please try again later.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			/**
+			 * Final validity gate — lets Pro add extra conditions.
+			 *
+			 * @param bool        $valid  Currently true.
+			 * @param RBFW_Coupon $coupon The coupon.
+			 * @param array       $ctx    The context.
+			 */
+			$valid = (bool) apply_filters( 'rbfw_coupon_is_valid', true, $coupon, $ctx );
+			if ( ! $valid ) {
+				return $fail( esc_html__( 'This coupon cannot be applied to your booking.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			return array( 'valid' => true, 'reason' => '' );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Targeting
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * The lines in $ctx this coupon applies to (include filters minus exclude filters).
+		 *
+		 * @return array List of item rows from $ctx['items'].
+		 */
+		public static function get_targeted_lines( RBFW_Coupon $coupon, array $ctx ) {
+			$out = array();
+			foreach ( ( isset( $ctx['items'] ) ? $ctx['items'] : array() ) as $item ) {
+				if ( self::item_is_targeted( $coupon, $item ) ) {
+					$out[] = $item;
+				}
+			}
+			return $out;
+		}
+
+		protected static function item_is_targeted( RBFW_Coupon $coupon, array $item ) {
+			$id        = isset( $item['item_id'] ) ? absint( $item['item_id'] ) : 0;
+			$names     = isset( $item['rent_type_names'] ) ? (array) $item['rent_type_names'] : array();
+			$rent_type = isset( $item['rent_type'] ) ? (string) $item['rent_type'] : '';
+			$locations = isset( $item['locations'] ) ? (array) $item['locations'] : array();
+
+			// Rent-type targeting matches either a category NAME or the rent_type slug, for flexibility.
+			$type_haystack = array_merge( $names, array( $rent_type ) );
+
+			// Exclusions win.
+			if ( in_array( $id, $coupon->get_exclude_items(), true )
+				|| array_intersect( $type_haystack, $coupon->get_exclude_rent_types() )
+				|| array_intersect( $locations, $coupon->get_exclude_locations() ) ) {
+				return false;
+			}
+
+			if ( $coupon->targets_everything() ) {
+				return true;
+			}
+
+			// Union across include dimensions.
+			return in_array( $id, $coupon->get_target_items(), true )
+				|| (bool) array_intersect( $type_haystack, $coupon->get_target_rent_types() )
+				|| (bool) array_intersect( $locations, $coupon->get_target_locations() );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Discount calculation
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * Compute the per-line discount for one coupon.
+		 *
+		 * @param array $available Optional map line_key => remaining base (for stacking). When a
+		 *                         line is present here its value is used as the base ceiling.
+		 * @return array{total:float,per_line:array<string,float>}
+		 */
+		public static function calculate_discount( RBFW_Coupon $coupon, array $ctx, $available = null ) {
+			$decimals = wc_get_price_decimals();
+			$targeted = self::get_targeted_lines( $coupon, $ctx );
+			if ( empty( $targeted ) ) {
+				return array( 'total' => 0.0, 'per_line' => array() );
+			}
+
+			// Base per targeted line: remaining balance if stacking, else the (filtered) line base.
+			$base = array();
+			foreach ( $targeted as $item ) {
+				$key = (string) $item['line_key'];
+				if ( is_array( $available ) && array_key_exists( $key, $available ) ) {
+					$base[ $key ] = max( 0, (float) $available[ $key ] );
+				} else {
+					$base[ $key ] = max( 0, (float) apply_filters( 'rbfw_coupon_line_base', self::line_base( $item ), $item, $coupon ) );
+				}
+			}
+
+			$type     = $coupon->get_discount_type();
+			$value    = $coupon->get_discount_value();
+			$per_line = array();
+
+			if ( 'free_days' === $type ) {
+				// Per-line, independent: free N billed-units at that line's effective per-unit rate.
+				// The rate comes from the DURATION price (services/fees are not per-day), but the
+				// resulting share is still capped by the line's remaining discountable base.
+				foreach ( $targeted as $item ) {
+					$key   = (string) $item['line_key'];
+					$units = isset( $item['duration_units'] ) ? (float) $item['duration_units'] : 1.0;
+					$units = $units > 0 ? $units : 1.0;
+					$free  = min( $value, $units );
+
+					$duration = isset( $item['duration_price'] ) ? (float) $item['duration_price'] : self::line_base( $item );
+					$duration = min( $duration, $base[ $key ] ); // stacking may have eaten into it
+					$rate     = $duration / $units;
+
+					$share            = min( $base[ $key ], $free * $rate );
+					$per_line[ $key ] = round( $share, $decimals );
+				}
+			} else {
+				// percentage / fixed → a target total distributed across lines proportional to base.
+				$sum_base = array_sum( $base );
+				if ( $sum_base <= 0 ) {
+					return array( 'total' => 0.0, 'per_line' => array() );
+				}
+
+				if ( 'percentage' === $type ) {
+					$pct    = min( 100, max( 0, $value ) ) / 100;
+					$target = $sum_base * $pct;
+					$cap    = $coupon->get_max_discount();
+					if ( $cap > 0 && $target > $cap ) {
+						$target = $cap;
+					}
+				} else { // fixed
+					$target = min( $value, $sum_base );
+				}
+
+				$per_line = self::distribute( $target, $base, $decimals );
+			}
+
+			$total = 0.0;
+			foreach ( $per_line as $k => $amt ) {
+				$amt            = max( 0, (float) $amt );
+				$per_line[ $k ] = $amt;
+				$total         += $amt;
+			}
+
+			return array( 'total' => round( $total, $decimals ), 'per_line' => $per_line );
+		}
+
+		/**
+		 * The discountable base of a line: the rental subtotal (line total minus mandatory
+		 * management fee). Falls back gracefully for contexts that only carry a duration price.
+		 *
+		 * @param array $item
+		 * @return float
+		 */
+		public static function line_base( array $item ) {
+			if ( isset( $item['base_price'] ) ) {
+				return max( 0, (float) $item['base_price'] );
+			}
+			if ( isset( $item['duration_price'] ) ) {
+				return max( 0, (float) $item['duration_price'] );
+			}
+			return isset( $item['line_total'] ) ? max( 0, (float) $item['line_total'] ) : 0.0;
+		}
+
+		/**
+		 * Distribute a total across weighted buckets using largest-remainder rounding so the
+		 * rounded parts sum EXACTLY to the (rounded) total. Keys are preserved.
+		 *
+		 * @param float                $total
+		 * @param array<string,float>  $weights key => weight (also the per-line ceiling)
+		 * @param int                  $decimals
+		 * @return array<string,float>
+		 */
+		protected static function distribute( $total, array $weights, $decimals ) {
+			$out = array();
+			foreach ( $weights as $k => $w ) {
+				$out[ $k ] = 0.0;
+			}
+			$sum_w = array_sum( $weights );
+			if ( $total <= 0 || $sum_w <= 0 ) {
+				return $out;
+			}
+
+			$factor      = (int) pow( 10, max( 0, (int) $decimals ) );
+			$total_units = (int) round( $total * $factor );
+
+			$floor_units = array();
+			$remainders  = array();
+			$assigned    = 0;
+			foreach ( $weights as $k => $w ) {
+				$exact          = $total_units * ( $w / $sum_w );
+				$floor          = (int) floor( $exact );
+				$floor_units[ $k ] = $floor;
+				$remainders[ $k ]  = $exact - $floor;
+				$assigned         += $floor;
+			}
+
+			$leftover = $total_units - $assigned;
+			if ( $leftover > 0 ) {
+				arsort( $remainders );
+				foreach ( array_keys( $remainders ) as $k ) {
+					if ( $leftover <= 0 ) {
+						break;
+					}
+					$floor_units[ $k ]++;
+					$leftover--;
+				}
+			}
+
+			foreach ( $floor_units as $k => $units ) {
+				// Never exceed the line's own ceiling.
+				$out[ $k ] = min( (float) $weights[ $k ], $units / $factor );
+			}
+			return $out;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Resolution — manual + automatic + stacking
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * Resolve the discount for a context, given an optional manually entered code.
+		 *
+		 * @return array{
+		 *   applied:array<int,array{id:int,code:string,type:string,amount:float}>,
+		 *   per_line:array<string,float>,
+		 *   total_discount:float,
+		 *   manual_error:string
+		 * }
+		 */
+		public static function resolve( array $ctx, $manual_code = '' ) {
+			$empty = array( 'applied' => array(), 'per_line' => array(), 'total_discount' => 0.0, 'manual_error' => '' );
+
+			if ( ! self::is_enabled() || empty( $ctx['items'] ) ) {
+				return $empty;
+			}
+
+			$manual       = null;
+			$manual_error = '';
+			$manual_code  = RBFW_Coupon::normalize_code( $manual_code );
+
+			// Cheap short-circuit: nothing typed and no automatic rules exist → no work to do.
+			if ( '' === $manual_code && ! RBFW_Coupon::has_auto_coupons() ) {
+				return $empty;
+			}
+			if ( '' !== $manual_code ) {
+				$candidate = RBFW_Coupon::load_by_code( $manual_code );
+				if ( ! $candidate ) {
+					$manual_error = esc_html__( 'Invalid coupon code.', 'booking-and-rental-manager-for-woocommerce' );
+				} else {
+					$v = self::validate( $candidate, $ctx );
+					if ( $v['valid'] ) {
+						$manual = $candidate;
+					} else {
+						$manual_error = $v['reason'];
+					}
+				}
+			}
+
+			// Valid automatic coupons, priority-ordered.
+			$autos = array();
+			foreach ( RBFW_Coupon::get_active_auto_coupons() as $auto ) {
+				if ( $manual && $auto->get_id() === $manual->get_id() ) {
+					continue; // don't double-apply a coupon that is also the manual one
+				}
+				$v = self::validate( $auto, $ctx );
+				if ( $v['valid'] ) {
+					$autos[] = $auto;
+				}
+			}
+
+			// Build the ordered apply list, honouring stacking.
+			$list = array();
+			if ( $manual ) {
+				$list[] = $manual;
+				if ( $manual->allows_combine() ) {
+					foreach ( $autos as $a ) {
+						if ( $a->allows_combine() ) {
+							$list[] = $a;
+						}
+					}
+				}
+			} elseif ( $autos ) {
+				$best   = $autos[0]; // highest priority
+				$list[] = $best;
+				if ( $best->allows_combine() ) {
+					foreach ( array_slice( $autos, 1 ) as $a ) {
+						if ( $a->allows_combine() ) {
+							$list[] = $a;
+						}
+					}
+				}
+			}
+
+			// Apply sequentially against remaining per-line balances.
+			$remaining = array();
+			foreach ( $ctx['items'] as $item ) {
+				$key               = (string) $item['line_key'];
+				$remaining[ $key ] = max( 0, (float) apply_filters( 'rbfw_coupon_line_base', self::line_base( $item ), $item, null ) );
+			}
+
+			$per_line_merged = array();
+			$applied         = array();
+			foreach ( $list as $coupon ) {
+				$res = self::calculate_discount( $coupon, $ctx, $remaining );
+				if ( $res['total'] <= 0 ) {
+					continue;
+				}
+				foreach ( $res['per_line'] as $key => $amt ) {
+					$remaining[ $key ]       = max( 0, ( isset( $remaining[ $key ] ) ? $remaining[ $key ] : 0 ) - $amt );
+					$per_line_merged[ $key ] = ( isset( $per_line_merged[ $key ] ) ? $per_line_merged[ $key ] : 0 ) + $amt;
+				}
+				$applied[] = array(
+					'id'     => $coupon->get_id(),
+					'code'   => $coupon->get_code(),
+					'type'   => $coupon->get_discount_type(),
+					'amount' => $res['total'],
+				);
+			}
+
+			$total = round( array_sum( $per_line_merged ), wc_get_price_decimals() );
+
+			$result = array(
+				'applied'        => $applied,
+				'per_line'       => $per_line_merged,
+				'total_discount' => $total,
+				'manual_error'   => $manual_error,
+			);
+
+			/**
+			 * Fires after resolution. Read-only observation seam for Pro (analytics etc.).
+			 *
+			 * @param array $result
+			 * @param array $ctx
+			 */
+			do_action( 'rbfw_coupon_applied', $result, $ctx );
+
+			return $result;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Usage recording (delegates to RBFW_Coupon_Usage)
+		 * ---------------------------------------------------------------------- */
+
+		public static function record_usage( $code, $object, $user_id = 0, $email = '', $amount = 0.0 ) {
+			$coupon = RBFW_Coupon::load_by_code( $code );
+			if ( ! $coupon ) {
+				// Fall back to any coupon (incl. inactive) so a later-deactivated coupon still counts.
+				$coupon = self::load_any_by_code( $code );
+			}
+			if ( ! $coupon ) {
+				return false;
+			}
+			return RBFW_Coupon_Usage::record( $coupon->get_id(), $object, $user_id, $email, $amount );
+		}
+
+		/** Load a coupon by code regardless of active/inactive status (for usage recording). */
+		protected static function load_any_by_code( $code ) {
+			$code = RBFW_Coupon::normalize_code( $code );
+			if ( '' === $code ) {
+				return null;
+			}
+			$q = new WP_Query( array(
+				'post_type'      => RBFW_Coupon_Post_Type::POST_TYPE,
+				'post_status'    => array( 'publish', 'draft', 'pending', 'private' ),
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array( 'key' => 'rbfw_code', 'value' => $code, 'compare' => '=' ),
+				),
+			) );
+			return empty( $q->posts ) ? null : new RBFW_Coupon( (int) $q->posts[0] );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Helpers
+		 * ---------------------------------------------------------------------- */
+
+		/** Whether the user/email already has a prior booking or WooCommerce order. */
+		protected static function has_prior_bookings( $user_id, $email ) {
+			$user_id = absint( $user_id );
+			$email   = sanitize_email( $email );
+
+			if ( $user_id && function_exists( 'wc_get_customer_order_count' ) && wc_get_customer_order_count( $user_id ) > 0 ) {
+				return true;
+			}
+
+			$meta_query = array( 'relation' => 'OR' );
+			if ( $user_id ) {
+				$meta_query[] = array( 'key' => 'rbfw_user_id', 'value' => $user_id, 'compare' => '=' );
+			}
+			if ( $email ) {
+				$meta_query[] = array( 'key' => 'rbfw_customer_email', 'value' => $email, 'compare' => '=' );
+			}
+			if ( count( $meta_query ) < 2 ) {
+				return false; // nothing to match on
+			}
+
+			$q = new WP_Query( array(
+				'post_type'      => 'rbfw_booking',
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'fields'         => 'ids',
+				'meta_query'     => $meta_query,
+			) );
+			return ! empty( $q->posts );
+		}
+	}
+}

--- a/inc/coupon/RBFW_Coupon_Frontend.php
+++ b/inc/coupon/RBFW_Coupon_Frontend.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Frontend coupon field.
+ *
+ * Placement differs by mode, because the two modes have different "carts":
+ *  - Standalone: one booking = one item, so the field lives INSIDE the booking form. It is
+ *    rendered on the shared `rbfw_ticket_feature_info` hook (present inside the <form> of all
+ *    four registration templates, just after the totals) — no template edits required, so theme
+ *    overrides keep working.
+ *  - WooCommerce: a real multi-item cart exists, so the field lives on the cart/checkout page
+ *    where the coupon can be validated against actual cart contents.
+ *
+ * The field NEVER rewrites the `.total` element: rbfw_native_checkout.js reads that element and
+ * posts it as `rbfw_total`, so discounting it here would make the server subtract twice (and the
+ * pricing scripts rewrite it on every input change anyway). The discount is shown in its own
+ * summary row instead.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Frontend' ) ) {
+	class RBFW_Coupon_Frontend {
+
+		public function __construct() {
+			// Coupon entry points, by mode:
+			//  - Standalone: the field lives INSIDE the native checkout modal (templates/layout/
+			//    native_checkout_modal.php), right by the Total + Confirm, handled by
+			//    rbfw_native_checkout.js. We deliberately do NOT also render it on the item-page
+			//    booking form — two fields would double-submit the code.
+			//  - WooCommerce: the native WC coupon field (classic cart/checkout AND the Blocks)
+			//    accepts our codes via RBFW_Coupon_WC's virtual-coupon bridge.
+
+			// Keep the "any automatic rules?" cache honest whenever a coupon changes.
+			add_action( 'save_post_' . RBFW_Coupon_Post_Type::POST_TYPE, array( 'RBFW_Coupon', 'flush_auto_cache' ) );
+			add_action( 'deleted_post', array( 'RBFW_Coupon', 'flush_auto_cache' ), 10, 2 );
+		}
+
+		/** @deprecated internal alias — the cache lives on RBFW_Coupon. */
+		public static function flush_auto_cache() {
+			RBFW_Coupon::flush_auto_cache();
+		}
+
+		public static function enabled() {
+			return class_exists( 'RBFW_Coupon_Engine' )
+				&& RBFW_Coupon_Engine::is_enabled()
+				&& 'no' !== RBFW_Coupon_Engine::setting( 'rbfw_coupon_show_field', 'yes' );
+		}
+
+		/** Are there any active automatic rules? Lets the JS skip a needless preview request. */
+		public static function has_auto_coupons() {
+			return RBFW_Coupon::has_auto_coupons();
+		}
+
+		private function label() {
+			return RBFW_Coupon_Engine::setting( 'rbfw_coupon_label', __( 'Have a coupon?', 'booking-and-rental-manager-for-woocommerce' ) );
+		}
+
+		private function placeholder() {
+			return RBFW_Coupon_Engine::setting( 'rbfw_coupon_placeholder', __( 'Enter coupon code', 'booking-and-rental-manager-for-woocommerce' ) );
+		}
+
+		/** Standalone: inside the booking form. */
+		public function render_form_field() {
+			if ( ! self::enabled() || RBFW_Function::use_wc() ) {
+				return;
+			}
+			$this->markup( 'native' );
+		}
+
+		/** WooCommerce: on the cart / checkout page (a real cart exists there). */
+		public function render_wc_field() {
+			if ( ! self::enabled() || ! RBFW_Function::use_wc() ) {
+				return;
+			}
+			if ( ! function_exists( 'WC' ) || ! WC()->cart || WC()->cart->is_empty() ) {
+				return;
+			}
+			$this->markup( 'wc' );
+		}
+
+		/**
+		 * The field itself. The submit button is type="button" so it can never submit the
+		 * surrounding booking form; only the hidden input carries the code into the POST.
+		 */
+		private function markup( $mode ) {
+			$applied_code = '';
+			if ( 'wc' === $mode && class_exists( 'RBFW_Coupon_WC' ) ) {
+				// Static read — constructing RBFW_Coupon_WC here would re-register its hooks.
+				$applied_code = RBFW_Coupon_WC::get_session_code();
+			}
+			?>
+			<div class="rbfw-coupon" data-rbfw-coupon data-rbfw-coupon-mode="<?php echo esc_attr( $mode ); ?>">
+				<label class="rbfw-coupon__label" for="rbfw-coupon-input-<?php echo esc_attr( $mode ); ?>">
+					<?php echo esc_html( $this->label() ); ?>
+				</label>
+				<div class="rbfw-coupon__row">
+					<input type="text"
+						   id="rbfw-coupon-input-<?php echo esc_attr( $mode ); ?>"
+						   class="rbfw-coupon__input"
+						   autocomplete="off"
+						   value="<?php echo esc_attr( $applied_code ); ?>"
+						   placeholder="<?php echo esc_attr( $this->placeholder() ); ?>">
+					<button type="button" class="rbfw-coupon__apply">
+						<?php esc_html_e( 'Apply', 'booking-and-rental-manager-for-woocommerce' ); ?>
+					</button>
+				</div>
+
+				<?php // Serialized with the booking form in standalone mode. ?>
+				<input type="hidden" name="rbfw_coupon_code" class="rbfw-coupon__code" value="<?php echo esc_attr( $applied_code ); ?>">
+
+				<div class="rbfw-coupon__msg" role="status" aria-live="polite"></div>
+
+				<div class="rbfw-coupon__summary"<?php echo $applied_code ? '' : ' hidden'; ?>>
+					<span class="rbfw-coupon__applied"></span>
+					<button type="button" class="rbfw-coupon__remove">
+						<?php esc_html_e( 'Remove', 'booking-and-rental-manager-for-woocommerce' ); ?>
+					</button>
+				</div>
+			</div>
+			<?php
+		}
+	}
+
+	new RBFW_Coupon_Frontend();
+}

--- a/inc/coupon/RBFW_Coupon_Native.php
+++ b/inc/coupon/RBFW_Coupon_Native.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Standalone (native checkout) application layer for the unified coupon engine.
+ *
+ * Loaded only when the WooCommerce cart/checkout flow is NOT in use, so it cannot rely on a
+ * WC session: the applied code travels with the booking form as `rbfw_coupon_code` and is
+ * re-validated server-side on submit (see RBFW_Native_Checkout::process()).
+ *
+ * This class provides the live preview endpoint used by the coupon field. It is READ-ONLY —
+ * it never records usage and never trusts a client-sent discount; it only echoes back what the
+ * engine computes from the coupon's own configuration.
+ *
+ * Endpoint name is deliberately distinct from the WooCommerce one: when WooCommerce is active
+ * but Booking Mode = Standalone, BOTH layers are loaded and must not collide.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Native' ) ) {
+	class RBFW_Coupon_Native {
+
+		public function __construct() {
+			add_action( 'wp_ajax_rbfw_apply_coupon_native', array( $this, 'ajax_apply' ) );
+			add_action( 'wp_ajax_nopriv_rbfw_apply_coupon_native', array( $this, 'ajax_apply' ) );
+		}
+
+		/**
+		 * Validate a code (or resolve automatic discounts) against the posted booking form and
+		 * return a preview of the discount. Nothing is persisted.
+		 */
+		public function ajax_apply() {
+			check_ajax_referer( 'rbfw_apply_coupon_action', 'nonce' );
+
+			if ( RBFW_Function::use_wc() || ! RBFW_Coupon_Engine::is_enabled() ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Coupons are not available.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			// preview=1 → resolve automatic discounts with no code entered (page load).
+			$preview = isset( $_POST['preview'] ) && '1' === sanitize_text_field( wp_unslash( $_POST['preview'] ) );
+			$code    = isset( $_POST['code'] ) ? sanitize_text_field( wp_unslash( $_POST['code'] ) ) : '';
+
+			if ( ! $preview && '' === trim( $code ) ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Please enter a coupon code.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			$raw     = RBFW_Function::data_sanitize( wp_unslash( $_POST ) );
+			$item_id = isset( $raw['rbfw_post_id'] ) ? absint( $raw['rbfw_post_id'] ) : 0;
+			if ( ! $item_id || get_post_type( $item_id ) !== 'rbfw_item' ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Invalid rental item.', 'booking-and-rental-manager-for-woocommerce' ) ) );
+			}
+
+			$ctx = RBFW_Coupon_Context::from_native_post( $raw );
+			$res = RBFW_Coupon_Engine::resolve( $ctx, $code );
+
+			if ( '' !== trim( $code ) && '' !== $res['manual_error'] ) {
+				wp_send_json_error( array( 'message' => $res['manual_error'] ) );
+			}
+
+			$gross     = self::posted_total( $raw, $ctx );
+			$discount  = min( (float) $res['total_discount'], $gross );
+			$new_total = max( 0, $gross - $discount );
+
+			$codes = array();
+			foreach ( $res['applied'] as $a ) {
+				$codes[] = $a['code'];
+			}
+
+			wp_send_json_success( array(
+				'message'       => $discount > 0
+					? esc_html__( 'Coupon applied.', 'booking-and-rental-manager-for-woocommerce' )
+					: esc_html__( 'No discount applies to this booking.', 'booking-and-rental-manager-for-woocommerce' ),
+				'code'          => implode( ', ', $codes ),
+				'applied'       => $codes,
+				'discount'      => round( $discount, wc_get_price_decimals() ),
+				'discount_html' => wp_strip_all_tags( wc_price( $discount ) ),
+				'total'         => round( $new_total, wc_get_price_decimals() ),
+				'total_html'    => wp_strip_all_tags( wc_price( $new_total ) ),
+			) );
+		}
+
+		/** The client-computed grand total (pre-coupon). Used only as a ceiling. */
+		public static function posted_total( $raw, $ctx ) {
+			if ( isset( $raw['rbfw_total'] ) && '' !== $raw['rbfw_total'] ) {
+				return max( 0, (float) preg_replace( '/[^0-9.]/', '', (string) $raw['rbfw_total'] ) );
+			}
+			return isset( $ctx['subtotal'] ) ? max( 0, (float) $ctx['subtotal'] ) : 0.0;
+		}
+	}
+
+	new RBFW_Coupon_Native();
+}

--- a/inc/coupon/RBFW_Coupon_Post_Type.php
+++ b/inc/coupon/RBFW_Coupon_Post_Type.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Registers the `rbfw_coupon` custom post type that stores each coupon / automatic
+ * discount rule for the unified coupon engine.
+ *
+ * The engine works identically in WooCommerce and Standalone modes, so this CPT (and
+ * the whole engine) loads in EVERY execution context — do not gate registration on
+ * is_admin(). It is hidden from the default admin menu (show_in_menu => false); coupons
+ * are managed through the custom "Coupons" page under the Rental menu (RBFW_Coupon_Admin).
+ *
+ * Storage philosophy mirrors rbfw_booking: CPT + flat rbfw_* post meta, no custom tables.
+ * The coupon code lives both in post_title (human-readable, admin list) and in the
+ * normalized meta `rbfw_code` (uppercased, trimmed) which is what lookups query against.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Post_Type' ) ) {
+	class RBFW_Coupon_Post_Type {
+
+		const POST_TYPE = 'rbfw_coupon';
+
+		public function __construct() {
+			add_action( 'init', array( $this, 'register' ) );
+		}
+
+		public function register() {
+			$labels = array(
+				'name'          => esc_html__( 'Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+				'singular_name' => esc_html__( 'Coupon', 'booking-and-rental-manager-for-woocommerce' ),
+				'menu_name'     => esc_html__( 'Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+				'all_items'     => esc_html__( 'Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+				'edit_item'     => esc_html__( 'Edit Coupon', 'booking-and-rental-manager-for-woocommerce' ),
+				'search_items'  => esc_html__( 'Search Coupons', 'booking-and-rental-manager-for-woocommerce' ),
+				'not_found'     => esc_html__( 'No coupons found', 'booking-and-rental-manager-for-woocommerce' ),
+			);
+
+			$args = array(
+				'labels'              => $labels,
+				'public'              => false,
+				'publicly_queryable'  => false,
+				'show_ui'             => false,
+				'show_in_menu'        => false,
+				'show_in_admin_bar'   => false,
+				'show_in_nav_menus'   => false,
+				'exclude_from_search' => true,
+				'has_archive'         => false,
+				'rewrite'             => false,
+				'query_var'           => false,
+				'hierarchical'        => false,
+				'supports'            => array( 'title' ),
+				'map_meta_cap'        => true,
+				'capability_type'     => 'post',
+			);
+
+			register_post_type( self::POST_TYPE, $args );
+		}
+	}
+
+	new RBFW_Coupon_Post_Type();
+}

--- a/inc/coupon/RBFW_Coupon_Usage.php
+++ b/inc/coupon/RBFW_Coupon_Usage.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Coupon usage tracking — counters + idempotent redemption recording.
+ *
+ * DESIGN: every usage counter lives on the COUPON post as meta, incremented atomically at
+ * the DB level. This is deliberately independent of where the order/booking is stored, so it
+ * is correct under WooCommerce HPOS (order meta lives in a custom table that WP_Query cannot
+ * scan) and in Standalone mode alike:
+ *
+ *   rbfw_usage_count                 total redemptions        (cheap total-cap gate)
+ *   rbfw_usage_user_<user_id>        redemptions by that user (per-user cap)
+ *   rbfw_usage_email_<md5(email)>    redemptions by a guest   (per-user cap, logged-out)
+ *   rbfw_usage_day_<Ymd GMT>         redemptions that day     (per-day cap)
+ *   rbfw_usage_amount_total          aggregate money discounted (reporting, best-effort)
+ *
+ * Idempotency: recording is guarded by a `rbfw_coupon_recorded` flag written on the
+ * order/booking object. WooCommerce fires its paid hooks more than once, so record() no-ops
+ * if the flag is already set — the coupon counters are never double-incremented.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_Usage' ) ) {
+	class RBFW_Coupon_Usage {
+
+		/* -------------------------------------------------------------------------
+		 * Recording
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * Record one redemption of a coupon against an order/booking. Idempotent.
+		 *
+		 * @param int    $coupon_id  rbfw_coupon post id.
+		 * @param array  $object     [ 'type' => 'order'|'booking', 'id' => int ].
+		 * @param int    $user_id    Redeeming user (0 for guest).
+		 * @param string $email      Redeeming email (used when user_id is 0).
+		 * @param float  $amount     Discount amount granted.
+		 * @return bool  True if newly recorded, false if it was already recorded (or invalid).
+		 */
+		public static function record( $coupon_id, $object, $user_id = 0, $email = '', $amount = 0.0 ) {
+			$coupon_id = absint( $coupon_id );
+			$object_id = isset( $object['id'] ) ? absint( $object['id'] ) : 0;
+			$type      = isset( $object['type'] ) ? $object['type'] : '';
+
+			if ( ! $coupon_id || ! $object_id || ! in_array( $type, array( 'order', 'booking' ), true ) ) {
+				return false;
+			}
+
+			// Idempotency guard — do not double count on hook re-fires. Keyed per COUPON so that
+			// several stacked coupons on the same order each record exactly once.
+			$guard = 'rbfw_coupon_recorded_' . $coupon_id;
+			if ( self::object_meta_get( $type, $object_id, $guard ) ) {
+				return false;
+			}
+			self::object_meta_set( $type, $object_id, $guard, '1' );
+
+			$user_id = absint( $user_id );
+			$email   = sanitize_email( $email );
+			$amount  = (float) $amount;
+
+			self::increment_meta( $coupon_id, 'rbfw_usage_count' );
+			self::increment_meta( $coupon_id, self::user_key( $user_id, $email ) );
+			self::increment_meta( $coupon_id, self::day_key( self::today_gmt() ) );
+
+			if ( $amount > 0 ) {
+				// Reporting aggregate — best-effort (not money-authoritative), so a plain RMW is fine.
+				$current = (float) get_post_meta( $coupon_id, 'rbfw_usage_amount_total', true );
+				update_post_meta( $coupon_id, 'rbfw_usage_amount_total', round( $current + $amount, wc_get_price_decimals() ) );
+			}
+
+			/**
+			 * Fires after a coupon redemption is recorded.
+			 *
+			 * @param int   $coupon_id rbfw_coupon id.
+			 * @param array $object    [type,id] of the order/booking.
+			 * @param float $amount    Discount granted.
+			 */
+			do_action( 'rbfw_coupon_recorded', $coupon_id, $object, $amount );
+
+			return true;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Counting (all O(1) reads off the coupon post)
+		 * ---------------------------------------------------------------------- */
+
+		public static function count_total( $coupon_id ) {
+			return (int) get_post_meta( absint( $coupon_id ), 'rbfw_usage_count', true );
+		}
+
+		public static function count_for_user( $coupon_id, $user_id, $email = '' ) {
+			return (int) get_post_meta( absint( $coupon_id ), self::user_key( absint( $user_id ), $email ), true );
+		}
+
+		public static function count_for_day( $coupon_id, $date_ymd = '' ) {
+			$date_ymd = $date_ymd ? $date_ymd : self::today_gmt();
+			return (int) get_post_meta( absint( $coupon_id ), self::day_key( $date_ymd ), true );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Keys
+		 * ---------------------------------------------------------------------- */
+
+		protected static function user_key( $user_id, $email ) {
+			if ( $user_id > 0 ) {
+				return 'rbfw_usage_user_' . $user_id;
+			}
+			$email = strtolower( sanitize_email( $email ) );
+			return 'rbfw_usage_email_' . md5( $email );
+		}
+
+		protected static function day_key( $date_ymd ) {
+			return 'rbfw_usage_day_' . preg_replace( '/[^0-9]/', '', $date_ymd );
+		}
+
+		protected static function today_gmt() {
+			return gmdate( 'Ymd' );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Atomic-ish counter increment on a coupon post meta row
+		 * ---------------------------------------------------------------------- */
+
+		protected static function increment_meta( $post_id, $key ) {
+			global $wpdb;
+			$post_id = absint( $post_id );
+
+			// Atomic increment when the row already exists (avoids lost updates on concurrent
+			// checkouts). meta_value is stored as text; MySQL casts it for the arithmetic.
+			$updated = $wpdb->query( $wpdb->prepare(
+				"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s",
+				$post_id,
+				$key
+			) );
+
+			if ( ! $updated ) {
+				// Row did not exist yet — create it. unique=true guards a concurrent create.
+				add_post_meta( $post_id, $key, 1, true );
+			}
+
+			wp_cache_delete( $post_id, 'post_meta' );
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Object meta helpers (HPOS-safe for orders)
+		 * ---------------------------------------------------------------------- */
+
+		protected static function object_meta_get( $type, $object_id, $key ) {
+			if ( 'order' === $type && function_exists( 'wc_get_order' ) ) {
+				$order = wc_get_order( $object_id );
+				return $order ? $order->get_meta( $key ) : '';
+			}
+			return get_post_meta( $object_id, $key, true );
+		}
+
+		protected static function object_meta_set( $type, $object_id, $key, $value ) {
+			if ( 'order' === $type && function_exists( 'wc_get_order' ) ) {
+				$order = wc_get_order( $object_id );
+				if ( $order ) {
+					$order->update_meta_data( $key, $value );
+					$order->save();
+				}
+				return;
+			}
+			update_post_meta( $object_id, $key, $value );
+		}
+	}
+}

--- a/inc/coupon/RBFW_Coupon_WC.php
+++ b/inc/coupon/RBFW_Coupon_WC.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * WooCommerce application layer — bridges the unified coupon engine into WooCommerce's own
+ * coupon system so codes work in EVERY WooCommerce surface: the classic cart/checkout, the
+ * Cart/Checkout Blocks, and the Store API. All of those validate a code by constructing a
+ * WC_Coupon, which fires `woocommerce_get_shop_coupon_data`; we answer that filter with a
+ * "virtual" coupon (no shop_coupon post needed) whose amount is computed by OUR engine.
+ *
+ * The engine stays authoritative: it decides validity (targeting, dates, spend, usage limits,
+ * eligibility) and the exact discount amount. WooCommerce is only the delivery mechanism, so the
+ * discount renders natively in the cart, Block checkout, order, emails and reports.
+ *
+ * The `rbfw_order` mirror / thank-you / PDF read the `_rbfw_ticket_info` snapshot (captured at
+ * add-to-cart, pre-coupon), which a native coupon does NOT touch — so we still rewrite that
+ * snapshot at order creation so revenue reporting reflects the discount.
+ *
+ * @package booking-and-rental-manager-for-woocommerce
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'RBFW_Coupon_WC' ) ) {
+	class RBFW_Coupon_WC {
+
+		/** @var array code(normalized) => rejection reason, for friendlier error messaging. */
+		protected static $reasons = array();
+
+		/** @var array|null Memoized applied-coupon resolution during order creation. */
+		protected $order_resolution = null;
+
+		public function __construct() {
+			// THE bridge: make our codes resolvable as WooCommerce coupons everywhere.
+			add_filter( 'woocommerce_get_shop_coupon_data', array( $this, 'virtual_coupon' ), 10, 3 );
+			add_filter( 'woocommerce_coupon_error', array( $this, 'coupon_error' ), 10, 3 );
+
+			// Auto-apply no-code rules onto the cart.
+			add_action( 'woocommerce_before_calculate_totals', array( $this, 'auto_apply' ), 5 );
+
+			// Keep the rbfw_order mirror / thank-you / PDF honest (they read _rbfw_ticket_info).
+			add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'persist_line_coupon' ), 95, 4 );
+			add_action( 'woocommerce_checkout_create_order', array( $this, 'persist_order_meta' ), 20, 2 );
+			add_action( 'woocommerce_store_api_checkout_order_processed', array( $this, 'persist_order_meta_and_save' ), 20 );
+
+			// Record usage on paid (idempotent per coupon + order).
+			add_action( 'woocommerce_payment_complete', array( $this, 'record_usage_once' ) );
+			add_action( 'woocommerce_order_status_processing', array( $this, 'record_usage_once' ) );
+			add_action( 'woocommerce_order_status_completed', array( $this, 'record_usage_once' ) );
+		}
+
+		protected function active() {
+			return RBFW_Function::use_wc() && RBFW_Coupon_Engine::is_enabled();
+		}
+
+		protected function context() {
+			return RBFW_Coupon_Context::from_wc_cart();
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Virtual coupon bridge
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * Answer WooCommerce's coupon-data lookup for our codes.
+		 *
+		 * @param mixed  $data   false unless another filter already provided data.
+		 * @param string $code   The (WC-normalized, lowercase) coupon code being looked up.
+		 * @param mixed  $coupon The WC_Coupon being constructed.
+		 * @return array|false   Virtual coupon data, or false to let WooCommerce handle it.
+		 */
+		public function virtual_coupon( $data, $code, $coupon = null ) {
+			// Respect an existing real coupon / another integration.
+			if ( false !== $data ) {
+				return $data;
+			}
+			if ( ! $this->active() ) {
+				return false;
+			}
+
+			$rbfw = RBFW_Coupon::load_by_code( $code );
+			if ( ! $rbfw ) {
+				return false; // not one of ours → let WooCommerce say "does not exist".
+			}
+
+			$ctx = $this->context();
+			if ( empty( $ctx['items'] ) ) {
+				return $this->reject( $code, esc_html__( 'Add a rental to your cart before applying this coupon.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			$valid = RBFW_Coupon_Engine::validate( $rbfw, $ctx );
+			if ( empty( $valid['valid'] ) ) {
+				return $this->reject( $code, $valid['reason'] );
+			}
+
+			$discount = RBFW_Coupon_Engine::calculate_discount( $rbfw, $ctx );
+			if ( $discount['total'] <= 0 ) {
+				return $this->reject( $code, esc_html__( 'This coupon does not apply to the item(s) in your cart.', 'booking-and-rental-manager-for-woocommerce' ) );
+			}
+
+			// A fixed_cart coupon of the exact engine-computed amount keeps OUR rules authoritative
+			// (targeting, caps, base = rental minus mandatory fees) — WooCommerce just subtracts it.
+			return array(
+				'id'                   => $rbfw->get_id(),
+				'amount'               => $discount['total'],
+				'discount_type'        => 'fixed_cart',
+				'individual_use'       => ! $rbfw->allows_combine(),
+				'usage_limit'          => 0, // enforced by our engine, not WooCommerce.
+				'usage_limit_per_user' => 0,
+				'product_ids'          => array(),
+				'excluded_product_ids' => array(),
+				'exclude_sale_items'   => false,
+				'minimum_amount'       => '',
+				'maximum_amount'       => '',
+				'free_shipping'        => false,
+			);
+		}
+
+		protected function reject( $code, $reason ) {
+			self::$reasons[ RBFW_Coupon::normalize_code( $code ) ] = $reason;
+			return false;
+		}
+
+		/**
+		 * Replace WooCommerce's generic "does not exist" with our real reason when the code is
+		 * one of ours but was rejected (expired, not applicable, usage limit, …).
+		 */
+		public function coupon_error( $err, $err_code, $coupon = null ) {
+			if ( is_object( $coupon ) && method_exists( $coupon, 'get_code' ) ) {
+				$key = RBFW_Coupon::normalize_code( $coupon->get_code() );
+				if ( ! empty( self::$reasons[ $key ] ) ) {
+					return self::$reasons[ $key ];
+				}
+			}
+			return $err;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Automatic (no-code) rules
+		 * ---------------------------------------------------------------------- */
+
+		public function auto_apply( $cart ) {
+			static $running = false;
+			if ( $running || ! $this->active() || ! is_object( $cart ) ) {
+				return;
+			}
+			if ( is_admin() && ! wp_doing_ajax() ) {
+				return;
+			}
+
+			$autos = RBFW_Coupon::get_active_auto_coupons();
+			if ( empty( $autos ) ) {
+				return;
+			}
+
+			$ctx = $this->context();
+			if ( empty( $ctx['items'] ) ) {
+				return;
+			}
+
+			$running = true;
+			foreach ( $autos as $c ) {
+				$code = $c->get_code();
+				if ( $cart->has_discount( wc_format_coupon_code( $code ) ) ) {
+					continue;
+				}
+				$valid = RBFW_Coupon_Engine::validate( $c, $ctx );
+				if ( empty( $valid['valid'] ) ) {
+					continue;
+				}
+				$d = RBFW_Coupon_Engine::calculate_discount( $c, $ctx );
+				if ( $d['total'] > 0 ) {
+					$cart->apply_coupon( $code );
+				}
+			}
+			$running = false;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Order persistence (mirror / usage source of truth)
+		 * ---------------------------------------------------------------------- */
+
+		/**
+		 * Resolve every applied coupon that maps to an rbfw_coupon, with a per-line breakdown.
+		 * Memoized for the duration of order creation.
+		 *
+		 * @return array{applied:array,per_line:array<string,float>,total:float}
+		 */
+		protected function cart_resolution() {
+			if ( null !== $this->order_resolution ) {
+				return $this->order_resolution;
+			}
+			$empty = array( 'applied' => array(), 'per_line' => array(), 'total' => 0.0 );
+
+			if ( ! $this->active() || ! function_exists( 'WC' ) || ! WC()->cart ) {
+				$this->order_resolution = $empty;
+				return $empty;
+			}
+
+			$ctx      = $this->context();
+			$applied  = array();
+			$per_line = array();
+
+			foreach ( WC()->cart->get_applied_coupons() as $code ) {
+				$rbfw = RBFW_Coupon::load_by_code( $code );
+				if ( ! $rbfw ) {
+					continue; // a genuine WooCommerce coupon — not ours.
+				}
+				$d = RBFW_Coupon_Engine::calculate_discount( $rbfw, $ctx );
+				if ( $d['total'] <= 0 ) {
+					continue;
+				}
+				foreach ( $d['per_line'] as $key => $amt ) {
+					$per_line[ $key ] = ( isset( $per_line[ $key ] ) ? $per_line[ $key ] : 0 ) + (float) $amt;
+				}
+				$applied[] = array( 'id' => $rbfw->get_id(), 'code' => $rbfw->get_code(), 'amount' => $d['total'] );
+			}
+
+			$this->order_resolution = array(
+				'applied'  => $applied,
+				'per_line' => $per_line,
+				'total'    => round( array_sum( $per_line ), wc_get_price_decimals() ),
+			);
+			return $this->order_resolution;
+		}
+
+		protected function applied_codes( $res ) {
+			return implode( ', ', wp_list_pluck( $res['applied'], 'code' ) );
+		}
+
+		/** Classic checkout: order not yet saved, update_meta_data suffices. */
+		public function persist_order_meta( $order, $data = array() ) {
+			if ( ! $this->active() || ! is_a( $order, 'WC_Order' ) ) {
+				return;
+			}
+			$res = $this->cart_resolution();
+			if ( $res['total'] <= 0 || empty( $res['applied'] ) ) {
+				return;
+			}
+			$order->update_meta_data( 'rbfw_coupon_code', $this->applied_codes( $res ) );
+			$order->update_meta_data( 'rbfw_coupon_discount', (float) $res['total'] );
+			$order->update_meta_data( 'rbfw_coupon_applied', $res['applied'] );
+		}
+
+		/** Block / Store API: order already persisted, so save() explicitly. */
+		public function persist_order_meta_and_save( $order ) {
+			if ( ! is_a( $order, 'WC_Order' ) ) {
+				return;
+			}
+			$this->persist_order_meta( $order );
+			if ( $order->get_id() ) {
+				$order->save();
+			}
+		}
+
+		/**
+		 * Rewrite the `_rbfw_ticket_info` snapshot for a discounted line so the rbfw_order mirror,
+		 * thank-you page and PDF report the discounted price. Runs at 95 (after the plugin's own
+		 * rbfw_add_order_item_data at 90).
+		 */
+		public function persist_line_coupon( $item, $cart_item_key, $values, $order ) {
+			if ( ! $this->active() || ! is_object( $item ) ) {
+				return;
+			}
+			$res   = $this->cart_resolution();
+			$share = isset( $res['per_line'][ $cart_item_key ] ) ? (float) $res['per_line'][ $cart_item_key ] : 0.0;
+			if ( $share <= 0 ) {
+				return;
+			}
+
+			$codes = $this->applied_codes( $res );
+			$item->update_meta_data( '_rbfw_coupon_code', $codes );
+			$item->update_meta_data( '_rbfw_coupon_discount', $share );
+
+			$ticket_info = $item->get_meta( '_rbfw_ticket_info', true );
+			if ( is_array( $ticket_info ) && $ticket_info ) {
+				$item->update_meta_data( '_rbfw_ticket_info', self::discount_ticket_info( $ticket_info, $share, $codes ) );
+			}
+		}
+
+		/**
+		 * Subtract a line's coupon share from its ticket_info snapshot, split across rows in
+		 * proportion to (ticket_price * ticket_qty), and stamp the coupon fields for display.
+		 */
+		public static function discount_ticket_info( array $ticket_info, $share, $codes ) {
+			$decimals = wc_get_price_decimals();
+
+			$weights = array();
+			foreach ( $ticket_info as $i => $row ) {
+				$price         = isset( $row['ticket_price'] ) ? (float) $row['ticket_price'] : 0.0;
+				$qty           = isset( $row['ticket_qty'] ) ? max( 1, (int) $row['ticket_qty'] ) : 1;
+				$weights[ $i ] = max( 0, $price * $qty );
+			}
+			$total_weight = array_sum( $weights );
+
+			foreach ( $ticket_info as $i => $row ) {
+				$row_share = ( $total_weight > 0 ) ? $share * ( $weights[ $i ] / $total_weight ) : 0.0;
+				$qty       = isset( $row['ticket_qty'] ) ? max( 1, (int) $row['ticket_qty'] ) : 1;
+				$price     = isset( $row['ticket_price'] ) ? (float) $row['ticket_price'] : 0.0;
+
+				$new_price = max( 0, $price - ( $row_share / $qty ) );
+
+				$ticket_info[ $i ]['ticket_price']         = round( $new_price, $decimals );
+				$ticket_info[ $i ]['rbfw_coupon_code']     = $codes;
+				$ticket_info[ $i ]['rbfw_coupon_discount'] = round( $row_share, $decimals );
+			}
+
+			return $ticket_info;
+		}
+
+		/* -------------------------------------------------------------------------
+		 * Usage recording (idempotent per coupon + order)
+		 * ---------------------------------------------------------------------- */
+
+		public function record_usage_once( $order_id ) {
+			if ( ! function_exists( 'wc_get_order' ) ) {
+				return;
+			}
+			$order = wc_get_order( $order_id );
+			if ( ! $order ) {
+				return;
+			}
+
+			$applied = $order->get_meta( 'rbfw_coupon_applied' );
+			if ( empty( $applied ) || ! is_array( $applied ) ) {
+				return;
+			}
+
+			$user_id = (int) $order->get_customer_id();
+			$email   = (string) $order->get_billing_email();
+
+			foreach ( $applied as $a ) {
+				$cid = isset( $a['id'] ) ? absint( $a['id'] ) : 0;
+				$amt = isset( $a['amount'] ) ? (float) $a['amount'] : 0.0;
+				if ( $cid ) {
+					RBFW_Coupon_Usage::record( $cid, array( 'type' => 'order', 'id' => $order->get_id() ), $user_id, $email, $amt );
+				}
+			}
+		}
+	}
+
+	new RBFW_Coupon_WC();
+}

--- a/inc/rbfw_file_include.php
+++ b/inc/rbfw_file_include.php
@@ -29,6 +29,19 @@ require_once RBFW_PLUGIN_DIR . '/lib/classes/class-pro-page.php';
 require_once RBFW_PLUGIN_DIR . '/lib/classes/class-welcome-page.php';
 require_once RBFW_PLUGIN_DIR . '/inc/class-bike-car-sd-function.php';
 
+// ---- Unified coupon engine (mode-agnostic core; loads in every mode) ----
+require_once RBFW_PLUGIN_DIR . '/inc/coupon/RBFW_Coupon_Post_Type.php';
+require_once RBFW_PLUGIN_DIR . '/inc/coupon/RBFW_Coupon.php';
+require_once RBFW_PLUGIN_DIR . '/inc/coupon/RBFW_Coupon_Usage.php';
+require_once RBFW_PLUGIN_DIR . '/inc/coupon/RBFW_Coupon_Context.php';
+require_once RBFW_PLUGIN_DIR . '/inc/coupon/RBFW_Coupon_Engine.php';
+require_once RBFW_PLUGIN_DIR . '/inc/coupon/RBFW_Coupon_Frontend.php';
+if ( is_admin() ) {
+    // Coupons manager page + the "Coupons" tab on the global settings page.
+    require_once RBFW_PLUGIN_DIR . '/inc/coupon/RBFW_Coupon_Admin.php';
+    require_once RBFW_PLUGIN_DIR . '/admin/settings/RBFW_Coupon_Settings.php';
+}
+
 
 
 require_once RBFW_PLUGIN_DIR . '/inc/rbfw_order_meta.php';
@@ -108,6 +121,9 @@ function rbfw_free_woocommerce_integrate(){
         require_once(RBFW_PLUGIN_DIR . "/inc/woocommerce/class-status.php");
         require_once(RBFW_PLUGIN_DIR . "/inc/woocommerce/class-meta.php");
         require_once(RBFW_PLUGIN_DIR . "/inc/woocommerce/rbfw_cart_price_function.php");
+        // Coupon engine: WooCommerce application layer. Hook bodies additionally gate on use_wc(),
+        // so it stays inert when WooCommerce is active but Booking Mode = Standalone.
+        require_once(RBFW_PLUGIN_DIR . "/inc/coupon/RBFW_Coupon_WC.php");
     }
 
     // Native checkout + booking confirmation run whenever the WooCommerce flow is not in
@@ -115,6 +131,9 @@ function rbfw_free_woocommerce_integrate(){
     if ( ! RBFW_Function::use_wc() ) {
         require_once(RBFW_PLUGIN_DIR . "/inc/booking/RBFW_Native_Checkout.php");
         require_once(RBFW_PLUGIN_DIR . "/inc/booking/RBFW_Booking_Confirmation.php");
+        // Coupon engine: standalone application layer (live preview endpoint). The authoritative
+        // recompute happens inside RBFW_Native_Checkout::process().
+        require_once(RBFW_PLUGIN_DIR . "/inc/coupon/RBFW_Coupon_Native.php");
     }
 
 }

--- a/inc/rbfw_order_export.php
+++ b/inc/rbfw_order_export.php
@@ -98,6 +98,8 @@ function rbfw_export_columns() {
 		'duration_cost'    => __( 'Duration Cost', 'booking-and-rental-manager-for-woocommerce' ),
 		'service_cost'     => __( 'Service Cost', 'booking-and-rental-manager-for-woocommerce' ),
 		'discount'         => __( 'Discount', 'booking-and-rental-manager-for-woocommerce' ),
+		'coupon'           => __( 'Coupon', 'booking-and-rental-manager-for-woocommerce' ),
+		'coupon_discount'  => __( 'Coupon Discount', 'booking-and-rental-manager-for-woocommerce' ),
 		'security_deposit' => __( 'Security Deposit', 'booking-and-rental-manager-for-woocommerce' ),
 		'status'           => __( 'Status', 'booking-and-rental-manager-for-woocommerce' ),
 		'order_total'      => __( 'Order Total', 'booking-and-rental-manager-for-woocommerce' ),
@@ -126,7 +128,7 @@ function rbfw_export_column_groups() {
 		),
 		'pricing'  => array(
 			'label'   => __( 'Pricing', 'booking-and-rental-manager-for-woocommerce' ),
-			'columns' => array( 'duration_cost', 'service_cost', 'discount', 'security_deposit' ),
+			'columns' => array( 'duration_cost', 'service_cost', 'discount', 'coupon', 'coupon_discount', 'security_deposit' ),
 		),
 	);
 }
@@ -327,6 +329,8 @@ function rbfw_collect_export_rows( $filters ) {
 				'duration_cost'    => isset( $ticket['duration_cost'] ) ? (float) $ticket['duration_cost'] : 0,
 				'service_cost'     => isset( $ticket['service_cost'] ) ? (float) $ticket['service_cost'] : 0,
 				'discount'         => isset( $ticket['discount_amount'] ) ? (float) $ticket['discount_amount'] : 0,
+				'coupon'           => isset( $ticket['rbfw_coupon_code'] ) ? (string) $ticket['rbfw_coupon_code'] : '',
+				'coupon_discount'  => isset( $ticket['rbfw_coupon_discount'] ) ? (float) $ticket['rbfw_coupon_discount'] : 0,
 				'security_deposit' => isset( $ticket['security_deposit_amount'] ) ? (float) $ticket['security_deposit_amount'] : 0,
 				'status'           => ucfirst( str_replace( 'wc-', '', $order_status ) ),
 				// The WC order total belongs to the whole order; only attribute it
@@ -568,7 +572,7 @@ function rbfw_export_orders_csv( $rows, $filters ) {
 	// Header row.
 	fputcsv( $out, array_values( $columns ) );
 
-	$money_keys = array( 'duration_cost', 'service_cost', 'discount', 'security_deposit', 'order_total' );
+	$money_keys = array( 'duration_cost', 'service_cost', 'discount', 'coupon_discount', 'security_deposit', 'order_total' );
 
 	foreach ( $rows as $row ) {
 		$line = array();
@@ -715,7 +719,7 @@ function rbfw_export_pdf_footer_html() {
  */
 function rbfw_export_pdf_body_html( $rows, $filters ) {
 	$columns    = rbfw_export_enabled_columns();
-	$money_keys = array( 'duration_cost', 'service_cost', 'discount', 'security_deposit', 'order_total' );
+	$money_keys = array( 'duration_cost', 'service_cost', 'discount', 'coupon_discount', 'security_deposit', 'order_total' );
 	$num_keys   = array( 'qty', 'total_days' );
 
 	$html  = '<style>' . rbfw_export_pdf_css() . '</style>';

--- a/inc/rbfw_order_meta.php
+++ b/inc/rbfw_order_meta.php
@@ -1406,6 +1406,14 @@ function fetch_order_details_callback() {
                         <th colspan="2"><span class="rbfw_ol_sec_ico"><?php echo rbfw_inv_icon( 'calculator' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG ?></span><?php rbfw_string( 'rbfw_text_total', __( 'Summary', 'booking-and-rental-manager-for-woocommerce' ) ); ?></th>
                     </tr>
                     </thead>
+                    <?php
+                    // Coupon discount is read natively from the WooCommerce order — this covers the
+                    // unified coupon engine (our codes apply as real order coupons) and any other
+                    // WooCommerce coupon. Empty on old orders / orders without a coupon.
+                    $order_coupon_codes    = method_exists( $wc_order_details, 'get_coupon_codes' ) ? (array) $wc_order_details->get_coupon_codes() : array();
+                    $order_coupon_discount = (float) $wc_order_details->get_discount_total();
+                    $order_coupon_label    = $order_coupon_codes ? implode( ', ', array_map( 'strtoupper', $order_coupon_codes ) ) : '';
+                    ?>
                     <tbody>
                     <tr>
                         <td>
@@ -1413,8 +1421,20 @@ function fetch_order_details_callback() {
                                 <?php rbfw_string( 'rbfw_text_summary', __( 'Subtotal', 'booking-and-rental-manager-for-woocommerce' ) ); ?>
                             </strong>
                         </td>
-                        <td><?php echo wp_kses( wc_price( $wc_order_details->get_total() - $total_security_deposit_amount - $wc_order_details->get_total_tax() ), rbfw_allowed_html() ); ?></td>
+                        <td><?php echo wp_kses( wc_price( $wc_order_details->get_total() - $total_security_deposit_amount - $wc_order_details->get_total_tax() + $order_coupon_discount ), rbfw_allowed_html() ); ?></td>
                     </tr>
+                    <?php if ( $order_coupon_discount > 0 ) { ?>
+                        <tr>
+                            <td>
+                                <strong><?php
+                                    echo esc_html( $rbfw->get_option( 'rbfw_text_coupon', 'rbfw_basic_translation_settings', __( 'Coupon', 'booking-and-rental-manager-for-woocommerce' ) ) );
+                                    if ( $order_coupon_label ) { echo ' (' . esc_html( $order_coupon_label ) . ')'; }
+                                    echo ':';
+                                ?></strong>
+                            </td>
+                            <td>&minus;<?php echo wp_kses( wc_price( $order_coupon_discount ), rbfw_allowed_html() ); ?></td>
+                        </tr>
+                    <?php } ?>
                     <?php if ( $wc_order_details->get_total_tax() ) { ?>
                         <tr>
                             <td>

--- a/js/rbfw_script.js
+++ b/js/rbfw_script.js
@@ -311,7 +311,7 @@
                         let display_markup = response.data.display_date;
 
                         if (!display_markup) {
-                            display_markup = '<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">Sorry, no data found!</div></div>';
+                            display_markup = '<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' + ((window.rbfw_translation||{}).no_data_found || 'Sorry, no data found!') + '</div></div>';
                         }
 
                         // $('#rbfw_rent_list_wrapper').html( response.data.display_date );
@@ -321,13 +321,13 @@
 
                         $('#rbfw_shoe_result_text').html('<span >'+text_display+'</span>');
                     }else{
-                        $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div></div>');
-                        $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
+                        $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' + ((window.rbfw_translation||{}).no_match_found || 'No Match Result Found!') + '</div></div>');
+                        $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' + ((window.rbfw_translation||{}).no_match_found || 'No Match Result Found!') + '</div>');
                     }
                 },
                 error: function () {
-                    $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div></div>');
-                    $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">No Match Result Found!</div>');
+                    $('#rbfw_rent_list_wrapper').html('<div class="rbfw_search_result_empty_state"><div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' + ((window.rbfw_translation||{}).no_match_found || 'No Match Result Found!') + '</div></div>');
+                    $('#rbfw_shoe_result_text').html('<div class="rbfw_search_result_empty" data-placeholder="" style="display: block;">' + ((window.rbfw_translation||{}).no_match_found || 'No Match Result Found!') + '</div>');
                 },
                 complete: function () {
                     $("#rbfw_left_filter_cover").hide();

--- a/languages/booking-and-rental-manager-for-woocommerce.pot
+++ b/languages/booking-and-rental-manager-for-woocommerce.pot
@@ -13344,3 +13344,19 @@ msgstr ""
 #: support/blocks/js/blocks.build.js:488
 msgid "This block displays search results for rental items."
 msgstr ""
+
+#: inc/RBFW_Dependencies.php
+msgid "Please enter the date"
+msgstr ""
+
+#: inc/RBFW_Dependencies.php
+msgid "Please enter the pickup date"
+msgstr ""
+
+#: inc/RBFW_Dependencies.php
+msgid "Please enter the pickup time"
+msgstr ""
+
+#: inc/RBFW_Dependencies.php
+msgid "No Match Result Found!"
+msgstr ""

--- a/templates/layout/native_checkout_modal.php
+++ b/templates/layout/native_checkout_modal.php
@@ -28,6 +28,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	.rbfw-native-modal__submit{width:100%;padding:11px 16px;font-size:15px;cursor:pointer;}
 	.rbfw-native-modal__submit.is-loading{opacity:.6;cursor:progress;}
 	.rbfw-native-modal__note{margin:10px 0 0;font-size:12px;color:#777;text-align:center;}
+	.rbfw-native-coupon{margin:0 0 16px;padding:12px 14px;border:1px dashed #d7dae0;border-radius:8px;background:#fbfbfc;}
+	.rbfw-native-coupon__label{display:block;font-size:13px;font-weight:600;color:#374151;margin-bottom:8px;}
+	.rbfw-native-coupon__row{display:flex;gap:8px;}
+	.rbfw-native-coupon__input{flex:1;min-width:0;padding:9px 11px;border:1px solid #cfd4da;border-radius:6px;box-sizing:border-box;text-transform:uppercase;}
+	.rbfw-native-coupon__apply,.rbfw-native-coupon__remove{flex:0 0 auto;cursor:pointer;border:0;border-radius:6px;padding:9px 16px;font-size:13px;font-weight:600;color:#fff;background:var(--color_theme,#f12971);}
+	.rbfw-native-coupon__remove{background:transparent;color:#6b7280;text-decoration:underline;padding:2px 4px;font-weight:500;}
+	.rbfw-native-coupon.is-busy{opacity:.6;pointer-events:none;}
+	.rbfw-native-coupon__msg{margin-top:8px;font-size:12.5px;line-height:1.4;}
+	.rbfw-native-coupon__msg.error{color:#b32d2e;}
+	.rbfw-native-coupon__msg.success{color:#1a7f37;}
+	.rbfw-native-coupon__applied{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:10px;padding:8px 12px;border-radius:6px;background:#ecfdf3;border:1px solid #abefc6;font-size:13px;font-weight:600;color:#166534;}
+	.rbfw-native-coupon__applied[hidden]{display:none;}
 </style>
 <div id="rbfw-native-checkout-modal" class="rbfw-native-modal" aria-hidden="true" style="display:none;">
 	<div class="rbfw-native-modal__overlay" data-rbfw-native-close></div>
@@ -39,6 +51,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<span class="rbfw-native-modal__total-label"><?php echo esc_html__( 'Total', 'booking-and-rental-manager-for-woocommerce' ); ?>:</span>
 			<span class="rbfw-native-modal__total-value" data-rbfw-native-total></span>
 		</div>
+
+		<?php
+		// Coupon field — shown here (inside the standalone checkout modal) because this is where the
+		// Total and Confirm live. Handled by rbfw_native_checkout.js against the active booking form.
+		if ( class_exists( 'RBFW_Coupon_Frontend' ) && RBFW_Coupon_Frontend::enabled() ) :
+			$rbfw_cpn_label = RBFW_Coupon_Engine::setting( 'rbfw_coupon_label', __( 'Have a coupon?', 'booking-and-rental-manager-for-woocommerce' ) );
+			$rbfw_cpn_ph    = RBFW_Coupon_Engine::setting( 'rbfw_coupon_placeholder', __( 'Enter coupon code', 'booking-and-rental-manager-for-woocommerce' ) );
+			?>
+			<div class="rbfw-native-coupon" data-rbfw-native-coupon>
+				<label class="rbfw-native-coupon__label"><?php echo esc_html( $rbfw_cpn_label ); ?></label>
+				<div class="rbfw-native-coupon__row">
+					<input type="text" class="rbfw-native-coupon__input" data-rbfw-native-coupon-input placeholder="<?php echo esc_attr( $rbfw_cpn_ph ); ?>" autocomplete="off">
+					<button type="button" class="rbfw-native-coupon__apply" data-rbfw-native-coupon-apply><?php echo esc_html__( 'Apply', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+				</div>
+				<div class="rbfw-native-coupon__msg" data-rbfw-native-coupon-msg aria-live="polite"></div>
+				<div class="rbfw-native-coupon__applied" data-rbfw-native-coupon-applied hidden>
+					<span data-rbfw-native-coupon-summary></span>
+					<button type="button" class="rbfw-native-coupon__remove" data-rbfw-native-coupon-remove><?php echo esc_html__( 'Remove', 'booking-and-rental-manager-for-woocommerce' ); ?></button>
+				</div>
+			</div>
+		<?php endif; ?>
 
 		<div class="rbfw-native-modal__fields">
 			<p class="rbfw-native-field">

--- a/templates/single/default/multi-day.php
+++ b/templates/single/default/multi-day.php
@@ -70,7 +70,7 @@ $rbfw_default_hero_subtitle = get_post_meta( $post_id, 'rbfw_item_sub_title', tr
 								<?php endif; ?>
 								<?php if ( $rbfw_default_hero_price > 0 ) : ?>
 								<div class="rbfw_default_hero_price_wrap">
-									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices Start At', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices start at', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
 									<div class="rbfw_default_hero_price_amount"><?php echo wp_kses( wc_price( $rbfw_default_hero_price ), rbfw_allowed_html() ); ?></div>
 								</div>
 								<?php endif; ?>

--- a/templates/single/default/multiple-items.php
+++ b/templates/single/default/multiple-items.php
@@ -49,7 +49,7 @@ $rbfw_default_hero_subtitle = get_post_meta( $post_id, 'rbfw_item_sub_title', tr
 								<?php endif; ?>
 								<?php if ( $rbfw_default_hero_price > 0 ) : ?>
 								<div class="rbfw_default_hero_price_wrap">
-									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices Start At', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices start at', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
 									<div class="rbfw_default_hero_price_amount"><?php echo wp_kses( wc_price( $rbfw_default_hero_price ), rbfw_allowed_html() ); ?></div>
 								</div>
 								<?php endif; ?>

--- a/templates/single/default/resort.php
+++ b/templates/single/default/resort.php
@@ -60,7 +60,7 @@
 								<?php endif; ?>
 								<?php if ( $rbfw_default_hero_price > 0 ) : ?>
 								<div class="rbfw_default_hero_price_wrap">
-									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices Start At', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices start at', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
 									<div class="rbfw_default_hero_price_amount"><?php echo wp_kses( wc_price( $rbfw_default_hero_price ), rbfw_allowed_html() ); ?></div>
 								</div>
 								<?php endif; ?>

--- a/templates/single/default/single-day.php
+++ b/templates/single/default/single-day.php
@@ -59,7 +59,7 @@ $rbfw_default_hero_subtitle = get_post_meta( $post_id, 'rbfw_item_sub_title', tr
 								<?php endif; ?>
 								<?php if ( $rbfw_default_hero_price > 0 ) : ?>
 								<div class="rbfw_default_hero_price_wrap">
-									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices Start At', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
+									<div class="rbfw_default_hero_price_label"><?php esc_html_e( 'Prices start at', 'booking-and-rental-manager-for-woocommerce' ); ?></div>
 									<div class="rbfw_default_hero_price_amount"><?php echo wp_kses( wc_price( $rbfw_default_hero_price ), rbfw_allowed_html() ); ?></div>
 								</div>
 								<?php endif; ?>


### PR DESCRIPTION
Adds a single coupon/discount engine that works identically in WooCommerce and Standalone (no-WooCommerce) modes, supporting coupon codes AND automatic (no-code) rules with per-rental targeting, spend/date conditions, usage limits and eligibility. Storage is a CPT + flat post meta (no custom tables).

Core engine (inc/coupon/, loads in every mode)
- RBFW_Coupon_Post_Type: rbfw_coupon CPT (code in post_title + normalized rbfw_code meta; publish=active / draft=inactive).
- RBFW_Coupon: typed model, load_by_code(), get_active_auto_coupons(), and a cached has_auto_coupons()/flush_auto_cache() short-circuit.
- RBFW_Coupon_Context: normalizes the live WC cart OR a standalone POST into one shape (items[]/subtotal/user/email/date) so the engine is written once. Base = rental subtotal minus the mandatory management fee, clamped to line total.
- RBFW_Coupon_Engine: validate(), calculate_discount() (percentage with cap, fixed distributed largest-remainder, free-days per billed unit), resolve() (manual + automatic reconciliation with stacking on the remaining balance), is_enabled()/setting(). Always authoritative server-side: only the code is trusted, never a client-sent amount; totals clamped >= 0.
- RBFW_Coupon_Usage: per-coupon counters (total / per-user / per-day) stored on the coupon post (HPOS-proof) with an idempotent per-(coupon,object) guard.

WooCommerce integration (RBFW_Coupon_WC, loaded when WooCommerce is active)
- Bridges our codes into WooCommerce via woocommerce_get_shop_coupon_data as a virtual fixed_cart coupon whose amount the engine computes, so codes apply in the classic cart, the Cart/Checkout Blocks AND the Store API. Engine still owns validity/amount; woocommerce_coupon_error surfaces the real rejection reason.
- Auto-applies no-code rules; persists rbfw_coupon_code / rbfw_coupon_discount / rbfw_coupon_applied on the order (HPOS-safe via $order->update_meta_data); records usage once on paid.
- Rewrites the _rbfw_ticket_info snapshot at prio 95 (after the plugin's own line-item writer at 90) so the rbfw_order mirror, thank-you page, PDFs and revenue reports reflect the discounted price.

Standalone integration
- RBFW_Coupon_Native: rbfw_apply_coupon_native preview/validate endpoint.
- RBFW_Native_Checkout::process() recomputes the coupon value server-side and passes subtotal/discount/code to the booking; RBFW_Standalone_Booking_Service stores rbfw_subtotal / rbfw_discount / rbfw_coupon_code and records usage.
- The coupon field lives INSIDE the native checkout modal (next to Total and Confirm), handled by rbfw_native_checkout.js (apply/remove, live Total update, code carried on submit). The duplicate item-page field was removed.
- Fix: guard RBFW_Coupon_Context::current_email() with method_exists so it no longer fatals when WooCommerce is fully deactivated (fallback WC() shim).

Admin
- RBFW_Coupon_Admin: "Coupons" page rebuilt as a modern multi-step wizard styled to match the Global Settings page (gradient header, left step rail, searchable token multi-selects, per-step validation with inline errors, live review). List with stats + AJAX CRUD, all nonce + capability guarded.
- RBFW_Coupon_Settings: "Coupons" settings tab (enable engine, field label/placeholder, field visibility, default stacking).

Reporting (free)
- Order List detail modal: Subtotal / Coupon (code) / Total breakdown, read natively from the WooCommerce order.
- Order CSV/PDF export: new Coupon + Coupon Discount columns.

i18n / translatability fixes
- Route previously hard-coded JS strings (sd_script.js alerts, js/rbfw_script.js search empty-states) through the rbfw_translation localize object so they can be translated.
- Normalize "Prices Start At" -> "Prices start at" across the default single templates so the existing translation applies; refresh the .pot.

Security: every AJAX handler is nonce + capability checked; inputs are sanitized/whitelisted; output escaped; the one counter UPDATE is prepared; negative totals are clamped at every stage.