### PR TITLE
Add sold-out marking to the single-day Pickup Time dropdown

### DIFF
--- a/assets/mp_script/sd_script.js
+++ b/assets/mp_script/sd_script.js
@@ -51,6 +51,8 @@
                         getAvailableTimes(rbfw_particulars_data , start_date_ymd,rdfw_available_time,'pickup_time');
                         //particular_time_date_dependent_ajax(post_id,start_date_ymd,'time_enable',time_slot_switch,'');
                         // Listener registered once at document-ready level below — do NOT re-bind here.
+                        // Grey out pickup times that are sold out (see helper below).
+                        rbfwFetchPickupSoldOut(post_id, start_date_ymd);
 
                     }
                 }
@@ -272,6 +274,10 @@
             jQuery('#rbfw_service_price').val(rbfw_service_price);
 
             jQuery('#rbfw_service_type_for_st').val(service_type);
+
+            // Duration-aware: refine the pickup dropdown for the chosen rent type so
+            // times whose [start, start + this duration] window is full are disabled.
+            rbfwApplyPickupSoldOut(service_type);
 
             jQuery('.single-type-timely').each(function(index, element) {
                 jQuery('.single-type-timely').removeClass('selected');
@@ -710,6 +716,103 @@ function rbfw_get_selected_variations(){
         }
     });
     return selected;
