### PR TITLE
Add SEO score column to the Rental Items list

### DIFF
--- a/admin/RBFW_Rental_List.php
+++ b/admin/RBFW_Rental_List.php
@@ -170,6 +170,8 @@ if (!class_exists('RBFW_Rental_List')) {
                 'update_term_meta_cache' => true,
             ));
             $rent_types = RBFW_Function::rbfw_rent_types();
+            // Resolved in one pass so AIOSEO needs a single query rather than one per row.
+            $seo_scores = $this->seo_scores(wp_list_pluck($query->posts, 'ID'));
             $items = array();
             foreach ($query->posts as $post) {
                 $pid       = $post->ID;
@@ -184,6 +186,7 @@ if (!class_exists('RBFW_Rental_List')) {
                     'type_label' => $type_lbl,
                     'cats'       => $cats,
                     'price'      => $this->get_price_label($pid),
+                    'seo_score'  => isset($seo_scores[$pid]) ? $seo_scores[$pid] : null,
                     'status'     => $post->post_status,
                     'thumb'      => get_the_post_thumbnail_url($pid, 'medium_large'),
                     'author'     => get_the_author_meta('display_name', $post->post_author),
@@ -199,6 +202,156 @@ if (!class_exists('RBFW_Rental_List')) {
             }
 
             return $items;
+        }
+
+        /**
+         * Which SEO plugin is currently ACTIVE, if any.
+         *
+         * Detection is by runtime constant, not by the plugin being present on
+         * disk: an installed-but-deactivated plugin stores no scores, so the
+         * column must stay hidden for it.
+         *
+         * @return string '' | 'yoast' | 'rankmath' | 'aioseo' | 'seopress'
+         */
+        private function seo_plugin(): string
+        {
+            static $plugin = null;
+            if (null !== $plugin) {
+                return $plugin;
+            }
+
+            if (defined('WPSEO_VERSION')) {
+                $plugin = 'yoast';
+            } elseif (defined('RANK_MATH_VERSION')) {
+                $plugin = 'rankmath';
+            } elseif (defined('AIOSEO_VERSION')) {
+                $plugin = 'aioseo';
+            } elseif (defined('SEOPRESS_VERSION')) {
+                $plugin = 'seopress';
+            } else {
+                $plugin = '';
+            }
+
+            /**
+             * Let an unsupported SEO plugin declare itself; pair with
+             * `rbfw_item_seo_scores` to supply the numbers.
+             */
+            $plugin = (string) apply_filters('rbfw_item_seo_plugin', $plugin);
+
+            return $plugin;
+        }
+
+        /**
+         * Human name of the active SEO plugin, for the column tooltip.
+         */
+        private function seo_plugin_label(): string
+        {
+            switch ($this->seo_plugin()) {
+                case 'yoast':
+                    return __('Yoast SEO', 'booking-and-rental-manager-for-woocommerce');
+                case 'rankmath':
+                    return __('Rank Math', 'booking-and-rental-manager-for-woocommerce');
+                case 'aioseo':
+                    return __('All in One SEO', 'booking-and-rental-manager-for-woocommerce');
+                case 'seopress':
+                    return __('SEOPress', 'booking-and-rental-manager-for-woocommerce');
+            }
+
+            return __('SEO', 'booking-and-rental-manager-for-woocommerce');
+        }
+
+        /**
+         * SEO scores for a set of items, keyed by post ID.
+         *
+         * Read in bulk rather than per row: the meta-backed plugins ride the
+         * WP_Query meta cache, and AIOSEO (which stores scores in its own table)
+         * gets a single query instead of one per item.
+         *
+         * A value of null means "not analysed" and renders as a dash. Both Yoast
+         * and Rank Math store 0 for an unanalysed post, so 0 is treated the same
+         * way their own UIs treat it.
+         *
+         * @param int[] $post_ids
+         * @return array<int, int|null> 0-100 per post, or null
+         */
+        private function seo_scores(array $post_ids): array
+        {
+            $plugin = $this->seo_plugin();
+            $scores = array();
+
+            if ('' === $plugin || empty($post_ids)) {
+                return $scores;
+            }
+
+            switch ($plugin) {
+                case 'yoast':
+                case 'rankmath':
+                    $key = ('yoast' === $plugin) ? '_yoast_wpseo_linkdex' : 'rank_math_seo_score';
+                    foreach ($post_ids as $pid) {
+                        $raw           = get_post_meta($pid, $key, true);
+                        $scores[$pid]  = ('' === $raw || null === $raw) ? null : (int) $raw;
+                    }
+                    break;
+
+                case 'aioseo':
+                    global $wpdb;
+                    $table = $wpdb->prefix . 'aioseo_posts';
+                    // The constant can exist before the table does (fresh install).
+                    if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) === $table) {
+                        $ids = implode(',', array_map('absint', $post_ids));
+                        // $ids is a sanitised integer list; the table name is prefix-derived.
+                        $rows = $wpdb->get_results("SELECT post_id, seo_score FROM {$table} WHERE post_id IN ({$ids})"); // phpcs:ignore WordPress.DB.PreparedSQL
+                        foreach ((array) $rows as $row) {
+                            $scores[(int) $row->post_id] = (null === $row->seo_score) ? null : (int) $row->seo_score;
+                        }
+                    }
+                    break;
+
+                case 'seopress':
+                    foreach ($post_ids as $pid) {
+                        $data         = get_post_meta($pid, '_seopress_analysis_data', true);
+                        $scores[$pid] = (is_array($data) && isset($data['score']['value'])) ? (int) $data['score']['value'] : null;
+                    }
+                    break;
+            }
+
+            /**
+             * Filter the resolved scores, keyed by post ID (0-100, or null when
+             * not analysed). Use with `rbfw_item_seo_plugin` to add support for
+             * an SEO plugin this list does not know about.
+             */
+            return (array) apply_filters('rbfw_item_seo_scores', $scores, $post_ids, $plugin);
+        }
+
+        /**
+         * Bucket a score using the active plugin's own thresholds, so the badge
+         * agrees with what that plugin shows on the edit screen.
+         *
+         * @param int $score 0-100
+         * @return string 'good' | 'ok' | 'bad'
+         */
+        private function seo_rank(int $score): string
+        {
+            switch ($this->seo_plugin()) {
+                case 'rankmath':
+                    if ($score >= 81) {
+                        return 'good';
+                    }
+                    return ($score >= 51) ? 'ok' : 'bad';
+
+                case 'aioseo':
+                    if ($score >= 80) {
+                        return 'good';
+                    }
+                    return ($score >= 50) ? 'ok' : 'bad';
+            }
+
+            // Yoast / SEOPress / default — mirrors WPSEO_Rank: 71+ good, 41-70 ok.
+            if ($score >= 71) {
+                return 'good';
+            }
+
+            return ($score >= 41) ? 'ok' : 'bad';
         }
 
         private function get_price_label($pid): string
