### PR TITLE
Fix modern editor save: toggle persistence, pricing-gate abort, numbe…

### DIFF
--- a/admin/RBFW_Modern_Editor.php
+++ b/admin/RBFW_Modern_Editor.php
@@ -461,16 +461,18 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 				wp_send_json_error( 'Forbidden', 403 );
 			}
 
-			$item_type = isset( $_POST['rbfw_item_type'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_item_type'] ) ) : '';
+			// Pricing completeness is only a *publish* gate. Previously any pricing
+			// validation error aborted the whole request via wp_send_json_error()
+			// before a single field was written, which silently discarded every
+			// other tab's changes (Advanced, FAQ, Template, Terms, Tax, etc.) even
+			// though those sections have nothing to do with pricing. Now the errors
+			// are collected but saving continues unconditionally; they are only used
+			// below to keep an incomplete item out of "publish" status.
+			$item_type      = isset( $_POST['rbfw_item_type'] ) ? sanitize_text_field( wp_unslash( $_POST['rbfw_item_type'] ) ) : '';
+			$pricing_errors = [];
 			if ( class_exists( 'RBFW_Pricing' ) ) {
 				$pricing_validator = new RBFW_Pricing();
 				$pricing_errors    = $pricing_validator->get_pricing_validation_errors( $item_type, wp_unslash( $_POST ) );
-				if ( ! empty( $pricing_errors ) ) {
-					wp_send_json_error( [
-						'message' => implode( ' ', $pricing_errors ),
-						'errors'  => $pricing_errors,
-					] );
-				}
 			}
 
 			/* ── Post fields ── */
@@ -481,6 +483,11 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 				: get_post_status( $post_id );
 			// First save of a freshly-opened item promotes the auto-draft to a real draft.
 			if ( $status === 'auto-draft' ) {
+				$status = 'draft';
+			}
+			// Never let an item go live with incomplete pricing — keep it as a draft
+			// and let the rest of the save proceed normally so nothing else is lost.
+			if ( $status === 'publish' && ! empty( $pricing_errors ) ) {
 				$status = 'draft';
 			}
 
@@ -859,10 +866,11 @@ if ( ! class_exists( 'RBFW_Modern_Editor' ) ) {
 			$this->set_edit_mode( $post_id, 'modern' );
 
 			wp_send_json_success( [
-				'post_id'      => $post_id,
-				'post_status'  => get_post_status( $post_id ),
-				'permalink'    => get_permalink( $post_id ),
-				'edit_url'     => $this->edit_url( $post_id, 'general' ),
+				'post_id'         => $post_id,
+				'post_status'     => get_post_status( $post_id ),
+				'permalink'       => get_permalink( $post_id ),
+				'edit_url'        => $this->edit_url( $post_id, 'general' ),
+				'pricing_errors'  => $pricing_errors,
 			] );
 		}
 

--- a/admin/js/mkb-admin.js
+++ b/admin/js/mkb-admin.js
@@ -2,6 +2,19 @@
     "use strict";
 
     /**
+     * Some legacy click handlers below flip a checkbox's `value` attribute
+     * instead of relying on the native `checked` state. That was fine for
+     * the classic editor, but the modern editor (.rbfw-me-wrap) reads the
+     * value attribute when serialising form data — so the legacy handlers
+     * would flip the value to the OPPOSITE of what the user just clicked
+     * and the AJAX save would persist the inverse of the user's intent.
+     * Helper to skip those handlers inside the modern editor wrap.
+     */
+    var rbfwIsLegacyEditorTarget = function (target) {
+        return ! $(target).closest('.rbfw-me-wrap').length;
+    };
+
+    /**
      * Extra Service admin sections — only one visible at a time.
      *
      * Category 1 (.rbfw_es_price_config_wrapper):
@@ -1453,6 +1466,7 @@
     }
 
     $(document).on('click', 'input[name=rbfw_enable_term_content]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'yes') {
             $(this).val('no')
@@ -1612,6 +1626,7 @@
 
 
     $(document).on('click', 'input[name=rbfw_term_condition_required]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'yes') {
             $(this).val('no')
@@ -1631,6 +1646,7 @@
      */
      // Toggle visibility for category service price
     $(document).on('click', 'input[name=rbfw_enable_category_service_price]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'on') {
             $(this).val('off')
@@ -1646,6 +1662,7 @@
 
 
     $(document).on('click', 'input[name=rbfw_enable_extra_service_qty]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'yes') {
             $(this).val('no');
@@ -1657,7 +1674,17 @@
     });
 
 
+    // Legacy "value-flip" click handlers. These were written for the classic
+    // editor, where the checkbox's value attribute (not its checked state) was
+    // the source of truth. They run on every admin page and would also fire on
+    // the modern editor's toggles, flipping the value attribute to the OPPOSITE
+    // of what the user just clicked — so collectFormData() would read the wrong
+    // value and the AJAX save would write the inverse of the user's intent.
+    // The modern editor manages these toggles through rbfw-modern-editor.js
+    // (initToggles() + collectFormData()) and does not need these handlers, so
+    // skip them whenever the click target lives inside the modern editor wrap.
     $(document).on('click', 'input[name=shipping_enable]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'yes') {
             $(this).val('no')
@@ -1667,6 +1694,7 @@
         }
     });
     $(document).on('click', 'input[name=rbfw_enable_faq_content]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'yes') {
             $(this).val('no')
@@ -1679,6 +1707,7 @@
     });
 
     $(document).on('click', 'input[name=rbfw_enable_additional_gallary]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'on') {
             $(this).val('off');
@@ -1690,6 +1719,7 @@
         }
     });
     $(document).on('click', 'input[name=rbfw_dt_sidebar_switch]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'on') {
             $(this).val('off')
@@ -1700,6 +1730,7 @@
     });
     // Daily price
     $(document).on('click', 'input[name=rbfw_enable_daily_rate]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'yes') {
             $(this).val('no');
@@ -1712,6 +1743,7 @@
     });
     // Hourly price
     $(document).on('click', 'input[name=rbfw_enable_hourly_rate]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = $(this).val();
         if (status === 'yes') {
             $(this).val('no');
@@ -1730,6 +1762,7 @@
     });
     // Day long price
     $(document).on('click', 'input[name=rbfw_enable_resort_daylong_price]', function (e) {
+        if ( ! rbfwIsLegacyEditorTarget(this) ) return;
         var status = jQuery(this).val();
         if (status === 'yes') {
             jQuery(this).val('no');

--- a/admin/js/rbfw-modern-editor.js
+++ b/admin/js/rbfw-modern-editor.js
@@ -1227,7 +1227,20 @@
     }
 
     function doSave(status) {
-        if ( ! validateBeforeSave() ) return;
+        // Never abort the request on a validation failure — doing so used to
+        // silently discard every Advanced-tab change (Template, FAQ toggle, Tax,
+        // Security Deposit, Terms, Related, Front-end Display, …) whenever the
+        // pricing/description/time-slots were still incomplete.
+        //
+        //   • A draft may legitimately be incomplete, so it always saves as-is.
+        //   • Publishing still runs the full client-side checks so the exact
+        //     problems are highlighted inline; but instead of blocking, an
+        //     incomplete item is saved as a *draft* so nothing the user entered
+        //     is lost. This mirrors the server, which keeps an incomplete item
+        //     out of "publish" status and returns the pricing errors.
+        if ( status === 'publish' && ! validateBeforeSave() ) {
+            status = 'draft';
+        }
 
         setSaveIndicator('saving', cfg.i18n && cfg.i18n.saving || 'Saving your changes…');
 
@@ -1239,18 +1252,28 @@
 
         $.post(cfg.ajax_url, data, function (res) {
             if (res.success) {
-                setSaveIndicator('saved', cfg.i18n && cfg.i18n.saved || 'All changes saved');
+                var savedStatus = (res.data && res.data.post_status) || status;
+                var pricingErrors = (res.data && res.data.pricing_errors) || [];
+
+                if (status === 'publish' && pricingErrors.length && savedStatus !== 'publish') {
+                    // Everything was saved, but the item couldn't go live because the
+                    // pricing setup is incomplete — surface that without discarding input.
+                    setSaveIndicator('error', pricingErrors.join(' '));
+                } else {
+                    setSaveIndicator('saved', cfg.i18n && cfg.i18n.saved || 'All changes saved');
+                    setTimeout(function () { setSaveIndicator('', ''); }, 4500);
+                }
+
                 // Update publish button label if status changed
-                if (status === 'publish') {
+                if (savedStatus === 'publish') {
                     $wrap.find('.rbfw-me-publish').text(cfg.i18n && cfg.i18n.update || 'Update').data('published', '1');
                 }
                 // Update status dot
                 var $dot   = $wrap.find('.rbfw-me-status-dot');
                 var $label = $wrap.find('.rbfw-me-status-label');
-                $dot.attr('class', 'rbfw-me-status-dot rbfw-me-status-dot--' + status);
-                $label.text(status.charAt(0).toUpperCase() + status.slice(1));
-
-                setTimeout(function () { setSaveIndicator('', ''); }, 4500);
+                $dot.attr('class', 'rbfw-me-status-dot rbfw-me-status-dot--' + savedStatus);
+                $label.text(savedStatus.charAt(0).toUpperCase() + savedStatus.slice(1));
+                $wrap.find('select.rbfw-me-select[name="post_status"]').val(savedStatus);
             } else {
                 var errorMsg = cfg.i18n && cfg.i18n.save_error || 'Save failed — please try again';
                 if (res.data && res.data.message) {

--- a/admin/settings/Pricing.php
+++ b/admin/settings/Pricing.php
@@ -172,7 +172,11 @@
 				$rbfw_bike_car_sd_data           = get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true ) ? get_post_meta( $post_id, 'rbfw_bike_car_sd_data', true ) : [];
 				$manage_inventory_as_timely      = get_post_meta( $post_id, 'manage_inventory_as_timely', true );
 				$manage_inventory_as_timely      = $manage_inventory_as_timely ? $manage_inventory_as_timely : 'off';
-				$rbfw_item_stock_quantity_timely = get_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', true ) ? get_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', true ) : 'off';
+				// Stock quantity is a number field — default to '' (not the string
+				// 'off', which the browser rejects on a type="number" input with
+				// "The specified value 'off' cannot be parsed", blanking the field).
+				$rbfw_item_stock_quantity_timely = get_post_meta( $post_id, 'rbfw_item_stock_quantity_timely', true );
+				$rbfw_item_stock_quantity_timely = ( $rbfw_item_stock_quantity_timely !== '' && $rbfw_item_stock_quantity_timely !== false ) ? $rbfw_item_stock_quantity_timely : '';
 				$enable_specific_duration        = get_post_meta( $post_id, 'enable_specific_duration', true ) ? get_post_meta( $post_id, 'enable_specific_duration', true ) : 'off';
 				$enable_specific_duration        = $enable_specific_duration ? $enable_specific_duration : 'off';
 				?>
@@ -1067,8 +1071,13 @@
                 $rbfw_enable_half_day_rate   = get_post_meta( $post_id, 'rbfw_enable_half_day_rate', true ) ? get_post_meta( $post_id, 'rbfw_enable_half_day_rate', true ) : 'no';
                 $rbfw_half_day_rate          = get_post_meta( $post_id, 'rbfw_half_day_rate', true ) ? get_post_meta( $post_id, 'rbfw_half_day_rate', true ) : 0;
 
-                $half_day_hour_threshold_start   = get_post_meta( $post_id, 'half_day_hour_threshold_start', true ) ? get_post_meta( $post_id, 'half_day_hour_threshold_start', true ) : 'no';
-                $half_day_hour_threshold_end   = get_post_meta( $post_id, 'half_day_hour_threshold_end', true ) ? get_post_meta( $post_id, 'half_day_hour_threshold_end', true ) : 'no';
+                // Hour values feed type="number" inputs — default to '' (not the
+                // string 'no', which the browser rejects with "cannot be parsed"
+                // and blanks the field).
+                $half_day_hour_threshold_start   = get_post_meta( $post_id, 'half_day_hour_threshold_start', true );
+                $half_day_hour_threshold_start   = ( $half_day_hour_threshold_start !== '' && $half_day_hour_threshold_start !== false ) ? $half_day_hour_threshold_start : '';
+                $half_day_hour_threshold_end     = get_post_meta( $post_id, 'half_day_hour_threshold_end', true );
+                $half_day_hour_threshold_end     = ( $half_day_hour_threshold_end !== '' && $half_day_hour_threshold_end !== false ) ? $half_day_hour_threshold_end : '';
 
                 $rbfw_hourly_threshold   = get_post_meta( $post_id, 'rbfw_hourly_threshold', true ) ? get_post_meta( $post_id, 'rbfw_hourly_threshold', true ) : '0';
                 $rbfw_enable_hourly_threshold    = get_post_meta( $post_id, 'rbfw_enable_hourly_threshold', true ) ? get_post_meta( $post_id, 'rbfw_enable_hourly_threshold', true ) : 'no';


### PR DESCRIPTION
…r-input defaults

Modern rental-item editor: several Advanced-tab settings were silently discarded on save. Root causes and fixes:

* Toggle values corrupted by legacy handlers (mkb-admin.js): classic click handlers flip a checkbox's `value` attribute on click. The modern editor serialises the value attribute, so a checked toggle was saved as its inverse (or empty). Skip those handlers inside `.rbfw-me-wrap` via rbfwIsLegacyEditorTarget() — covers FAQ, Additional Gallery, Term, category service price, extra-service qty, day/hourly rate, etc.

* Pricing completeness was a hard SAVE gate, not just a publish gate (RBFW_Modern_Editor::ajax_save + doSave): an incomplete-pricing item aborted the whole request before any meta was written, discarding Template/FAQ/Tax/Terms/etc. Now saving always proceeds; publish is downgraded to draft when pricing is incomplete and the errors are returned for display. Client mirrors this: drafts never block, publish downgrades instead of aborting.

* Number inputs rendered non-numeric string defaults ('off'/'no') that the browser rejects ("value cannot be parsed") and blanks (Pricing.php: rbfw_item_stock_quantity_timely, half_day_hour_threshold start/end) — default to '' to match the rest of the codebase.