+}
+
+/* =========================================================================
+ * Sold-out Pickup Time dropdown
+ *
+ * Fetches per-time / per-rent-type remaining stock for the selected date, then
+ * disables sold-out <option>s in #pickup_time. Before a duration is chosen a
+ * time is disabled only when EVERY rent type is full there (nothing bookable);
+ * once a rent type is selected the dropdown is refined for that duration's
+ * booked window. Cached per (post, date) so switching durations never re-fetches.
+ * ========================================================================= */
+var rbfwPickupState = { key: '', avail: {}, type: null };
+
+function rbfwPickupSoldOutLabel() {
+    return (window.rbfw_translation && rbfw_translation.sold_out) ? rbfw_translation.sold_out : 'Sold out';
+}
+
+// Apply the cached availability to #pickup_time. `type` = selected rent type, or
+// null/undefined to use the "fully sold out across all rent types" rule.
+function rbfwApplyPickupSoldOut(type) {
+    if (type !== undefined) { rbfwPickupState.type = type || null; }
+    var avail = rbfwPickupState.avail || {};
+    var label = rbfwPickupSoldOutLabel();
+    var $sel  = jQuery('#pickup_time');
+    if (!$sel.length) { return; }
+
+    $sel.find('option').each(function () {
+        var opt = this;
+        if (!opt.value) { return; } // skip the "Pickup Time" placeholder
+        var perType = avail[opt.value];
+        if (!perType) { return; }   // unknown time — leave as-is (no false mark)
+
+        var soldOut;
+        if (rbfwPickupState.type && perType.hasOwnProperty(rbfwPickupState.type)) {
+            soldOut = (parseInt(perType[rbfwPickupState.type], 10) || 0) <= 0;
+        } else {
+            var maxRemaining = -1;
+            for (var k in perType) {
+                if (perType.hasOwnProperty(k)) {
+                    maxRemaining = Math.max(maxRemaining, parseInt(perType[k], 10) || 0);
+                }
+            }
+            soldOut = maxRemaining <= 0;
+        }
+
+        if (opt.getAttribute('data-rbfw-base-label') === null) {
+            opt.setAttribute('data-rbfw-base-label', opt.textContent);
+        }
+        var base = opt.getAttribute('data-rbfw-base-label');
+
+        // Never override the past-time disabling done in getAvailableTimes().
+        var pastDisabled = (opt.title === 'Past time' || opt.title === 'Past Time');
+        if (soldOut) {
+            opt.disabled = true;
+            opt.classList.add('rbfw-pickup-sold-out');
+            opt.textContent = base + ' (' + label + ')';
+        } else if (!pastDisabled) {
+            opt.disabled = false;
+            opt.classList.remove('rbfw-pickup-sold-out');
+            opt.textContent = base;
+        }
+    });
+}
+
+function rbfwFetchPickupSoldOut(post_id, start_date) {
+    var $sel = jQuery('#pickup_time');
+    if (!$sel.length || !post_id || !start_date) { return; }
+
+    var times = [];
+    $sel.find('option').each(function () {
+        if (this.value) { times.push(this.value); }
+    });
+    if (!times.length) { return; }
+
+    var key = post_id + '|' + start_date;
+    rbfwPickupState.key  = key;
+    rbfwPickupState.type = null; // date changed → reset the selected duration
+
+    jQuery.ajax({
+        type: 'POST',
+        dataType: 'json',
+        url: rbfw_ajax_front.rbfw_ajaxurl,
+        data: {
+            'action': 'rbfw_sd_pickup_times_availability',
+            'post_id': post_id,
+            'selected_date': start_date,
+            'times': times,
+            'nonce': rbfw_ajax_front.nonce_service_type_timely_stock
+        },
+        success: function (res) {
+            if (rbfwPickupState.key !== key) { return; } // a newer date won the race
+            if (res && res.success && res.data && res.data.avail) {
+                rbfwPickupState.avail = res.data.avail;
+                rbfwApplyPickupSoldOut(rbfwPickupState.type);
+            }
+        }
+    });
 }
 
 function rbfw_service_type_timely_stock_ajax(post_id,start_date,start_time='',enable_specific_duration = 'off'){

--- a/inc/class-bike-car-sd-function.php
+++ b/inc/class-bike-car-sd-function.php
@@ -27,6 +27,86 @@
 				add_action( 'wp_ajax_nopriv_rbfw_service_type_timely_stock', array( $this, 'rbfw_service_type_timely_stock' ) );
 				add_action( 'wp_ajax_rbfw_bikecarsd_sold_out_times', array( $this, 'rbfw_bikecarsd_sold_out_times' ) );
 				add_action( 'wp_ajax_nopriv_rbfw_bikecarsd_sold_out_times', array( $this, 'rbfw_bikecarsd_sold_out_times' ) );
+				add_action( 'wp_ajax_rbfw_sd_pickup_times_availability', array( $this, 'rbfw_sd_pickup_times_availability' ) );
+				add_action( 'wp_ajax_nopriv_rbfw_sd_pickup_times_availability', array( $this, 'rbfw_sd_pickup_times_availability' ) );
+			}
+
+			/**
+			 * AJAX: per-pickup-time availability for single-day items, so the Pickup
+			 * Time dropdown can disable sold-out times.
+			 *
+			 * For each posted time it returns the remaining stock of every rent type,
+			 * evaluated against that rent type's real booked window:
+			 *   - timely inventory (non-specific-duration): the interval
+			 *     [time, time + duration] via rbfw_timely_available_quantity_updated();
+			 *   - appointment: the exact (date, time) slot via
+			 *     rbfw_get_bike_car_sd_available_qty().
+			 * Other configurations (date-based, specific-duration) are not time-gated,
+			 * so every type is reported available (no false "sold out" marks).
+			 *
+			 * The client keys the response by the exact option value it sent, so
+			 * 12-hour ("2:30 PM") and 24-hour ("14:30") formats both work — PHP's
+			 * DateTime/strtotime normalises either.
+			 */
+			public function rbfw_sd_pickup_times_availability() {
+				check_ajax_referer( 'rbfw_service_type_timely_stock_action', 'nonce' );
+
+				$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+				$date    = isset( $_POST['selected_date'] ) ? sanitize_text_field( wp_unslash( $_POST['selected_date'] ) ) : '';
+				$times   = ( isset( $_POST['times'] ) && is_array( $_POST['times'] ) )
+					? array_map( 'sanitize_text_field', wp_unslash( $_POST['times'] ) )
+					: array();
+
+				if ( ! $post_id || '' === $date || empty( $times ) ) {
+					wp_send_json_success( array( 'avail' => array() ) );
+				}
+
+				$item_type = get_post_meta( $post_id, 'rbfw_item_type', true );
+				$is_timely = 'on' === get_post_meta( $post_id, 'manage_inventory_as_timely', true );
+				$specific  = 'on' === get_post_meta( $post_id, 'enable_specific_duration', true );
+				$sd_data   = get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true );
+				$sd_data   = is_array( $sd_data ) ? $sd_data : array();
+
+				$avail = array();
+				foreach ( $times as $time ) {
+					if ( '' === $time ) {
+						continue;
+					}
+					$per_type = array();
+					foreach ( $sd_data as $row ) {
+						$type = isset( $row['rent_type'] ) ? $row['rent_type'] : '';
+						if ( '' === $type ) {
+							continue;
+						}
+
+						if ( $is_timely && ! $specific ) {
+							$duration = ! empty( $row['duration'] ) ? (int) $row['duration'] : 0;
+							$d_type   = ! empty( $row['d_type'] ) ? $row['d_type'] : 'Hours';
+							if ( $duration <= 0 ) {
+								continue;
+							}
+							try {
+								$start_dt = new DateTime( $date . ' ' . $time );
+							} catch ( Exception $e ) {
+								continue;
+							}
+							$hours  = ( 'Hours' === $d_type ? $duration : ( 'Days' === $d_type ? $duration * 24 : ( 'Weeks' === $d_type ? $duration * 24 * 7 : $duration * 24 * 30 ) ) );
+							$end_dt = clone $start_dt;
+							$end_dt->modify( "+$hours hours" );
+							$per_type[ $type ] = (int) rbfw_timely_available_quantity_updated(
+								$post_id, $date, $time, $end_dt->format( 'Y-m-d' ), $end_dt->format( 'H:i:s' )
+							);
+						} elseif ( 'appointment' === $item_type ) {
+							$per_type[ $type ] = (int) rbfw_get_bike_car_sd_available_qty( $post_id, $date, $type, $time );
+						} else {
+							// Time is not a stock axis for this configuration.
+							$per_type[ $type ] = 1;
+						}
+					}
+					$avail[ $time ] = $per_type;
+				}
+
+				wp_send_json_success( array( 'avail' => $avail ) );
 			}
 
 			public function rbfw_get_bikecarsd_rent_info( $product_id, $rent_info , $booking_date = null ) {


### PR DESCRIPTION
New rbfw_sd_pickup_times_availability AJAX returns, per pickup time, the remaining stock of each rent type against that type's real booked window (timely: [time, time+duration]; appointment: the exact slot). The dropdown disables a time when every rent type is full there, and refines per the selected duration once one is chosen. Mirrors the add-to-cart availability gate so an offered time can never fail at checkout.