@@ -256,6 +409,10 @@ if (!class_exists('RBFW_Rental_List')) {
             $name = self::cpt_label();
             // phpcs:ignore WordPress.Security.NonceVerification.Recommended
             $is_trash = isset($_GET['rbfw_status']) && sanitize_text_field(wp_unslash($_GET['rbfw_status'])) === 'trash';
+
+            // SEO column is opt-in on the active SEO plugin: no plugin, no column.
+            $seo_active = '' !== $this->seo_plugin();
+            $seo_label  = $this->seo_plugin_label();
 
             $active    = $this->get_items();
             $total     = count($active);
@@ -450,6 +607,10 @@ if (!class_exists('RBFW_Rental_List')) {
                                 <th><?php esc_html_e('Name', 'booking-and-rental-manager-for-woocommerce'); ?></th>
                                 <th><?php esc_html_e('Price Type', 'booking-and-rental-manager-for-woocommerce'); ?></th>
                                 <th><?php esc_html_e('Price', 'booking-and-rental-manager-for-woocommerce'); ?></th>
+                                <?php // SEO column appears only while an SEO plugin is active — header and cell are gated together. ?>
+                                <?php if ($seo_active) : ?>
+                                <th class="rbfw-th-seo" title="<?php echo esc_attr(sprintf(/* translators: %s: SEO plugin name */ __('SEO score from %s', 'booking-and-rental-manager-for-woocommerce'), $seo_label)); ?>"><?php esc_html_e('SEO', 'booking-and-rental-manager-for-woocommerce'); ?></th>
+                                <?php endif; ?>
                                 <th><?php esc_html_e('Status', 'booking-and-rental-manager-for-woocommerce'); ?></th>
                                 <th><?php esc_html_e('Actions', 'booking-and-rental-manager-for-woocommerce'); ?></th>
                             </tr>
@@ -473,6 +634,17 @@ if (!class_exists('RBFW_Rental_List')) {
                                     </td>
                                     <td data-label="<?php esc_attr_e('Price Type', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php echo $it['type_label'] ? '<span class="rbfw-t-badge type">' . esc_html($it['type_label']) . '</span>' : '-'; ?></td>
                                     <td data-label="<?php esc_attr_e('Price', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php echo esc_html($it['price'] ?: '-'); ?></td>
+                                    <?php if ($seo_active) : ?>
+                                    <td class="rbfw-td-seo" data-label="<?php esc_attr_e('SEO', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                        <?php if (null === $it['seo_score'] || 0 === $it['seo_score']) : ?>
+                                            <span class="rbfw-seo-badge is-none" title="<?php esc_attr_e('Not analysed yet — open the item and set a focus keyword.', 'booking-and-rental-manager-for-woocommerce'); ?>">&mdash;</span>
+                                        <?php else : ?>
+                                            <span class="rbfw-seo-badge is-<?php echo esc_attr($this->seo_rank((int) $it['seo_score'])); ?>" title="<?php echo esc_attr(sprintf(/* translators: 1: score 0-100, 2: SEO plugin name */ __('SEO score %1$s/100 (%2$s)', 'booking-and-rental-manager-for-woocommerce'), number_format_i18n((int) $it['seo_score']), $seo_label)); ?>">
+                                                <?php echo esc_html(number_format_i18n((int) $it['seo_score'])); ?><i>/100</i>
+                                            </span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <?php endif; ?>
                                     <td data-label="<?php esc_attr_e('Status', 'booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw-status-dot status-<?php echo esc_attr($it['status']); ?>"><?php echo esc_html($this->status_label($it['status'])); ?></span></td>
                                     <td data-label="<?php esc_attr_e('Actions', 'booking-and-rental-manager-for-woocommerce'); ?>">
                                         <div class="rbfw-table-acts">

--- a/admin/RBFW_Rental_List.php
+++ b/admin/RBFW_Rental_List.php
@@ -722,17 +722,28 @@ if (!class_exists('RBFW_Rental_List')) {
                                                 </span>
                                             <?php endif; ?>
                                         </span>
+                                        <?php
+                                        // Detail line: keyword text, then icon-only warnings. Icons rather
+                                        // than words because this column is narrow — the tooltip carries
+                                        // the explanation, so the cell stays one line at any table width.
+                                        ?>
                                         <span class="rbfw-seo-sub">
                                             <?php if ('' !== $seo['keyword']) : ?>
                                                 <span class="rbfw-seo-kw" title="<?php echo esc_attr(sprintf(/* translators: %s: focus keyword */ __('Focus keyword: %s', 'booking-and-rental-manager-for-woocommerce'), $seo['keyword'])); ?>"><?php echo esc_html($seo['keyword']); ?></span>
                                             <?php else : ?>
-                                                <span class="rbfw-seo-flag" title="<?php esc_attr_e('No focus keyword set — the plugin cannot score this item.', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php esc_html_e('No keyword', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+                                                <span class="rbfw-seo-ico" title="<?php esc_attr_e('No focus keyword set — the plugin cannot score this item.', 'booking-and-rental-manager-for-woocommerce'); ?>" aria-label="<?php esc_attr_e('No focus keyword', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="7.5" cy="15.5" r="4.5"/><path d="M10.7 12.3 21 2"/><path d="m17 6 3 3"/></svg>
+                                                </span>
                                             <?php endif; ?>
                                             <?php if (! $seo['has_desc']) : ?>
-                                                <span class="rbfw-seo-flag" title="<?php esc_attr_e('No meta description — search engines will invent one.', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php esc_html_e('No description', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+                                                <span class="rbfw-seo-ico" title="<?php esc_attr_e('No meta description — search engines will invent one.', 'booking-and-rental-manager-for-woocommerce'); ?>" aria-label="<?php esc_attr_e('No meta description', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h5"/><path d="M8 17h8"/></svg>
+                                                </span>
                                             <?php endif; ?>
                                             <?php if ($seo['noindex']) : ?>
-                                                <span class="rbfw-seo-flag is-noindex" title="<?php esc_attr_e('Excluded from search engines (noindex).', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php esc_html_e('noindex', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+                                                <span class="rbfw-seo-ico is-noindex" title="<?php esc_attr_e('Excluded from search engines (noindex).', 'booking-and-rental-manager-for-woocommerce'); ?>" aria-label="<?php esc_attr_e('Excluded from search engines', 'booking-and-rental-manager-for-woocommerce'); ?>">
+                                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9.9 4.2A10.9 10.9 0 0 1 12 4c7 0 10 8 10 8a18.5 18.5 0 0 1-2.2 3.2"/><path d="M6.6 6.6A18.4 18.4 0 0 0 2 12s3 8 10 8a10.9 10.9 0 0 0 5.4-1.4"/><path d="M14.1 14.1a3 3 0 1 1-4.2-4.2"/><path d="m2 2 20 20"/></svg>
+                                                </span>
                                             <?php endif; ?>
                                         </span>
                                     </td>

--- a/admin/RBFW_Rental_List.php
+++ b/admin/RBFW_Rental_List.php
@@ -171,7 +171,7 @@ if (!class_exists('RBFW_Rental_List')) {
             ));
             $rent_types = RBFW_Function::rbfw_rent_types();
             // Resolved in one pass so AIOSEO needs a single query rather than one per row.
-            $seo_scores = $this->seo_scores(wp_list_pluck($query->posts, 'ID'));
+            $seo_data = $this->seo_data(wp_list_pluck($query->posts, 'ID'));
             $items = array();
             foreach ($query->posts as $post) {
                 $pid       = $post->ID;
@@ -186,7 +186,7 @@ if (!class_exists('RBFW_Rental_List')) {
                     'type_label' => $type_lbl,
                     'cats'       => $cats,
                     'price'      => $this->get_price_label($pid),
-                    'seo_score'  => isset($seo_scores[$pid]) ? $seo_scores[$pid] : null,
+                    'seo'        => isset($seo_data[$pid]) ? $seo_data[$pid] : null,
                     'status'     => $post->post_status,
                     'thumb'      => get_the_post_thumbnail_url($pid, 'medium_large'),
                     'author'     => get_the_author_meta('display_name', $post->post_author),
@@ -234,7 +234,7 @@ if (!class_exists('RBFW_Rental_List')) {
 
             /**
              * Let an unsupported SEO plugin declare itself; pair with
-             * `rbfw_item_seo_scores` to supply the numbers.
+             * `rbfw_item_seo_data` to supply the signals.
              */
             $plugin = (string) apply_filters('rbfw_item_seo_plugin', $plugin);
 
@@ -261,35 +261,74 @@ if (!class_exists('RBFW_Rental_List')) {
         }
 
         /**
-         * SEO scores for a set of items, keyed by post ID.
+         * SEO signals for a set of items, keyed by post ID.
          *
          * Read in bulk rather than per row: the meta-backed plugins ride the
-         * WP_Query meta cache, and AIOSEO (which stores scores in its own table)
-         * gets a single query instead of one per item.
+         * WP_Query meta cache, and AIOSEO (which stores its data in its own
+         * table) gets a single query instead of one per item.
          *
-         * A value of null means "not analysed" and renders as a dash. Both Yoast
-         * and Rank Math store 0 for an unanalysed post, so 0 is treated the same
-         * way their own UIs treat it.
+         * Every entry has the same shape:
+         *   score       int|null  0-100, null when not analysed
+         *   readability int|null  0-100, null when the plugin has no such score
+         *   keyword     string    primary focus keyword ('' when unset)
+         *   has_desc    bool      a meta description is set
+         *   noindex     bool      excluded from search engines
+         *
+         * Both Yoast and Rank Math store 0 for an unanalysed post, so 0 is
+         * treated as "not analysed", the way their own UIs treat it.
+         *
+         * Meta keys are taken from each plugin's source, not guessed:
+         * Yoast builds keys from $meta_prefix '_yoast_wpseo_' + field name, and
+         * its meta-robots-noindex is '1' = no-index ('0' post-type default,
+         * '2' = index).
          *
          * @param int[] $post_ids
-         * @return array<int, int|null> 0-100 per post, or null
+         * @return array<int, array<string, mixed>>
          */
-        private function seo_scores(array $post_ids): array
+        private function seo_data(array $post_ids): array
         {
             $plugin = $this->seo_plugin();
-            $scores = array();
+            $out    = array();
+            $blank  = array(
+                'score'       => null,
+                'readability' => null,
+                'keyword'     => '',
+                'has_desc'    => false,
+                'noindex'     => false,
+            );
 
             if ('' === $plugin || empty($post_ids)) {
-                return $scores;
+                return $out;
             }
 
             switch ($plugin) {
                 case 'yoast':
-                case 'rankmath':
-                    $key = ('yoast' === $plugin) ? '_yoast_wpseo_linkdex' : 'rank_math_seo_score';
                     foreach ($post_ids as $pid) {
-                        $raw           = get_post_meta($pid, $key, true);
-                        $scores[$pid]  = ('' === $raw || null === $raw) ? null : (int) $raw;
+                        $score = get_post_meta($pid, '_yoast_wpseo_linkdex', true);
+                        $read  = get_post_meta($pid, '_yoast_wpseo_content_score', true);
+                        $out[$pid] = array(
+                            'score'       => ('' === $score || null === $score) ? null : (int) $score,
+                            'readability' => ('' === $read || null === $read) ? null : (int) $read,
+                            'keyword'     => (string) get_post_meta($pid, '_yoast_wpseo_focuskw', true),
+                            'has_desc'    => '' !== trim((string) get_post_meta($pid, '_yoast_wpseo_metadesc', true)),
+                            'noindex'     => '1' === (string) get_post_meta($pid, '_yoast_wpseo_meta-robots-noindex', true),
+                        );
+                    }
+                    break;
+
+                case 'rankmath':
+                    foreach ($post_ids as $pid) {
+                        $score  = get_post_meta($pid, 'rank_math_seo_score', true);
+                        $kw     = (string) get_post_meta($pid, 'rank_math_focus_keyword', true);
+                        $robots = get_post_meta($pid, 'rank_math_robots', true);
+                        $kw     = explode(',', $kw); // comma-separated; first entry is the primary keyword
+                        $out[$pid] = array(
+                            'score'       => ('' === $score || null === $score) ? null : (int) $score,
+                            'readability' => null, // Rank Math reports one combined score, no separate readability
+                            'keyword'     => trim((string) reset($kw)),
+                            'has_desc'    => '' !== trim((string) get_post_meta($pid, 'rank_math_description', true)),
+                            'noindex'     => is_array($robots) && in_array('noindex', $robots, true),
+                        );
                     }
                     break;
 
@@ -300,38 +339,70 @@ if (!class_exists('RBFW_Rental_List')) {
                     if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) === $table) {
                         $ids = implode(',', array_map('absint', $post_ids));
                         // $ids is a sanitised integer list; the table name is prefix-derived.
-                        $rows = $wpdb->get_results("SELECT post_id, seo_score FROM {$table} WHERE post_id IN ({$ids})"); // phpcs:ignore WordPress.DB.PreparedSQL
+                        $rows = $wpdb->get_results("SELECT post_id, seo_score, description, keyphrases, robots_noindex FROM {$table} WHERE post_id IN ({$ids})"); // phpcs:ignore WordPress.DB.PreparedSQL
                         foreach ((array) $rows as $row) {
-                            $scores[(int) $row->post_id] = (null === $row->seo_score) ? null : (int) $row->seo_score;
+                            $kw         = '';
+                            $keyphrases = json_decode((string) $row->keyphrases, true);
+                            if (isset($keyphrases['focus']['keyphrase'])) {
+                                $kw = (string) $keyphrases['focus']['keyphrase'];
+                            }
+                            $out[(int) $row->post_id] = array(
+                                'score'       => (null === $row->seo_score) ? null : (int) $row->seo_score,
+                                'readability' => null,
+                                'keyword'     => $kw,
+                                'has_desc'    => '' !== trim((string) $row->description),
+                                'noindex'     => ! empty($row->robots_noindex),
+                            );
                         }
                     }
                     break;
 
                 case 'seopress':
                     foreach ($post_ids as $pid) {
-                        $data         = get_post_meta($pid, '_seopress_analysis_data', true);
-                        $scores[$pid] = (is_array($data) && isset($data['score']['value'])) ? (int) $data['score']['value'] : null;
+                        $data = get_post_meta($pid, '_seopress_analysis_data', true);
+                        $out[$pid] = array(
+                            'score'       => (is_array($data) && isset($data['score']['value'])) ? (int) $data['score']['value'] : null,
+                            'readability' => null,
+                            'keyword'     => (string) get_post_meta($pid, '_seopress_analysis_target_kw', true),
+                            'has_desc'    => '' !== trim((string) get_post_meta($pid, '_seopress_titles_desc', true)),
+                            'noindex'     => 'yes' === (string) get_post_meta($pid, '_seopress_robots_index', true),
+                        );
                     }
                     break;
             }
 
+            // Normalise: every requested id gets the full shape, so the view never
+            // has to guard for a missing key.
+            foreach ($post_ids as $pid) {
+                $out[$pid] = isset($out[$pid]) ? array_merge($blank, $out[$pid]) : $blank;
+            }
+
             /**
-             * Filter the resolved scores, keyed by post ID (0-100, or null when
-             * not analysed). Use with `rbfw_item_seo_plugin` to add support for
-             * an SEO plugin this list does not know about.
+             * Filter the resolved SEO signals, keyed by post ID. Use with
+             * `rbfw_item_seo_plugin` to support an SEO plugin this list does not
+             * know about; keep the array shape documented above.
              */
-            return (array) apply_filters('rbfw_item_seo_scores', $scores, $post_ids, $plugin);
+            return (array) apply_filters('rbfw_item_seo_data', $out, $post_ids, $plugin);
         }
 
         /**
          * Bucket a score using the active plugin's own thresholds, so the badge
          * agrees with what that plugin shows on the edit screen.
          *
-         * @param int $score 0-100
+         * @param int  $score          0-100
+         * @param bool $is_readability Readability is graded on its own 71/41
+         *                             bands, independent of the plugin's SEO bands.
          * @return string 'good' | 'ok' | 'bad'
          */
-        private function seo_rank(int $score): string
+        private function seo_rank(int $score, bool $is_readability = false): string
         {
+            if ($is_readability) {
+                if ($score >= 71) {
+                    return 'good';
+                }
+                return ($score >= 41) ? 'ok' : 'bad';
+            }
+
             switch ($this->seo_plugin()) {
                 case 'rankmath':
                     if ($score >= 81) {
@@ -634,15 +705,36 @@ if (!class_exists('RBFW_Rental_List')) {
                                     </td>
                                     <td data-label="<?php esc_attr_e('Price Type', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php echo $it['type_label'] ? '<span class="rbfw-t-badge type">' . esc_html($it['type_label']) . '</span>' : '-'; ?></td>
                                     <td data-label="<?php esc_attr_e('Price', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php echo esc_html($it['price'] ?: '-'); ?></td>
-                                    <?php if ($seo_active) : ?>
+                                    <?php if ($seo_active) : $seo = $it['seo']; ?>
                                     <td class="rbfw-td-seo" data-label="<?php esc_attr_e('SEO', 'booking-and-rental-manager-for-woocommerce'); ?>">
-                                        <?php if (null === $it['seo_score'] || 0 === $it['seo_score']) : ?>
-                                            <span class="rbfw-seo-badge is-none" title="<?php esc_attr_e('Not analysed yet — open the item and set a focus keyword.', 'booking-and-rental-manager-for-woocommerce'); ?>">&mdash;</span>
-                                        <?php else : ?>
-                                            <span class="rbfw-seo-badge is-<?php echo esc_attr($this->seo_rank((int) $it['seo_score'])); ?>" title="<?php echo esc_attr(sprintf(/* translators: 1: score 0-100, 2: SEO plugin name */ __('SEO score %1$s/100 (%2$s)', 'booking-and-rental-manager-for-woocommerce'), number_format_i18n((int) $it['seo_score']), $seo_label)); ?>">
-                                                <?php echo esc_html(number_format_i18n((int) $it['seo_score'])); ?><i>/100</i>
-                                            </span>
-                                        <?php endif; ?>
+                                        <span class="rbfw-seo-line">
+                                            <?php if (null === $seo['score'] || 0 === $seo['score']) : ?>
+                                                <span class="rbfw-seo-badge is-none" title="<?php esc_attr_e('Not analysed yet — open the item and set a focus keyword.', 'booking-and-rental-manager-for-woocommerce'); ?>">&mdash;</span>
+                                            <?php else : ?>
+                                                <span class="rbfw-seo-badge is-<?php echo esc_attr($this->seo_rank((int) $seo['score'])); ?>" title="<?php echo esc_attr(sprintf(/* translators: 1: score 0-100, 2: SEO plugin name */ __('SEO score %1$s/100 (%2$s)', 'booking-and-rental-manager-for-woocommerce'), number_format_i18n((int) $seo['score']), $seo_label)); ?>">
+                                                    <?php echo esc_html(number_format_i18n((int) $seo['score'])); ?><i>/100</i>
+                                                </span>
+                                            <?php endif; ?>
+                                            <?php // Readability is a separate score; only Yoast reports one. ?>
+                                            <?php if (null !== $seo['readability'] && 0 !== $seo['readability']) : ?>
+                                                <span class="rbfw-seo-badge is-<?php echo esc_attr($this->seo_rank((int) $seo['readability'], true)); ?>" title="<?php echo esc_attr(sprintf(/* translators: %s: score 0-100 */ __('Readability %s/100', 'booking-and-rental-manager-for-woocommerce'), number_format_i18n((int) $seo['readability']))); ?>">
+                                                    <b>Aa</b> <?php echo esc_html(number_format_i18n((int) $seo['readability'])); ?>
+                                                </span>
+                                            <?php endif; ?>
+                                        </span>
+                                        <span class="rbfw-seo-sub">
+                                            <?php if ('' !== $seo['keyword']) : ?>
+                                                <span class="rbfw-seo-kw" title="<?php echo esc_attr(sprintf(/* translators: %s: focus keyword */ __('Focus keyword: %s', 'booking-and-rental-manager-for-woocommerce'), $seo['keyword'])); ?>"><?php echo esc_html($seo['keyword']); ?></span>
+                                            <?php else : ?>
+                                                <span class="rbfw-seo-flag" title="<?php esc_attr_e('No focus keyword set — the plugin cannot score this item.', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php esc_html_e('No keyword', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+                                            <?php endif; ?>
+                                            <?php if (! $seo['has_desc']) : ?>
+                                                <span class="rbfw-seo-flag" title="<?php esc_attr_e('No meta description — search engines will invent one.', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php esc_html_e('No description', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+                                            <?php endif; ?>
+                                            <?php if ($seo['noindex']) : ?>
+                                                <span class="rbfw-seo-flag is-noindex" title="<?php esc_attr_e('Excluded from search engines (noindex).', 'booking-and-rental-manager-for-woocommerce'); ?>"><?php esc_html_e('noindex', 'booking-and-rental-manager-for-woocommerce'); ?></span>
+                                            <?php endif; ?>
+                                        </span>
                                     </td>
                                     <?php endif; ?>
                                     <td data-label="<?php esc_attr_e('Status', 'booking-and-rental-manager-for-woocommerce'); ?>"><span class="rbfw-status-dot status-<?php echo esc_attr($it['status']); ?>"><?php echo esc_html($this->status_label($it['status'])); ?></span></td>

--- a/assets/admin/rbfw_rental_list.css
+++ b/assets/admin/rbfw_rental_list.css
@@ -142,23 +142,29 @@
 .rbfw-t-badge.type{background:var(--rb-red-soft);color:var(--rb-red);}
 /* SEO cell — rendered only while an SEO plugin is active. Badge colours follow
    that plugin's own good/ok/bad thresholds so they agree with its own UI.
-   Layout mirrors the Name cell: a strong first line, muted detail beneath. */
-.rbfw-th-seo{width:150px;}
-.rbfw-seo-line{display:flex;align-items:center;gap:5px;flex-wrap:wrap;}
-.rbfw-seo-badge{display:inline-flex;align-items:baseline;gap:2px;padding:3px 8px;border-radius:6px;font-size:11px;font-weight:700;white-space:nowrap;}
-.rbfw-seo-badge i{font-style:normal;font-weight:600;opacity:.6;font-size:10px;}
-.rbfw-seo-badge b{font-weight:800;opacity:.65;font-size:9px;letter-spacing:.02em;}
+   Layout mirrors the Name cell: a strong first line, muted detail beneath.
+   The table is table-layout:auto, so `width` alone is only a hint and the long
+   Name column steals it — min-width is what actually holds this column open. */
+.rbfw-th-seo{width:128px;min-width:128px;}
+.rbfw-td-seo{min-width:128px;}
+.rbfw-seo-line{display:flex;align-items:center;gap:4px;}
+.rbfw-seo-badge{display:inline-flex;align-items:baseline;gap:2px;padding:3px 7px;border-radius:6px;font-size:11px;font-weight:700;line-height:1.5;white-space:nowrap;}
+.rbfw-seo-badge i{font-style:normal;font-weight:600;opacity:.55;font-size:9px;}
+.rbfw-seo-badge b{font-weight:800;opacity:.6;font-size:9px;letter-spacing:.02em;}
 .rbfw-seo-badge.is-good{background:var(--rb-green-soft);color:var(--rb-green);}
 .rbfw-seo-badge.is-ok{background:var(--rb-orange-soft);color:var(--rb-orange);}
 .rbfw-seo-badge.is-bad{background:var(--rb-red-soft);color:var(--rb-red);}
-.rbfw-seo-badge.is-none{background:transparent;color:var(--rb-muted);font-weight:600;padding-left:0;}
-/* Detail line: focus keyword plus only the things that need attention. */
-.rbfw-seo-sub{display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-top:4px;font-size:10px;font-weight:600;line-height:1.4;}
-.rbfw-seo-kw{color:var(--rb-ink2);max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.rbfw-seo-kw::before{content:'\201C';opacity:.5;}
-.rbfw-seo-kw::after{content:'\201D';opacity:.5;}
-.rbfw-seo-flag{color:var(--rb-muted);background:var(--rb-bg);border:1px solid var(--rb-border);border-radius:4px;padding:1px 5px;white-space:nowrap;}
-.rbfw-seo-flag.is-noindex{color:var(--rb-red);background:var(--rb-red-soft);border-color:transparent;}
+.rbfw-seo-badge.is-none{background:transparent;color:var(--rb-muted);font-weight:700;padding-left:2px;}
+/* Detail line: focus keyword, then icon-only warnings (tooltips carry the
+   wording) so the cell stays on one line however narrow the column gets. */
+.rbfw-seo-sub{display:flex;align-items:center;gap:5px;margin-top:4px;min-height:14px;}
+.rbfw-seo-kw{font-size:10px;font-weight:600;color:var(--rb-muted);max-width:74px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.rbfw-seo-kw::before{content:'\201C';opacity:.55;}
+.rbfw-seo-kw::after{content:'\201D';opacity:.55;}
+.rbfw-seo-ico{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:5px;flex-shrink:0;color:var(--rb-muted);background:var(--rb-bg);border:1px solid var(--rb-border);cursor:help;transition:all .15s;}
+.rbfw-seo-ico:hover{color:var(--rb-ink2);border-color:var(--rb-muted);}
+.rbfw-seo-ico.is-noindex{color:var(--rb-red);background:var(--rb-red-soft);border-color:transparent;}
+.rbfw-seo-ico.is-noindex:hover{color:var(--rb-red);border-color:var(--rb-red);}
 /* Action icon buttons (table/list view) */
 .rbfw-table-acts{display:flex;align-items:center;gap:6px;}
 .rbfw-table-act{width:30px;height:30px;border-radius:7px;border:1px solid var(--rb-border);background:var(--rb-white);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;text-decoration:none;color:var(--rb-ink2) !important;transition:all .15s;flex-shrink:0;}
@@ -226,6 +232,13 @@ a.rbfw-cell-name:hover{color:var(--rb-red) !important;}
 
   /* Actions: buttons aligned right */
   .rbfw-table-acts{justify-content:flex-end;}
+
+  /* SEO: cells become label-left / value-right flex rows here, so drop the
+     desktop min-width and keep the badge + warnings on one right-aligned row. */
+  .rbfw-table td.rbfw-td-seo{min-width:0;flex-wrap:wrap;}
+  .rbfw-td-seo .rbfw-seo-line{margin-left:auto;}
+  .rbfw-td-seo .rbfw-seo-sub{margin-top:0;}
+  .rbfw-td-seo .rbfw-seo-kw{max-width:120px;}
 }
 @media (max-width:480px){
   .rbfw-fleet{padding:14px;}

--- a/assets/admin/rbfw_rental_list.css
+++ b/assets/admin/rbfw_rental_list.css
@@ -140,6 +140,15 @@
 .rbfw-table td:first-child a:hover{color:var(--rb-red) !important;}
 .rbfw-t-badge{display:inline-flex;align-items:center;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:600;}
 .rbfw-t-badge.type{background:var(--rb-red-soft);color:var(--rb-red);}
+/* SEO score badge — rendered only while an SEO plugin is active. Colours follow
+   that plugin's own good/ok/bad thresholds so the badge agrees with its UI. */
+.rbfw-th-seo{width:88px;}
+.rbfw-seo-badge{display:inline-flex;align-items:baseline;gap:1px;padding:3px 9px;border-radius:6px;font-size:11px;font-weight:700;white-space:nowrap;}
+.rbfw-seo-badge i{font-style:normal;font-weight:600;opacity:.6;font-size:10px;}
+.rbfw-seo-badge.is-good{background:var(--rb-green-soft);color:var(--rb-green);}
+.rbfw-seo-badge.is-ok{background:var(--rb-orange-soft);color:var(--rb-orange);}
+.rbfw-seo-badge.is-bad{background:var(--rb-red-soft);color:var(--rb-red);}
+.rbfw-seo-badge.is-none{background:transparent;color:var(--rb-muted);font-weight:600;padding-left:0;}
 /* Action icon buttons (table/list view) */
 .rbfw-table-acts{display:flex;align-items:center;gap:6px;}
 .rbfw-table-act{width:30px;height:30px;border-radius:7px;border:1px solid var(--rb-border);background:var(--rb-white);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;text-decoration:none;color:var(--rb-ink2) !important;transition:all .15s;flex-shrink:0;}

--- a/assets/admin/rbfw_rental_list.css
+++ b/assets/admin/rbfw_rental_list.css
@@ -140,15 +140,25 @@
 .rbfw-table td:first-child a:hover{color:var(--rb-red) !important;}
 .rbfw-t-badge{display:inline-flex;align-items:center;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:600;}
 .rbfw-t-badge.type{background:var(--rb-red-soft);color:var(--rb-red);}
-/* SEO score badge — rendered only while an SEO plugin is active. Colours follow
-   that plugin's own good/ok/bad thresholds so the badge agrees with its UI. */
-.rbfw-th-seo{width:88px;}
-.rbfw-seo-badge{display:inline-flex;align-items:baseline;gap:1px;padding:3px 9px;border-radius:6px;font-size:11px;font-weight:700;white-space:nowrap;}
+/* SEO cell — rendered only while an SEO plugin is active. Badge colours follow
+   that plugin's own good/ok/bad thresholds so they agree with its own UI.
+   Layout mirrors the Name cell: a strong first line, muted detail beneath. */
+.rbfw-th-seo{width:150px;}
+.rbfw-seo-line{display:flex;align-items:center;gap:5px;flex-wrap:wrap;}
+.rbfw-seo-badge{display:inline-flex;align-items:baseline;gap:2px;padding:3px 8px;border-radius:6px;font-size:11px;font-weight:700;white-space:nowrap;}
 .rbfw-seo-badge i{font-style:normal;font-weight:600;opacity:.6;font-size:10px;}
+.rbfw-seo-badge b{font-weight:800;opacity:.65;font-size:9px;letter-spacing:.02em;}
 .rbfw-seo-badge.is-good{background:var(--rb-green-soft);color:var(--rb-green);}
 .rbfw-seo-badge.is-ok{background:var(--rb-orange-soft);color:var(--rb-orange);}
 .rbfw-seo-badge.is-bad{background:var(--rb-red-soft);color:var(--rb-red);}
 .rbfw-seo-badge.is-none{background:transparent;color:var(--rb-muted);font-weight:600;padding-left:0;}
+/* Detail line: focus keyword plus only the things that need attention. */
+.rbfw-seo-sub{display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-top:4px;font-size:10px;font-weight:600;line-height:1.4;}
+.rbfw-seo-kw{color:var(--rb-ink2);max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.rbfw-seo-kw::before{content:'\201C';opacity:.5;}
+.rbfw-seo-kw::after{content:'\201D';opacity:.5;}
+.rbfw-seo-flag{color:var(--rb-muted);background:var(--rb-bg);border:1px solid var(--rb-border);border-radius:4px;padding:1px 5px;white-space:nowrap;}
+.rbfw-seo-flag.is-noindex{color:var(--rb-red);background:var(--rb-red-soft);border-color:transparent;}
 /* Action icon buttons (table/list view) */
 .rbfw-table-acts{display:flex;align-items:center;gap:6px;}
 .rbfw-table-act{width:30px;height:30px;border-radius:7px;border:1px solid var(--rb-border);background:var(--rb-white);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;text-decoration:none;color:var(--rb-ink2) !important;transition:all .15s;flex-shrink:0;}

--- a/rent-manager.php
+++ b/rent-manager.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Booking and Rental Manager for Bike | Car | Resort | Appointment | Dress | Equipment
 	 * Plugin URI: https://mage-people.com
 	 * Description: A complete booking & rental solution for WordPress.
-	 * Version: 2.7.2
+	 * Version: 2.7.3
 	 * Author: MagePeople Team
 	 * Author URI: https://www.mage-people.com/
 	 * Text Domain: booking-and-rental-manager-for-woocommerce


### PR DESCRIPTION
Shows each item's SEO score on admin.php?page=rbfw_item_list when an SEO plugin is active. rbfw_item is a public CPT, so the SEO plugins already analyse it and store scores — this just surfaces them next to the item.

Supports Yoast (_yoast_wpseo_linkdex), Rank Math (rank_math_seo_score), All in One SEO (its own aioseo_posts table) and SEOPress. Detection is by runtime constant, not by the plugin being present on disk: an installed but deactivated plugin stores no scores, so the column stays hidden. Header and cell are gated on the same flag so the table can never desync.

Scores are read in one batch. The meta-backed plugins ride the existing WP_Query meta cache, and AIOSEO gets a single query for all rows instead of one per item; its table is existence-checked first, since the constant can exist before the table does on a fresh install.

Thresholds follow each plugin's own good/ok/bad bands (Yoast 71/41, Rank Math 81/51, AIOSEO 80/50), so the badge agrees with what that plugin shows on the edit screen rather than inventing a scale — 45 reads "ok" under Yoast but "bad" under Rank Math, matching their UIs. Both treat 0 as "not analysed", so 0 and missing both render as a dash.

rbfw_item_seo_plugin / rbfw_item_seo_scores filters let an unsupported SEO plugin plug in without touching this class. Badge styling reuses the existing --rb-* palette and the data-label convention the mobile card layout relies on.