### PR TITLE
Add per-attendee registration form data across booking surfaces

### DIFF
--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -596,11 +596,22 @@ if (!class_exists('RBFW_Woocommerce')) {
 
             $discount_type   = '';
             $discount_amount = 0;
-            $rbfw_regf_info  = [];
+            $rbfw_regf_info      = [];
+            $rbfw_regf_attendees = [];
             if ( class_exists( 'Rbfw_Reg_Form' ) ) {
                 $ClassRegForm   = new Rbfw_Reg_Form();
-                $rbfw_regf_info = $ClassRegForm->rbfw_regf_value_array_function( $rbfw_id );
+                if ( method_exists( $ClassRegForm, 'rbfw_regf_attendees_value_array' ) ) {
+                    // One registration form per booked unit (attendee).
+                    $rbfw_regf_attendees = $ClassRegForm->rbfw_regf_attendees_value_array( $rbfw_id );
+                    $rbfw_regf_info      = ! empty( $rbfw_regf_attendees ) ? $rbfw_regf_attendees[0] : [];
+                } else {
+                    $rbfw_regf_info      = $ClassRegForm->rbfw_regf_value_array_function( $rbfw_id );
+                    $rbfw_regf_attendees = ! empty( $rbfw_regf_info ) ? array( $rbfw_regf_info ) : array();
+                }
             }
+            // Passed to the per-type ticket builders (which run in other classes)
+            // so each stored ticket carries the full attendee list.
+            $GLOBALS['rbfw_regf_attendees'] = $rbfw_regf_attendees;
             $cart_item_data['rbfw_id'] = $rbfw_id;
 
             if ( $rbfw_rent_type == 'resort' ) {
@@ -2122,9 +2133,13 @@ if (!class_exists('RBFW_Woocommerce')) {
             $rbfw_regf_info = isset( $values['rbfw_regf_info'] ) ? $values['rbfw_regf_info'] : [];
             if ( ! empty( $rbfw_regf_info ) ) {
                 $rbfw_regf_info_content = '<table style="border:1px solid #f5f5f5;margin:0;width: 100%;">';
-                foreach ( $rbfw_regf_info as $key => $value ):
+                foreach ( rbfw_regf_display_rows( $values ) as $key => $value ):
                     $the_label = $value['label'];
                     $the_value = $value['value'];
+                    if ( ! empty( $value['heading'] ) ) {
+                        $rbfw_regf_info_content .= '<tr><td colspan="2" style="border:1px solid #f5f5f5;padding-top:6px;"><strong>' . esc_html( $the_label ) . '</strong></td></tr>';
+                        continue;
+                    }
                     if ( is_array( $the_value ) && ! empty( $the_value ) ) {
                         $new_value   = '';
                         $i           = 1;
@@ -2192,6 +2207,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                         $ticket_type_arr[ $i ]['rbfw_management_price']    = $rbfw_management_price;
                         $ticket_type_arr[ $i ]['security_deposit_amount'] = $security_deposit['security_deposit_amount'];
                         $ticket_type_arr[ $i ]['rbfw_regf_info']          = $rbfw_regf_info;
+                        $ticket_type_arr[ $i ]['rbfw_regf_attendees']     = ( isset( $GLOBALS['rbfw_regf_attendees'] ) && ! empty( $GLOBALS['rbfw_regf_attendees'] ) ) ? $GLOBALS['rbfw_regf_attendees'] : ( ! empty( $rbfw_regf_info ) ? array( $rbfw_regf_info ) : array() );
                         $ticket_type_arr[ $i ]['rbfw_service_infos']      = $rbfw_service_infos;
                         $ticket_type_arr[ $i ]['total_days']              = $total_days;
                     }
@@ -2240,6 +2256,7 @@ if (!class_exists('RBFW_Woocommerce')) {
                         $ticket_type_arr[ $i ]['discount_amount']         = '';
                         $ticket_type_arr[ $i ]['security_deposit_amount'] = $security_deposit['security_deposit_amount'];
                         $ticket_type_arr[ $i ]['rbfw_regf_info']          = $rbfw_regf_info;
+                        $ticket_type_arr[ $i ]['rbfw_regf_attendees']     = ( isset( $GLOBALS['rbfw_regf_attendees'] ) && ! empty( $GLOBALS['rbfw_regf_attendees'] ) ) ? $GLOBALS['rbfw_regf_attendees'] : ( ! empty( $rbfw_regf_info ) ? array( $rbfw_regf_info ) : array() );
 
                     }
                 }

--- a/Frontend/RBFW_Woocommerse.php
+++ b/Frontend/RBFW_Woocommerse.php
@@ -729,7 +729,17 @@ if (!class_exists('RBFW_Woocommerce')) {
                     }
                 }
 
-                if ( ! ( $end_date && $end_time ) && ! empty( $rbfw_type_info ) ) {
+                // Authoritatively derive the end date/time from the selected rent
+                // type's duration on the SERVER for duration-based single-day rentals.
+                // The browser posts rbfw_end_time, but it parsed a 12-hour pickup time
+                // as 24-hour (e.g. 1:00 PM + 1h → "02:00" instead of "14:00"), which
+                // both displayed as 2:00 am AND made the stored booking interval run
+                // backwards — silently defeating rbfw_timely_available_quantity_updated()
+                // so a fully-booked slot still showed as available. PHP's DateTime parses
+                // the pickup time correctly. Specific-duration items keep their fixed
+                // configured clock times (posted from the rate's data attributes).
+                $rbfw_sd_specific_duration = get_post_meta( $rbfw_id, 'enable_specific_duration', true );
+                if ( 'on' !== $rbfw_sd_specific_duration && ! empty( $rbfw_type_info ) ) {
                     $rbfw_bike_car_sd_data = get_post_meta( $rbfw_id, 'rbfw_bike_car_sd_data', true ) ? get_post_meta( $rbfw_id, 'rbfw_bike_car_sd_data', true ) : array();
                     $selected_rent_type    = '';
                     foreach ( $rbfw_type_info as $type_name => $type_qty ) {

--- a/assets/mp_script/sd_script.js
+++ b/assets/mp_script/sd_script.js
@@ -195,14 +195,30 @@
 
                 jQuery('#rbfw_start_time').val(start_time);
 
+                // Pickup times render in 12-hour form (e.g. "1:00 PM"); a naive
+                // split(':') would read that as 01:00 and drop the meridiem, so a
+                // 1:00 PM + 1h booking ended at "02:00". Parse hours/minutes with
+                // AM/PM awareness (also tolerates plain 24-hour "13:00").
+                let rbfwParseClock = function (t) {
+                    t = (t || '').toString().trim();
+                    let m = t.match(/^(\d{1,2}):(\d{2})(?::\d{2})?\s*([AaPp][Mm])?$/);
+                    if (!m) { return { h: 0, i: 0 }; }
+                    let h = parseInt(m[1], 10) || 0;
+                    let i = parseInt(m[2], 10) || 0;
+                    let ap = m[3] ? m[3].toUpperCase() : '';
+                    if (ap === 'PM' && h < 12) { h += 12; }
+                    if (ap === 'AM' && h === 12) { h = 0; }
+                    return { h: h, i: i };
+                };
+
                 let dateParts = start_date.split('-').map(Number);
-                let timeParts = (start_time || '00:00').split(':').map(Number);
+                let tp = rbfwParseClock(start_time || '00:00');
                 let startDateTime = new Date(
                     dateParts[0],
                     dateParts[1] - 1,
                     dateParts[2],
-                    timeParts[0] || 0,
-                    timeParts[1] || 0,
+                    tp.h,
+                    tp.i,
                     0
                 );
 

--- a/inc/class-bike-car-md-function.php
+++ b/inc/class-bike-car-md-function.php
@@ -463,6 +463,7 @@ if ( ! class_exists( 'RBFW_BikeCarMd_Function' ) ) {
                 $main_array[0]['discount_type'] = $discount_type;
                 $main_array[0]['discount_amount'] = $discount_amount;
                 $main_array[0]['rbfw_regf_info'] = $rbfw_regf_info;
+                $main_array[0]['rbfw_regf_attendees'] = ( isset( $GLOBALS['rbfw_regf_attendees'] ) && ! empty( $GLOBALS['rbfw_regf_attendees'] ) ) ? $GLOBALS['rbfw_regf_attendees'] : ( ! empty( $rbfw_regf_info ) ? array( $rbfw_regf_info ) : array() );
 
                 return $main_array;
 

--- a/inc/class-bike-car-sd-function.php
+++ b/inc/class-bike-car-sd-function.php
@@ -212,6 +212,7 @@
 					$main_array[0]['service_cost']   = $total_service_price;
 					$main_array[0]['rbfw_management_price']   = $rbfw_management_price;
 					$main_array[0]['rbfw_regf_info'] = $rbfw_regf_info;
+					$main_array[0]['rbfw_regf_attendees'] = ( isset( $GLOBALS['rbfw_regf_attendees'] ) && ! empty( $GLOBALS['rbfw_regf_attendees'] ) ) ? $GLOBALS['rbfw_regf_attendees'] : ( ! empty( $rbfw_regf_info ) ? array( $rbfw_regf_info ) : array() );
 
 					return $main_array;
 				else:

--- a/inc/class-resort-function.php
+++ b/inc/class-resort-function.php
@@ -317,6 +317,7 @@
 					$main_array[0]['discount_type']   = $discount_type;
 					$main_array[0]['discount_amount'] = $discount_amount;
 					$main_array[0]['rbfw_regf_info']  = $rbfw_regf_info;
+					$main_array[0]['rbfw_regf_attendees'] = ( isset( $GLOBALS['rbfw_regf_attendees'] ) && ! empty( $GLOBALS['rbfw_regf_attendees'] ) ) ? $GLOBALS['rbfw_regf_attendees'] : ( ! empty( $rbfw_regf_info ) ? array( $rbfw_regf_info ) : array() );
 
 					return $main_array;
 				else:

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -3,6 +3,118 @@
 		exit;
 	}
 
+	if ( ! function_exists( 'rbfw_regf_attendees_list' ) ) {
+		/**
+		 * Normalise a ticket/order-meta entry into a 0-indexed list of attendee
+		 * registration-info arrays.
+		 *
+		 * Prefers the per-unit `rbfw_regf_attendees` list; falls back to the
+		 * legacy flat `rbfw_regf_info` so existing orders keep rendering. Each
+		 * returned item is a flat array of field => array( 'label', 'value' ).
+		 *
+		 * @param array $data Ticket_info entry or attendee meta array.
+		 * @return array[] List of attendee info arrays.
+		 */
+		function rbfw_regf_attendees_list( $data ) {
+			if ( ! is_array( $data ) ) {
+				return array();
+			}
+			if ( ! empty( $data['rbfw_regf_attendees'] ) && is_array( $data['rbfw_regf_attendees'] ) ) {
+				$list = array();
+				foreach ( $data['rbfw_regf_attendees'] as $att ) {
+					if ( ! empty( $att ) && is_array( $att ) ) {
+						$list[] = $att;
+					}
+				}
+				if ( ! empty( $list ) ) {
+					return $list;
+				}
+			}
+			if ( ! empty( $data['rbfw_regf_info'] ) && is_array( $data['rbfw_regf_info'] ) ) {
+				return array( $data['rbfw_regf_info'] );
+			}
+			return array();
+		}
+	}
+
+	if ( ! function_exists( 'rbfw_regf_attendee_heading' ) ) {
+		/**
+		 * Heading text for an attendee block, e.g. "Attendee 2".
+		 * Returns an empty string when there is only one attendee, so single
+		 * bookings look exactly as they did before.
+		 *
+		 * @param int $index Zero-based attendee index.
+		 * @param int $total Total attendees in the ticket.
+		 * @return string
+		 */
+		function rbfw_regf_attendee_heading( $index, $total ) {
+			if ( (int) $total <= 1 ) {
+				return '';
+			}
+			$label = function_exists( 'rbfw_string_return' )
+				? rbfw_string_return( 'rbfw_text_attendee', __( 'Attendee', 'booking-and-rental-manager-for-woocommerce' ) )
+				: __( 'Attendee', 'booking-and-rental-manager-for-woocommerce' );
+			return $label . ' ' . ( (int) $index + 1 );
+		}
+	}
+
+	if ( ! function_exists( 'rbfw_regf_display_rows' ) ) {
+		/**
+		 * Flatten one ticket/order-meta entry into display rows for the existing
+		 * "label: value" renderers, so no display loop needs restructuring.
+		 *
+		 * With a single attendee the output is byte-identical to the legacy flat
+		 * list. With multiple attendees each field's label is prefixed with the
+		 * attendee heading (e.g. "Attendee 2 — Full Name") so every surface
+		 * (thank-you, emails, PDFs, admin, calendar) labels the attendees without
+		 * any structural change.
+		 *
+		 * Accepts either a container (ticket_info / attendee meta with the
+		 * rbfw_regf_* keys) or an already-flat single-attendee array.
+		 *
+		 * @param array $data Container or flat attendee array.
+		 * @return array[] List of array( 'label' => string, 'value' => mixed ).
+		 */
+		function rbfw_regf_display_rows( $data ) {
+			if ( ! is_array( $data ) ) {
+				return array();
+			}
+			if ( isset( $data['rbfw_regf_attendees'] ) || isset( $data['rbfw_regf_info'] ) ) {
+				$attendees = rbfw_regf_attendees_list( $data );
+			} elseif ( ! empty( $data ) ) {
+				$attendees = array( $data ); // already a flat single-attendee array
+			} else {
+				$attendees = array();
+			}
+
+			$total = count( $attendees );
+			$rows  = array();
+			foreach ( $attendees as $i => $att ) {
+				if ( ! is_array( $att ) ) {
+					continue;
+				}
+				// With more than one attendee, precede each block with a heading row.
+				if ( $total > 1 ) {
+					$rows[] = array(
+						'label'   => rbfw_regf_attendee_heading( $i, $total ),
+						'value'   => '',
+						'heading' => true,
+					);
+				}
+				foreach ( $att as $info ) {
+					if ( ! is_array( $info ) ) {
+						continue;
+					}
+					$rows[] = array(
+						'label' => isset( $info['label'] ) ? $info['label'] : '',
+						'value' => isset( $info['value'] ) ? $info['value'] : '',
+					);
+				}
+			}
+			return $rows;
+		}
+	}
+
 	/**
 	 * Capability required to view/manage the booking admin screens
 	 * (Order List, Bookings, Booking Orders, Booking Calendar, Reports and their

--- a/inc/rbfw_functions.php
+++ b/inc/rbfw_functions.php
@@ -205,6 +205,7 @@
 				'data-rbfw-form' => true,       // conditional logic: form id
 				'data-rbfw-item' => true,       // conditional logic: rental item id
 				'data-rbfw-rent-type' => true,  // conditional logic: rent type token
+				'data-rbfw-attendee-mode' => true, // per-item attendee form mode (same|per_qty)
 			),
 			'table'   => array(
                 'class' => true,

--- a/inc/rbfw_order_meta.php
+++ b/inc/rbfw_order_meta.php
@@ -352,6 +352,11 @@ function rbfw_sync_attendee_meta_from_edit( $wc_order_id, $t, $billing, $billing
     if ( isset( $t['rbfw_regf_info'] ) ) {
         $meta['rbfw_regf_info'] = $t['rbfw_regf_info'];
     }
+    if ( ! empty( $t['rbfw_regf_attendees'] ) ) {
+        $meta['rbfw_regf_attendees'] = $t['rbfw_regf_attendees'];
+    } elseif ( ! empty( $t['rbfw_regf_info'] ) ) {
+        $meta['rbfw_regf_attendees'] = array( $t['rbfw_regf_info'] );
+    }
 
     foreach ( $query->posts as $attendee_id ) {
         foreach ( $meta as $key => $value ) {
@@ -1271,9 +1276,10 @@ function fetch_order_details_callback() {
                                 <td>
                                     <table class="wp-list-table widefat fixed striped table-view-list">
                                         <?php
-                                        foreach ( $rbfw_regf_info as $info ) {
+                                        foreach ( rbfw_regf_display_rows( $ticket_info ) as $info ) {
                                             $label = $info['label'];
                                             $value = $info['value'];
+											if ( ! empty( $info['heading'] ) ) { echo '<tr><td colspan="2" style="padding-top:8px"><strong>' . esc_html( $label ) . '</strong></td></tr>'; continue; }
                                             if ( filter_var( $value, FILTER_VALIDATE_URL ) ) {
                                                 $value = '<a href="' . esc_url( $value ) . '" target="_blank" style="text-decoration:underline">' . esc_html__( 'View File', 'booking-and-rental-manager-for-woocommerce' ) . '</a>';
                                             }
@@ -1865,9 +1871,10 @@ function rbfw_order_meta_box_callback() {
                             <td>
                                 <table class="wp-list-table widefat fixed striped table-view-list">
                                     <?php
-                                    foreach ( $rbfw_regf_info as $info ) {
+                                    foreach ( rbfw_regf_display_rows( $ticket_info ) as $info ) {
                                         $label = $info['label'];
                                         $value = $info['value'];
+											if ( ! empty( $info['heading'] ) ) { echo '<tr><td colspan="2" style="padding-top:8px"><strong>' . esc_html( $label ) . '</strong></td></tr>'; continue; }
                                         if ( filter_var( $value, FILTER_VALIDATE_URL ) ) {
                                             $value = '<a href="' . esc_url( $value ) . '" target="_blank" style="text-decoration:underline">' . esc_html__( 'View File', 'booking-and-rental-manager-for-woocommerce' ) . '</a>';
                                         }

--- a/lib/classes/class-thankyou-page.php
+++ b/lib/classes/class-thankyou-page.php
@@ -338,9 +338,10 @@
                                             <td>
                                                 <ol>
 													<?php
-														foreach ( $rbfw_regf_info as $info ) {
+														foreach ( rbfw_regf_display_rows( $ticket_info ) as $info ) {
 															$label = $info['label'];
 															$value = $info['value'];
+											if ( ! empty( $info['heading'] ) ) { echo '<li style="list-style:none;margin-top:8px;font-weight:600">' . esc_html( $label ) . '</li>'; continue; }
 															if ( filter_var( $value, FILTER_VALIDATE_URL ) ) {
 																$value = '<a href="' . esc_url( $value ) . '" target="_blank" style="text-decoration:underline">' . esc_html__( 'View File', 'booking-and-rental-manager-for-woocommerce' ) . '</a>';
 															}
@@ -642,9 +643,10 @@
                                     <td>
                                         <ol>
 											<?php
-												foreach ( $rbfw_regf_info as $info ) {
+												foreach ( rbfw_regf_display_rows( $ticket_info ) as $info ) {
 													$label = $info['label'];
 													$value = $info['value'];
+											if ( ! empty( $info['heading'] ) ) { echo '<li style="list-style:none;margin-top:8px;font-weight:600">' . esc_html( $label ) . '</li>'; continue; }
 													if ( filter_var( $value, FILTER_VALIDATE_URL ) ) {
 														$value = '<a href="' . esc_url( $value ) . '" target="_blank" style="text-decoration:underline">' . esc_html__( 'View File', 'booking-and-rental-manager-for-woocommerce' ) . '</a>';
 													}


### PR DESCRIPTION
Replicate the registration form per ticket unit and capture each attendee, rendering grouped "Attendee N" blocks in cart, order meta, emails, PDFs and the booking calendar via shared rbfw_regf_display_rows helpers. Single-attendee output stays byte-identical (backward compatible).